### PR TITLE
plex: add allowed networks

### DIFF
--- a/ix-dev/stable/plex/app.yaml
+++ b/ix-dev/stable/plex/app.yaml
@@ -48,4 +48,4 @@ sources:
 - https://hub.docker.com/r/plexinc/pms-docker
 title: Plex
 train: stable
-version: 1.0.19
+version: 1.0.20

--- a/ix-dev/stable/plex/migrations/migrate_from_kubernetes
+++ b/ix-dev/stable/plex/migrations/migrate_from_kubernetes
@@ -18,6 +18,7 @@ def migrate(values):
         "plex": {
             "additional_envs": config["plexConfig"].get("additionalEnvs", []),
             "claim_token": config["plexConfig"].get("claimToken", ""),
+            "allowed_networks": [],
             "image_selector": (
                 "image"
                 if config["plexConfig"]["imageSelector"] == "image"

--- a/ix-dev/stable/plex/migrations/migrate_from_kubernetes
+++ b/ix-dev/stable/plex/migrations/migrate_from_kubernetes
@@ -14,11 +14,20 @@ def migrate(values):
     if not config:
         raise ValueError("No config found in values")
 
+    envs = []
+    allowed_networks = []
+
+    for env in config["plexConfig"].get("additionalEnvs", []):
+        if env["name"] == "ALLOWED_NETWORKS":
+            allowed_networks = env["value"].split(",")
+        else:
+            envs.append(env)
+
     new_values = {
         "plex": {
-            "additional_envs": config["plexConfig"].get("additionalEnvs", []),
+            "additional_envs": envs,
             "claim_token": config["plexConfig"].get("claimToken", ""),
-            "allowed_networks": [],
+            "allowed_networks": allowed_networks,
             "image_selector": (
                 "image"
                 if config["plexConfig"]["imageSelector"] == "image"

--- a/ix-dev/stable/plex/questions.yaml
+++ b/ix-dev/stable/plex/questions.yaml
@@ -52,8 +52,16 @@ questions:
               - value: "plex_pass_image"
                 description: Plex Pass Image
         - variable: allowed_networks
-          label: Allowed Networks
-          description: The networks that are allowed to access Plex.
+          label: Local Networks
+          description: |
+            IP address or IP/netmask entries for networks that will be considered to be
+            on the local network when enforcing bandwidth restrictions. </br>
+            If set, all other IP addresses will be considered to be on the external
+            network and will be subject to external network bandwidth restrictions. </br>
+            Additionally, initial setup wizard will not be available on if your client is considered to be on the external network.</br>
+            If left blank, only the server's subnet is considered to be on the local network. </br>
+            "Server's subnet" when host network is NOT enabled, is the docker's network. Therefore,
+            all connections from other clients will be considered to be on the external network.
           schema:
             type: list
             default:

--- a/ix-dev/stable/plex/questions.yaml
+++ b/ix-dev/stable/plex/questions.yaml
@@ -51,6 +51,21 @@ questions:
                 description: Plex Official Image
               - value: "plex_pass_image"
                 description: Plex Pass Image
+        - variable: allowed_networks
+          label: Allowed Networks
+          description: The networks that are allowed to access Plex.
+          schema:
+            type: list
+            default:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+            items:
+              - variable: network
+                label: Network
+                schema:
+                  type: string
+                  required: true
         - variable: additional_envs
           label: Additional Environment Variables
           description: Configure additional environment variables for Plex.

--- a/ix-dev/stable/plex/questions.yaml
+++ b/ix-dev/stable/plex/questions.yaml
@@ -74,6 +74,30 @@ questions:
                 schema:
                   type: string
                   required: true
+        - variable: devices
+          label: Devices
+          description: |
+            Devices to use for Plex.
+            Eg: Host Device: /dev/dvb, Container Device: /dev/dvb
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: device
+                label: Device
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: host_device
+                      label: Host Device
+                      schema:
+                        type: string
+                        required: true
+                    - variable: container_device
+                      label: Container Device
+                      schema:
+                        type: string
+                        required: true
         - variable: additional_envs
           label: Additional Environment Variables
           description: Configure additional environment variables for Plex.

--- a/ix-dev/stable/plex/templates/docker-compose.yaml
+++ b/ix-dev/stable/plex/templates/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     user: "0:0"
     image: {{ ix_lib.base.utils.get_image(images=values.images, name=values.plex.image_selector) }}
     restart: unless-stopped
-    devices: {{ ix_lib.base.resources.get_devices(values.resources) | tojson }}
+    devices: {{ ix_lib.base.resources.get_devices(values.resources, values.plex.devices) | tojson }}
     deploy:
       resources: {{ ix_lib.base.resources.resources(values.resources) | tojson }}
     {% if perms_dirs.items %}

--- a/ix-dev/stable/plex/templates/docker-compose.yaml
+++ b/ix-dev/stable/plex/templates/docker-compose.yaml
@@ -56,12 +56,12 @@ services:
     {% if values.network.dns_opts %}
     dns_opt: {{ ix_lib.base.network.dns_opts(values.network.dns_opts) | tojson }}
     {% endif %}
-    {% set test = "/healthcheck.sh" %}
-    healthcheck: {{ ix_lib.base.healthchecks.check_health(test) | tojson }}
+    healthcheck: {{ ix_lib.base.healthchecks.check_health("/healthcheck.sh") | tojson }}
     environment: {{ ix_lib.base.environment.envs(app={
       "PLEX_UID": values.run_as.user,
       "PLEX_GID": values.run_as.group,
       "PLEX_CLAIM": values.plex.claim_token,
+      "ALLOWED_NETWORKS": values.plex.allowed_networks | join(","),
     }, user=values.plex.additional_envs, values=values) | tojson }}
     {% if not values.network.host_network %}
     ports:

--- a/ix-dev/stable/plex/templates/test_values/basic-values.yaml
+++ b/ix-dev/stable/plex/templates/test_values/basic-values.yaml
@@ -8,6 +8,10 @@ TZ: America/New_York
 plex:
   claim_token: ""
   image_selector: image
+  allowed_networks:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
   additional_envs: []
 network:
   host_network: false
@@ -17,17 +21,12 @@ run_as:
   user: 568
   group: 568
 
-ix_volumes:
-  plex-data: /mnt/pool/plex-data
-
-ix_context:
-  dev_mode: true
-
 storage:
   data:
-    type: ix_volume
-    ix_volume_config:
-      dataset_name: plex-data
+    type: volume
+    volume_name: plex-data
+    volume_config:
+      nocopy: true
   config:
     type: volume
     volume_name: plex-config
@@ -45,7 +44,3 @@ storage:
       mount_path: /scratchpad
       volume_config:
         nocopy: true
-    - type: host_path
-      mount_path: /plex-video
-      host_path_config:
-        path: /mnt/plex-video

--- a/ix-dev/stable/plex/templates/test_values/basic-values.yaml
+++ b/ix-dev/stable/plex/templates/test_values/basic-values.yaml
@@ -8,6 +8,7 @@ TZ: America/New_York
 plex:
   claim_token: ""
   image_selector: image
+  devices: []
   allowed_networks:
     - 10.0.0.0/8
     - 172.16.0.0/12

--- a/ix-dev/stable/plex/templates/test_values/hostnet-values.yaml
+++ b/ix-dev/stable/plex/templates/test_values/hostnet-values.yaml
@@ -8,6 +8,8 @@ TZ: America/New_York
 plex:
   claim_token: ""
   image_selector: image
+  devices: []
+  allowed_networks: []
   additional_envs: []
 network:
   host_network: true


### PR DESCRIPTION
Fixes https://ixsystems.atlassian.net/browse/NAS-131408
Fixes https://github.com/truenas/charts/issues/2741
FIxes https://github.com/truenas/charts/issues/2564

---

Allowed networks are also used by plex to show (or not) the initial setup page.
When plex runs in non-hostnetwork-ed container, it won't show the setup page, as it ONLY considers "local" the docker network. Which the user browser is most definitely not.

I've set as defaults all the private ranges.

On users migrating from DF, it will either keep the existing (no networks defined) or migrate if they have manually set the ALLOWED_NETWORKS variable.