### PR TITLE
[DRAFT] add some draft templates

### DIFF
--- a/templates/container_networks.yaml
+++ b/templates/container_networks.yaml
@@ -1,0 +1,16 @@
+- variable: networks
+  label: Networks
+  description: |
+    The networks to connect this container to
+  schema:
+    type: list
+    items:
+      - variable: network
+        label: Network
+        description: The name of the network
+        schema:
+          type: string
+          # TODO: $ref for networks here, should list
+          # the names of the  created
+          # TODO: link to navigate users to create network form
+          required: true

--- a/templates/networks.yaml
+++ b/templates/networks.yaml
@@ -1,0 +1,85 @@
+template:
+  # This should probably be outside of the app install form
+  # Each network can be used by multiple containers and stacks/apps
+  name: networks
+  items:
+    - variable: networks
+      label: Networks
+      description: |
+        The networks to connect this container to
+      schema:
+        type: list
+        items:
+          - variable: name
+            label: Network Name
+            description: The name of the network
+            schema:
+              type: string
+              required: true
+          - variable: driver
+            label: Driver
+            description: The network driver
+            schema:
+              type: string
+              default: bridge
+              required: true
+              enum:
+                - value: bridge
+                  description: Bridge
+                - value: host
+                  description: Host
+                - value: none
+                  description: None
+                - value: ipvlan
+                  description: Ipvlan
+                - value: macvlan
+                  description: Macvlan
+          - variable: ipam
+            label: IPAM
+            # https://docs.docker.com/compose/compose-file/06-networks/#ipam
+            description: The IPAM configuration for the network
+            schema:
+              type: dict
+              attrs:
+                - variable: config
+                  label: Config
+                  description: The IPAM configuration
+                  schema:
+                    type: list
+                    items:
+                      - variable: subnet
+                        label: Subnet
+                        description: The subnet
+                        schema:
+                          type: ipaddr
+                          cidr: true
+                      - variable: gateway
+                        label: Gateway
+                        description: The gateway
+                        schema:
+                          type: ipaddr
+                          cidr: false
+                      - variable: ip_range
+                        label: IP Range
+                        description: The IP range
+                        schema:
+                          type: ipaddr
+                          cidr: true
+                      - variable: aux_addresses
+                        label: Auxiliary Addresses
+                        description: The auxiliary addresses
+                        schema:
+                          type: list
+                          items:
+                            - variable: host
+                              label: Host
+                              schema:
+                                type: string
+                                required: true
+                            - variable: ip
+                              label: IP
+                              description: The IP
+                              schema:
+                                type: ipaddr
+                                cidr: false
+                                required: true

