### PR TITLE
add note for initial setup

### DIFF
--- a/ix-dev/community/adguard-home/app.yaml
+++ b/ix-dev/community/adguard-home/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://hub.docker.com/r/adguard/adguardhome
 title: AdGuard Home
 train: community
-version: 1.0.7
+version: 1.0.8

--- a/ix-dev/community/adguard-home/ix_values.yaml
+++ b/ix-dev/community/adguard-home/ix_values.yaml
@@ -7,3 +7,6 @@ consts:
   adguard_container_name: adguard
   config_path: /opt/adguardhome/conf
   work_path: /opt/adguardhome/work
+  notes_body: |
+    After initial setup, you need to stop and start the app from
+    the TrueNAS SCALE UI for the configuration to take effect.

--- a/ix-dev/community/adguard-home/templates/docker-compose.yaml
+++ b/ix-dev/community/adguard-home/templates/docker-compose.yaml
@@ -67,4 +67,4 @@ volumes: {{ volumes.items | tojson }}
 {% endif %}
 
 x-portals: {{ ix_lib.base.metadata.get_portals([{"port": values.network.web_port}]) | tojson }}
-x-notes: {{ ix_lib.base.metadata.get_notes("AdGuard Home") | tojson }}
+x-notes: {{ ix_lib.base.metadata.get_notes("AdGuard Home", body=values.consts.notes_body) | tojson }}


### PR DESCRIPTION
Fixes #283 

Surprisingly, docker will not do anything on unhealthy containers.
Will just provide info about that.

On initial setup, adguard allows users to setup the web port which defaults to `80`.
Even if we use the `--port` flag. 
While the `--port` flag has priority, the wizard will temporary set the port to 80. Which is why the restart is required, so the flag will take effect.

Previously we relied on k8s to restart the container once the probe started failing (due to the changed port).
But docker does not do that. It will only restart a container that is `exited`