### PR TITLE
lock concurrency on catalog update

### DIFF
--- a/.github/workflows/update_catalog.yaml
+++ b/.github/workflows/update_catalog.yaml
@@ -1,9 +1,12 @@
 name: catalog_update
 
+concurrency:
+  group: apps_catalog_update
+
 on:
   push:
     branches:
-      - 'master'
+      - "master"
   workflow_dispatch:
 
 jobs:
@@ -31,10 +34,10 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         if: env.CHANGES != '0'
         with:
-            commit_message: "Publish new changes in catalog [skip ci]"
-            commit_user_name: sonicaj
-            commit_user_email: waqarsonic1@gmail.com
-            commit_author: sonicaj <waqarsonic1@gmail.com>
+          commit_message: "Publish new changes in catalog [skip ci]"
+          commit_user_name: sonicaj
+          commit_user_email: waqarsonic1@gmail.com
+          commit_author: sonicaj <waqarsonic1@gmail.com>
       - name: Update catalog
         if: env.CHANGES != '0'
         run: |
@@ -42,7 +45,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         if: env.CHANGES != '0'
         with:
-            commit_message: "Update catalog changes [skip ci]"
-            commit_user_name: sonicaj
-            commit_user_email: waqarsonic1@gmail.com
-            commit_author: sonicaj <waqarsonic1@gmail.com>
+          commit_message: "Update catalog changes [skip ci]"
+          commit_user_name: sonicaj
+          commit_user_email: waqarsonic1@gmail.com
+          commit_author: sonicaj <waqarsonic1@gmail.com>

--- a/.github/workflows/update_catalog.yaml
+++ b/.github/workflows/update_catalog.yaml
@@ -1,12 +1,12 @@
 name: catalog_update
 
-concurrency:
+concurrency: 
   group: apps_catalog_update
 
 on:
   push:
     branches:
-      - "master"
+      - 'master'
   workflow_dispatch:
 
 jobs:
@@ -34,10 +34,10 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         if: env.CHANGES != '0'
         with:
-          commit_message: "Publish new changes in catalog [skip ci]"
-          commit_user_name: sonicaj
-          commit_user_email: waqarsonic1@gmail.com
-          commit_author: sonicaj <waqarsonic1@gmail.com>
+            commit_message: "Publish new changes in catalog [skip ci]"
+            commit_user_name: sonicaj
+            commit_user_email: waqarsonic1@gmail.com
+            commit_author: sonicaj <waqarsonic1@gmail.com>
       - name: Update catalog
         if: env.CHANGES != '0'
         run: |
@@ -45,7 +45,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         if: env.CHANGES != '0'
         with:
-          commit_message: "Update catalog changes [skip ci]"
-          commit_user_name: sonicaj
-          commit_user_email: waqarsonic1@gmail.com
-          commit_author: sonicaj <waqarsonic1@gmail.com>
+            commit_message: "Update catalog changes [skip ci]"
+            commit_user_name: sonicaj
+            commit_user_email: waqarsonic1@gmail.com
+            commit_author: sonicaj <waqarsonic1@gmail.com>

--- a/ix-dev/community/node-red/app.yaml
+++ b/ix-dev/community/node-red/app.yaml
@@ -23,10 +23,10 @@ run_as_context:
   uid: 1000
   user_name: node-red
 screenshots:
-- - https://media.sys.truenas.net/apps/node-red/screenshots/screenshot1.png
+- https://media.sys.truenas.net/apps/node-red/screenshots/screenshot1.png
 sources:
 - https://nodered.org
 - https://github.com/node-red/node-red-docker
 title: Node-RED
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/node-red/item.yaml
+++ b/ix-dev/community/node-red/item.yaml
@@ -2,6 +2,6 @@ categories:
 - productivity
 icon_url: https://media.sys.truenas.net/apps/node-red/icons/icon.png
 screenshots:
-- - https://media.sys.truenas.net/apps/node-red/screenshots/screenshot1.png
+- https://media.sys.truenas.net/apps/node-red/screenshots/screenshot1.png
 tags:
 - automation


### PR DESCRIPTION
Currently when 2 PRs are merged at the same time, update catalog will most likely fail.
Catalog update performs 2 commits, which between them the second catalog update can attempt to commit.

Solution:
Lock the catalog update concurrency to a single run at a time.
So newer catalog update workflows will be queued.

---

Also fixes a typo that leads to a CI failure here
https://github.com/truenas/apps/actions/runs/10248348970/job/28349443068