--- a/templates/networks.yaml
+++ b/templates/networks.yaml
@@ -1,85 +1,82 @@
-template:
-  # This should probably be outside of the app install form
-  # Each network can be used by multiple containers and stacks/apps
-  name: networks
-  items:
-    - variable: networks
-      label: Networks
-      description: |
-        The networks to connect this container to
-      schema:
-        type: list
-        items:
-          - variable: name
-            label: Network Name
-            description: The name of the network
-            schema:
-              type: string
-              required: true
-          - variable: driver
-            label: Driver
-            description: The network driver
-            schema:
-              type: string
-              default: bridge
-              required: true
-              enum:
-                - value: bridge
-                  description: Bridge
-                - value: host
-                  description: Host
-                - value: none
-                  description: None
-                - value: ipvlan
-                  description: Ipvlan
-                - value: macvlan
-                  description: Macvlan
-          - variable: ipam
-            label: IPAM
-            # https://docs.docker.com/compose/compose-file/06-networks/#ipam
-            description: The IPAM configuration for the network
-            schema:
-              type: dict
-              attrs:
-                - variable: config
-                  label: Config
-                  description: The IPAM configuration
-                  schema:
-                    type: list
-                    items:
-                      - variable: subnet
-                        label: Subnet
-                        description: The subnet
-                        schema:
-                          type: ipaddr
-                          cidr: true
-                      - variable: gateway
-                        label: Gateway
-                        description: The gateway
-                        schema:
-                          type: ipaddr
-                          cidr: false
-                      - variable: ip_range
-                        label: IP Range
-                        description: The IP range
-                        schema:
-                          type: ipaddr
-                          cidr: true
-                      - variable: aux_addresses
-                        label: Auxiliary Addresses
-                        description: The auxiliary addresses
-                        schema:
-                          type: list
-                          items:
-                            - variable: host
-                              label: Host
-                              schema:
-                                type: string
-                                required: true
-                            - variable: ip
-                              label: IP
-                              description: The IP
-                              schema:
-                                type: ipaddr
-                                cidr: false
-                                required: true
+# This should probably be outside of the app install form
+# Each network can be used by multiple containers and stacks/apps
+- variable: networks
+  label: Networks
+  description: |
+    The networks to connect this container to
+  schema:
+    type: list
+    items:
+      - variable: name
+        label: Network Name
+        description: The name of the network
+        schema:
+          type: string
+          required: true
+      - variable: driver
+        label: Driver
+        description: The network driver
+        schema:
+          type: string
+          default: bridge
+          required: true
+          enum:
+            - value: bridge
+              description: Bridge
+            - value: host
+              description: Host
+            - value: none
+              description: None
+            - value: ipvlan
+              description: Ipvlan
+            - value: macvlan
+              description: Macvlan
+      - variable: ipam
+        label: IPAM
+        # https://docs.docker.com/compose/compose-file/06-networks/#ipam
+        description: The IPAM configuration for the network
+        schema:
+          type: dict
+          attrs:
+            - variable: config
+              label: Config
+              description: The IPAM configuration
+              schema:
+                type: list
+                items:
+                  - variable: subnet
+                    label: Subnet
+                    description: The subnet
+                    schema:
+                      type: ipaddr
+                      cidr: true
+                  - variable: gateway
+                    label: Gateway
+                    description: The gateway
+                    schema:
+                      type: ipaddr
+                      cidr: false
+                  - variable: ip_range
+                    label: IP Range
+                    description: The IP range
+                    schema:
+                      type: ipaddr
+                      cidr: true
+                  - variable: aux_addresses
+                    label: Auxiliary Addresses
+                    description: The auxiliary addresses
+                    schema:
+                      type: list
+                      items:
+                        - variable: host
+                          label: Host
+                          schema:
+                            type: string
+                            required: true
+                        - variable: ip
+                          label: IP
+                          description: The IP
+                          schema:
+                            type: ipaddr
+                            cidr: false
+                            required: true

--- a/templates/ports.yaml
+++ b/templates/ports.yaml
@@ -1,0 +1,101 @@
+- variable: additional_ports
+  label: Additional Ports
+  description: Configure the ports for the container
+  schema:
+    type: list
+    items:
+      - variable: type
+        label: Type
+        description: The type of port
+        schema:
+          type: string
+          default: "single"
+          required: true
+          enum:
+            - value: single
+              description: Single
+            - value: range
+              description: Range
+      - variable: protocol
+        label: Protocol
+        description: The port protocol
+        schema:
+          type: string
+          default: "tcp"
+          required: true
+          enum:
+            - value: tcp
+              description: TCP
+            - value: udp
+              description: UDP
+      - variable: host_ip
+        label: Host IP (Optional)
+        description: |
+          The host IP to bind the port(s)
+          Empty means bind to all IPs
+        schema:
+          type: ipaddr
+          cidr: false
+          default: ""
+
+      # Single type
+      - variable: target
+        label: Container Port
+        description: The port exposed by the container
+        schema:
+          type: integer
+          min: 1
+          max: 65535
+          show_if: [["type", "=", "single"]]
+          required: true
+      - variable: published
+        label: Published Port
+        description: The port on the host
+        schema:
+          type: integer
+          min: 1
+          max: 65535
+          show_if: [["type", "=", "single"]]
+          required: true
+
+      # Range type
+      - variable: target_start
+        label: Container Port Start
+        description: The first port of the range exposed by the container
+        schema:
+          type: integer
+          min: 1
+          max: 65535
+          show_if: [["type", "=", "range"]]
+          required: true
+      - variable: target_end
+        label: Container Port End
+        description: The last port of the range exposed by the container
+        schema:
+          type: integer
+          min: 1
+          max: 65535
+          show_if: [["type", "=", "range"]]
+          required: true
+      - variable: published_start
+        label: Published Port Start
+        description: The first port of the range on the host
+        schema:
+          type: integer
+          min: 1
+          max: 65535
+          show_if: [["type", "=", "range"]]
+          required: true
+      - variable: published_end
+        label: Published Port End
+        description: The last port of the range on the host
+        schema:
+          type: integer
+          min: 1
+          max: 65535
+          show_if: [["type", "=", "range"]]
+          required: true
+# Notes:
+# Validate that range start is smaller than range end
+# Validate that both target and publish ranges are equal in length
+#

