### PR TITLE
nextcloud: add hook script to update db/redis host

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -67,4 +67,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/nextcloud
 title: Nextcloud
 train: stable
-version: 1.0.3
+version: 1.0.4

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -148,6 +148,15 @@ configs:
     content: |
       {% set bytes_gb = 1024 * 1024 * 1024 %}
       LimitRequestBody {{ values.nextcloud.php_upload_limit * bytes_gb }}
+  before-starting-script.sh:
+    content: |
+      #!/bin/bash
+      set -e
+      config_file="/var/www/html/config/config.php"
+      {# Reason for sed: https://github.com/nextcloud/server/issues/44924 #}
+      echo "Updating database and redis host in config.php"
+      sed -i "s/\('dbhost' => '\)[^']*postgres:5432',/\{{ values.consts.postgres_container_name }}:5432',/" "$$config_file"
+      occ config:system:set redis host --value="{{ values.consts.redis_container_name }}"
   occ:
     content: |
       #!/bin/bash
@@ -219,6 +228,9 @@ services:
         target: /usr/local/etc/php/conf.d/nextcloud-z-99.ini
       - source: opcache.ini
         target: /usr/local/etc/php/conf.d/opcache-z-99.ini
+      - source: before-starting-script.sh
+        target: /docker-entrypoint-hooks.d/before-starting/before-starting-script.sh
+        mode: 0755
     depends_on:
       {{ values.consts.postgres_container_name }}:
         condition: service_healthy

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -148,7 +148,7 @@ configs:
     content: |
       {% set bytes_gb = 1024 * 1024 * 1024 %}
       LimitRequestBody {{ values.nextcloud.php_upload_limit * bytes_gb }}
-  before-starting-script.sh:
+  ix-update-hosts-script.sh:
     content: |
       #!/bin/bash
       set -e
@@ -228,8 +228,8 @@ services:
         target: /usr/local/etc/php/conf.d/nextcloud-z-99.ini
       - source: opcache.ini
         target: /usr/local/etc/php/conf.d/opcache-z-99.ini
-      - source: before-starting-script.sh
-        target: /docker-entrypoint-hooks.d/before-starting/before-starting-script.sh
+      - source: ix-update-hosts-script.sh
+        target: /docker-entrypoint-hooks.d/before-starting/ix-update-hosts-script.sh
         mode: 0755
     depends_on:
       {{ values.consts.postgres_container_name }}:

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -155,7 +155,7 @@ configs:
       config_file="/var/www/html/config/config.php"
       {# Reason for sed: https://github.com/nextcloud/server/issues/44924 #}
       echo "Updating database and redis host in config.php"
-      sed -i "s/\('dbhost' => '\)[^']*postgres:5432',/\{{ values.consts.postgres_container_name }}:5432',/" "$$config_file"
+      sed -i "s/\('dbhost' => '\)[^']*postgres:5432',/\1{{ values.consts.postgres_container_name }}:5432',/" "$$config_file"
       occ config:system:set redis host --value="{{ values.consts.redis_container_name }}"
   occ:
     content: |


### PR DESCRIPTION
During migration the host is different than what it was in k8s.
This updates hosts in the config file, because nextcloud does not use the envvars to update those fields after initial installation.