### PR TITLE
do a patch bump on container updates

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -45,7 +45,7 @@ module.exports = {
         executionMode: "update",
         commands: [
           // https://docs.renovatebot.com/templates/#other-available-fields
-          "./.github/scripts/renovate_bump.sh {{{packageFileDir}}} {{{updateType}}} {{{depName}}} {{{newVersion}}}",
+          "./.github/scripts/renovate_bump.sh {{{packageFileDir}}} patch {{{depName}}} {{{newVersion}}}",
         ],
       },
     },


### PR DESCRIPTION
Lets bump `patch` version on apps when a container updates.

---

If we keep the bump type to whatever the container update type is, all Date Versioned containers will be at minimum a `minor` bump.