### PR TITLE
Fix paperless-ngx wrong consumption dir env variable

### DIFF
--- a/ix-dev/community/paperless-ngx/app.yaml
+++ b/ix-dev/community/paperless-ngx/app.yaml
@@ -53,4 +53,4 @@ sources:
 - https://github.com/paperless-ngx/paperless-ngx
 title: Paperless-ngx
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
+++ b/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
       "USERMAP_GID": values.run_as.group,
       "PAPERLESS_DATA_DIR": values.consts.data_path,
       "PAPERLESS_MEDIA_ROOT": values.consts.media_path,
-      "PAPERLESS_CONSUMPTION_DIR": values.consts.consumption_path,
+      "PAPERLESS_CONSUMPTION_DIR": values.consts.consume_path,
       "PAPERLESS_TRASH_DIR": values.consts.trash_path if values.storage.enable_trash else "",
       "PAPERLESS_SECRET_KEY": values.paperless.secret_key,
       "PAPERLESS_ADMIN_USER": values.paperless.admin_user,


### PR DESCRIPTION
Basic paperless-ngx setup leaves env variable PAPERLES_CONSUMPTION_PATH empty. Suspect that it's just a typo here.

<img width="614" alt="Screenshot 2024-09-13 at 10 26 42 PM" src="https://github.com/user-attachments/assets/b1fa765e-c55f-4d0b-a896-d28089fc7640">


