### PR TITLE
ci: fix typo

### DIFF
--- a/.github/scripts/renovate_bump.sh
+++ b/.github/scripts/renovate_bump.sh
@@ -21,7 +21,7 @@ if [[ -z "$update_type" ]]; then
 fi
 
 if grep "$app_path" "$log_path"; then
-  update_type = ""
+  update_type=""
 fi
 
 docker run --quiet --rm \


### PR DESCRIPTION
it was never setting the `update_type` to `""` due to bad syntax.

This resulted in bumping the same app multiple times if more than 1 images were updated