### PR TITLE
NAS-130170 / 24.10 / Add node bind ip ref to feature capability matrix

### DIFF
--- a/features_capability.json
+++ b/features_capability.json
@@ -7,6 +7,10 @@
     "stable": {"min": "24.10-ALPHA"},
     "nightlies": {"min": "24.10-MASTER-somever"}
   },
+  "normalize/node_bind_ip": {
+    "stable": {"min": "24.10-ALPHA"},
+    "nightlies": {"min": "24.10-MASTER-somever"}
+  },
   "definitions/timezone": {
     "stable": {"min": "24.10-ALPHA"},
     "nightlies": {"min": "24.10-MASTER"}


### PR DESCRIPTION
## Context

Document `node_bind_ip` ref in feature capability matrix.