### PR TITLE
nextcloud: add gpu questions

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -67,4 +67,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/nextcloud
 title: Nextcloud
 train: stable
-version: 1.3.7
+version: 1.3.8

--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -692,3 +692,11 @@ questions:
                   type: int
                   default: 4096
                   required: true
+        - variable: gpus
+          group: Resources Configuration
+          label: GPU Configuration
+          schema:
+            type: dict
+            $ref:
+              - "definitions/gpu_configuration"
+            attrs: []


### PR DESCRIPTION
Fixes https://github.com/truenas/charts/issues/2078

I couldn't find any additional dependencies needed gpu is used.
We can come back to this if we see any issues when consuming one.

(Library should pick up the gpu's from questions and map them automatically)