--- a/templates/resources.yaml
+++ b/templates/resources.yaml
@@ -1,0 +1,69 @@
+- variable: resources
+  label: Resources
+  description: |
+    The resources allocated to the container
+  schema:
+    type: dict
+    attrs:
+      - variable: limits
+        label: Limits
+        description: |
+          The maximum amount of resources that can be allocated
+        schema:
+          type: dict
+          attrs:
+            - variable: cpu
+              label: CPU
+              description: The maximum amount of CPU cores that can be allocated
+              schema:
+                type: string
+                # https://regex101.com/r/a4xrjj/1
+                valid_chars: '^[0-9]+(\.[0-9]{1,4})?$'
+                # https://docs.docker.com/compose/compose-file/deploy/#cpus
+                valid_chars_error: |
+                  Valid CPU limit formats are:</br>
+                    - Plain Integer - eg. 4</br>
+                    - Float - eg. 0.5</br>
+                  Up to 4 decimal places are supported
+                default: "4.0"
+                required: true
+            - variable: memory
+              label: Memory
+              description: The maximum amount of memory that can be allocated
+              schema:
+                type: string
+                # https://regex101.com/r/OAFKte/1
+                valid_chars: "^[1-9][0-9]*(k|m|g)b$"
+                # https://docs.docker.com/compose/compose-file/deploy/#memory
+                valid_chars_error: |
+                  Valid memory limit formats are:</br>
+                    - KiloBytes - eg. 1000kb</br>
+                    - MegaBytes - eg. 1000mb</br>
+                    - GigaBytes - eg. 1000gb</br>
+                default: "8gb"
+                required: true
+      - variable: reservations
+        label: Reservations
+        description: |
+          The amount of resources reserved
+        schema:
+          type: dict
+          attrs:
+            - variable: devices
+              label: Device
+              schema:
+                type: list
+                items:
+                  - variable: device_ids
+                    label: IDs
+                    schema:
+                      type: list
+                      default: []
+                      items:
+                        - variable: id
+                          label: ID
+                          schema:
+                            type: string
+                            default: ""
+                            # TODO: Use $ref here to populate IDs
+                            required: true

