### PR TITLE
fix chia's default enum value

### DIFF
--- a/ix-dev/community/chia/app.yaml
+++ b/ix-dev/community/chia/app.yaml
@@ -31,4 +31,4 @@ sources:
   - https://www.chia.net/
 title: Chia
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/chia/questions.yaml
+++ b/ix-dev/community/chia/questions.yaml
@@ -30,7 +30,7 @@ questions:
           description: The service to run.
           schema:
             type: string
-            default: full_node
+            default: ""
             enum:
               - value: farmer-only
                 description: Farmer only


### PR DESCRIPTION
@Qubad786 

Can we add validation that the `default` value is one of the `enum` that is defined?