### PR TITLE
NAS-129729 / 24.10 / Properly mark github action as success if nothing has been published

### DIFF
--- a/.github/workflows/update_catalog.yaml
+++ b/.github/workflows/update_catalog.yaml
@@ -25,16 +25,22 @@ jobs:
       - name: Publish catalog
         run: |
           /bin/bash -c "PWD=${pwd}; /usr/local/bin/apps_catalog_update publish --path $PWD"
+      - name: Check untracked files existence
+        run: echo "CHANGES=$(git -C ${pwd} --no-pager status --porcelain | wc -l)" >> "$GITHUB_ENV"
+
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: env.CHANGES != '0'
         with:
             commit_message: "Publish new changes in catalog [skip ci]"
             commit_user_name: sonicaj
             commit_user_email: waqarsonic1@gmail.com
             commit_author: sonicaj <waqarsonic1@gmail.com>
       - name: Update catalog
+        if: env.CHANGES != '0'
         run: |
           /bin/bash -c "PWD=${pwd}; /usr/local/bin/apps_catalog_update update --path $PWD"
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: env.CHANGES != '0'
         with:
             commit_message: "Update catalog changes [skip ci]"
             commit_user_name: sonicaj


### PR DESCRIPTION
## Problem

When there are no published apps, update catalog action would error out because it still tries to commit (part of it still commits where only date hashes are changed and published)

## Solution

Skip the commit generation if nothing has changed in the repository.
