### PR TITLE
set erroneous true to false

### DIFF
--- a/ix-dev/community/frigate/app.yaml
+++ b/ix-dev/community/frigate/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://github.com/blakeblackshear/frigate
 title: Frigate
 train: community
-version: 1.0.3
+version: 1.0.4

--- a/ix-dev/community/frigate/questions.yaml
+++ b/ix-dev/community/frigate/questions.yaml
@@ -88,7 +88,7 @@ questions:
           schema:
             type: boolean
             default: false
-            show_subquestions_if: true
+            show_subquestions_if: false
             subquestions:
               - variable: web_port
                 label: WebUI Port (Auth)


### PR DESCRIPTION
I'm not sure if this is the correct way to do this, but there seems to be a weird issue where subquestions are only shown when host network check is selected on frigate setup. And due to it binding to host network, these port setting are not respected  e.g. my frigate app is currently available on port 8971 which is frigate default and not 30058 which is what is set in the config. I strongly suspect this is due to the erroneous true set for subquestions. If this is not the right way to do this, please do the needful so frigate could be configured properly.