### PR TITLE
zerotier: make sure netid is quoted

### DIFF
--- a/ix-dev/community/zerotier/app.yaml
+++ b/ix-dev/community/zerotier/app.yaml
@@ -53,4 +53,4 @@ sources:
 - https://hub.docker.com/r/zerotier/zerotier
 title: Zerotier
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/zerotier/templates/docker-compose.yaml
+++ b/ix-dev/community/zerotier/templates/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     {% endif %}
     command:
     {% for net in values.zerotier.networks %}
-      - {{ net }}
+      - "{{ net }}"
     {% else %}
       {% do ix_lib.base.utils.throw_error("Zerotier requires at least one network to be configured") %}
     {% endfor %}

--- a/ix-dev/community/zerotier/templates/docker-compose.yaml
+++ b/ix-dev/community/zerotier/templates/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     {% endif %}
     command:
     {% for net in values.zerotier.networks %}
-      - "{{ net }}"
+      - "{{ net|lower }}"
     {% else %}
       {% do ix_lib.base.utils.throw_error("Zerotier requires at least one network to be configured") %}
     {% endfor %}

--- a/ix-dev/community/zerotier/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/zerotier/templates/test_values/basic-values.yaml
@@ -8,7 +8,7 @@ zerotier:
   identity_public: some identity public
   identity_secret: some identity secret
   networks:
-    - 0a1b2c3de4f56739
+    - 0A1B2C3DE4F56739
     - 0a1b2c3de4f56789
   additional_envs: []
 


### PR DESCRIPTION
Docker expects string in the command array, We should make sure its always a string
Also fixes https://github.com/truenas/charts/issues/2708#issuecomment-2284754762