### PR TITLE
FreshRSS: Use correct extensions volume config

### DIFF
--- a/ix-dev/community/freshrss/app.yaml
+++ b/ix-dev/community/freshrss/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://hub.docker.com/r/freshrss/freshrss
 title: FreshRSS
 train: community
-version: 1.1.2
+version: 1.1.3

--- a/ix-dev/community/freshrss/templates/docker-compose.yaml
+++ b/ix-dev/community/freshrss/templates/docker-compose.yaml
@@ -12,7 +12,7 @@
 {% set perms_dirs = namespace(items=[]) %}
 
 {% do storage_items.items.append(ix_lib.base.storage.storage_item(data=dict(values.storage.data, **{"mount_path": values.consts.data_path}), values=values)) %}
-{% do storage_items.items.append(ix_lib.base.storage.storage_item(data=dict(values.storage.data, **{"mount_path": "/var/www/FreshRSS/extensions"}), values=values)) %}
+{% do storage_items.items.append(ix_lib.base.storage.storage_item(data=dict(values.storage.extensions, **{"mount_path": "/var/www/FreshRSS/extensions"}), values=values)) %}
 {% do storage_items.items.append(ix_lib.base.storage.storage_item(data={"type":"anonymous", "mount_path": "/tmp"})) %}
 {% do storage_items.items.append(ix_lib.base.storage.storage_item(data={"type":"anonymous", "mount_path": "/.cache"})) %}
 


### PR DESCRIPTION
Similar to #334, this fixes the reuse of a volume path variable.

After #334, I quickly looked for similar problems and found this one. Please note, I did not test this fix, but from looking at the template, I believe `values.storage.extensions` is correct (as it is not used anywhere else).