### PR TITLE
App ci tester wouldnt fail if it failed to start any containers at all

### DIFF
--- a/ix-dev/community/bazarr/app.yaml
+++ b/ix-dev/community/bazarr/app.yaml
@@ -31,4 +31,4 @@ sources:
 - https://github.com/morpheus65535/bazarr
 title: Bazarr
 train: community
-version: 1.0.4
+version: 1.0.5

--- a/ix-dev/community/bazarr/ix_values.yaml
+++ b/ix-dev/community/bazarr/ix_values.yaml
@@ -1,6 +1,6 @@
 images:
   image:
-    repository: ghcr.io/onedr0p/bazarr-develop
+    repository: ghcr.io/onedr0p/bazarr
     tag: 1.4.3
 
 consts:


### PR DESCRIPTION
Docker daemon will exit with a non-zero code if a container exits with `0`.
Such case is init containers.

So we inspect containers to identify if it was actually a failure or not.

But if daemon failed to start all containers, the "failed" containers will always be 0, so we marked it as "success".
Such case is if the image is wrongly typed. (See app in this PR which had this issue and the commits before and after the change)
This PR checks that at least 1 container exists before starting checking for failed containers.
if there is none, it will fail the ci run.

Did a test run across all apps here to see if there was any other issues https://github.com/truenas/apps/pull/124
All seems to be good!
