### PR TITLE
navidrome: fix healthcheck

### DIFF
--- a/.github/scripts/ci.py
+++ b/.github/scripts/ci.py
@@ -357,6 +357,15 @@ def run_app():
 
     print_stderr(f"Exit code: {res.returncode}")
     if res.returncode != 0:
+        stderr = res.stderr.decode("utf-8")
+        if "error response from daemon" in stderr.lower():
+            print_stderr(
+                "Docker exited with non-zero code and no containers were found.\n"
+                + "Most likely docker couldn't start one of the containers at all.\n"
+                + "Such cases are for example when a device is not available on the host.\n"
+                + "or image cannot be found.\n\n"
+                + stderr
+            )
         parsed_containers = get_parsed_containers()
         if not parsed_containers:
             print_stderr(

--- a/.github/scripts/ci.py
+++ b/.github/scripts/ci.py
@@ -350,22 +350,25 @@ def print_inspect_data(container):
 def run_app():
     cmd = f"{get_base_cmd()} up --detach --quiet-pull --wait --wait-timeout 600"
     print_cmd(cmd)
-    res = subprocess.run(cmd, shell=True)
+    res = subprocess.run(cmd, shell=True, capture_output=True)
 
     print_docker_processes()
     print_logs()
 
     print_stderr(f"Exit code: {res.returncode}")
     if res.returncode != 0:
-        stderr = res.stderr.decode("utf-8")
-        if "error response from daemon" in stderr.lower():
-            print_stderr(
-                "Docker exited with non-zero code and no containers were found.\n"
-                + "Most likely docker couldn't start one of the containers at all.\n"
-                + "Such cases are for example when a device is not available on the host.\n"
-                + "or image cannot be found.\n\n"
-                + stderr
-            )
+        if res.stderr:
+            stderr = res.stderr.decode("utf-8")
+            err_msg = "error response from daemon"
+            if err_msg in stderr.lower():
+                print_stderr(
+                    "\nDocker exited with non-zero code and no containers were found.\n"
+                    + "Most likely docker couldn't start one of the containers at all.\n"
+                    + "Such cases are for example when a device is not available on the host.\n"
+                    + "or image cannot be found.\n\n"
+                    + stderr
+                )
+                sys.exit(1)
         parsed_containers = get_parsed_containers()
         if not parsed_containers:
             print_stderr(

--- a/ix-dev/community/navidrome/app.yaml
+++ b/ix-dev/community/navidrome/app.yaml
@@ -32,4 +32,4 @@ sources:
 - https://github.com/navidrome/navidrome/
 title: Navidrome
 train: community
-version: 1.0.13
+version: 1.0.14

--- a/ix-dev/community/navidrome/templates/docker-compose.yaml
+++ b/ix-dev/community/navidrome/templates/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
     {% if values.network.dns_opts %}
     dns_opt: {{ ix_lib.base.network.dns_opts(values.network.dns_opts) | tojson }}
     {% endif %}
-    {% set test = ix_lib.base.healthchecks.curl_test(port=values.network.web_port, path="/ping") %}
+    {% set test = ix_lib.base.healthchecks.wget_test(port=values.network.web_port, path="/ping") %}
     healthcheck: {{ ix_lib.base.healthchecks.check_health(test) | tojson }}
     environment: {{ ix_lib.base.environment.envs(app={
       "ND_MUSICFOLDER": values.consts.music_path,

--- a/ix-dev/community/navidrome/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/navidrome/templates/test_values/basic-values.yaml
@@ -5,7 +5,7 @@ resources:
 
 navidrome:
   welcome_message: "Welcome to Navidrome"
-  local_playback: true
+  local_playback: false
   additional_envs: []
 network:
   host_network: false


### PR DESCRIPTION
Adds another sanity check on ci.py to catch cases where some containers do not start at all, for various reasons.

(eg a host device is not available, or an image cannot be resolved)

This is usually marked as "daemon error"

Fixes navidrome as well