### PR TITLE
NAS-129730 / 24.10 / Do not trigger update catalog action for commits created by action

### DIFF
--- a/.github/workflows/update_catalog.yaml
+++ b/.github/workflows/update_catalog.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  validate:
+  publish_catalog:
     runs-on: ubuntu-latest
 
     container:

--- a/.github/workflows/update_catalog.yaml
+++ b/.github/workflows/update_catalog.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   publish_catalog:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
 
     container:
@@ -26,7 +27,7 @@ jobs:
           /bin/bash -c "PWD=${pwd}; /usr/local/bin/apps_catalog_update publish --path $PWD"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-            commit_message: Publish new changes in catalog
+            commit_message: "Publish new changes in catalog [skip ci]"
             commit_user_name: sonicaj
             commit_user_email: waqarsonic1@gmail.com
             commit_author: sonicaj <waqarsonic1@gmail.com>
@@ -35,7 +36,7 @@ jobs:
           /bin/bash -c "PWD=${pwd}; /usr/local/bin/apps_catalog_update update --path $PWD"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-            commit_message: Update catalog changes
+            commit_message: "Update catalog changes [skip ci]"
             commit_user_name: sonicaj
             commit_user_email: waqarsonic1@gmail.com
             commit_author: sonicaj <waqarsonic1@gmail.com>


### PR DESCRIPTION
This PR makes sure we don't trigger update catalog action for commits which were created by the gh action itself.