--- a/templates/storage.yaml
+++ b/templates/storage.yaml
@@ -1,0 +1,208 @@
+# - For host_paths we dont need to create a volume, we just mount the host_path on any container we need/want
+# so this type is not even on the list below at all. it will be at the container level.
+
+# - For volumes/cifs/nfs we need to create a top-level volume config always
+
+# ---
+
+# While we can have multiple nfs/cifs volumes pointing to the same server/share, (docker wont complain.)
+# Its not ideal. We create an additional connection to the server for no reason
+# Also this won't work with docker volumes, as each volume creates a unique mount point on the host.
+
+# We need to somehow select to which containers this volumes should be shared with and the mountPath for each
+
+# -- One option is to embed on each volume item, another list which will contain container names and mountPaths
+# This gets a bit messy.
+
+# -- Another option is to have different section that creates the volumes
+# and another section per container, that will reference the volume names and the mountPath.
+# But this leaves the door open for typos. We will ofcourse validate that on the template side.
+# and docker also does that anyway.
+
+# ---
+
+# Another thing to consider is that nfs/cifs volumes can be used across multiple compose projects.
+# That means that user might want to create this volume before any apps are installed.
+# and just reference them inside the each app by name and a mountpath
+
+# Regarding docker volumes, I don't think there is a good use case with shared
+# volumes across multiple compose projects. For such use case, host_paths are much easier to use.
+# docker volumes are host_paths after all, so there is no much difference.
+
+# With all that in mind, what we can do sometihng is something like that:
+# - Allow docker volumes only for predefined storage based on each app needs, eg `/config`
+#   where those are mounted and configured will be part of the template and up to the app developer
+#   those will be mostly as a sane default to make sure app works with "next" "next" "install".
+# - Allow host_paths for both predefined and "arbitrary" storages
+# - Move nfs/cifs to a new tab where users can pre-create those
+#   and allow them to select them inside each app. (Provide a $ref to list available)
+
+# Predefiend storage
+- variable: config
+  label: Config
+  description: |
+    The config to mount
+  schema:
+    type: dict
+    attrs:
+      - variable: type
+        label: Type
+        description: The type of the config
+        schema:
+          type: string
+          default: volume
+          required: true
+          enum:
+            - value: volume
+              description: Volume
+            - value: host_path
+              description: Host Path
+            - value: cifs
+              description: SMB
+            - value: nfs
+              description: NFS
+      - variable: volume_name
+        label: Volume Name
+        description: The name of the volume
+        schema:
+          type: string
+          # $ref here will be replaced with a list of available nfs/cifs volumes
+          show_if: [["type", "=", "nfs"], ["type", "=", "cifs"]]
+          required: true
+      - variable: host_path_options
+        label: Host Path Options
+        description: The host path options
+        schema:
+          type: dict
+          show_if: [["type", "=", "host_path"]]
+          attrs:
+            - variable: host_path
+              label: Host Path
+              description: The path on the host
+              schema:
+                type: path
+                required: true
+
+# This section can be either per container or have an enum with containers to mount it
+# Depends on the app
+- variable: additional_storage
+  label: Additional Storage
+  description: |
+    Additional storage to mount
+  schema:
+    type: list
+    items:
+      - variable: type
+        label: Type
+        description: The type of the storage
+        schema:
+          type: string
+          default: volume
+          required: true
+          enum:
+            - value: host_path
+              description: Host Path
+            - value: cifs
+              description: SMB
+            - value: nfs
+              description: NFS
+      - variable: volume_name
+        label: Volume Name
+        description: The name of the volume
+        schema:
+          type: string
+          # $ref here will be replaced with a list of available nfs/cifs volumes
+          show_if: [["type", "=", "nfs"], ["type", "=", "cifs"]]
+          required: true
+      - variable: mount_path
+        label: Mount Path
+        description: The mount path
+        schema:
+          type: path
+          required: true
+
+# Volumes, will be in a new tab to allow users to pre-create
+- variable: volumes
+  labels: Volumes
+  description: |
+    The volumes to mount
+  schema:
+    type: list
+    items:
+      - variable: name
+        label: Volume Name
+        description: The name of the volume
+        schema:
+          type: string
+          required: true
+      - variable: type
+        label: Type
+        description: The type of the volume
+        schema:
+          type: string
+          default: none
+          required: true
+          enum:
+            - value: cifs
+              description: SMB
+            - value: nfs
+              description: NFS
+      - variable: cifs_options
+        label: SMB Options
+        description: The SMB options
+        schema:
+          type: dict
+          show_if: [["type", "=", "cifs"]]
+          attrs:
+            - variable: server
+              label: Server
+              description: The SMB server
+              schema:
+                # maybe leave it as string?
+                # Have to test if dns works
+                type: ipaddr
+                required: true
+            - variable: share
+              label: Share
+              description: The SMB share
+              schema:
+                type: string
+                required: true
+            - variable: username
+              label: Username
+              description: The SMB username
+              schema:
+                type: string
+                required: true
+            - variable: password
+              label: Password
+              description: The SMB password
+              schema:
+                type: string
+                private: true
+                required: true
+            - variable: domain
+              label: Domain
+              description: The SMB domain
+              schema:
+                type: string
+            # Maybe allow additional user-defind mount options?
+      - variable: nfs_options
+        label: NFS Options
+        description: The NFS options
+        schema:
+          type: dict
+          attrs:
+            - variable: server
+              label: Server
+              description: The NFS server
+              schema:
+                type: string
+                required: true
+            - variable: path
+              label: Path
+              description: The NFS path
+              schema:
+                type: string
+                required: true
+            # Maybe allow additional user-defind mount options


### PR DESCRIPTION
Drafted some templates while exploring docker-compose docs.

While not all options from the compose spec are included, tried to keep the as flexible as possible for future expansion.
Final format will very once we have some pieces together and see how everything will fall into place.

Those templates will probably be accompanied with some jinja custom funcs to parse and return valid compose spec snippets to be injected directly into the compose.