### PR TITLE
freshrss: fix migration

### DIFF
--- a/ix-dev/community/freshrss/app.yaml
+++ b/ix-dev/community/freshrss/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://hub.docker.com/r/freshrss/freshrss
 title: FreshRSS
 train: community
-version: 1.1.11
+version: 1.1.12

--- a/ix-dev/community/freshrss/ix_values.yaml
+++ b/ix-dev/community/freshrss/ix_values.yaml
@@ -10,8 +10,6 @@ consts:
   fresh_rss_container_name: fresh_rss
   perms_container_name: permissions
   postgres_container_name: postgres
-  db_user: fresh_rss
-  db_name: fresh_rss
   pg_run_user: 999
   pg_run_group: 999
   data_path: /var/www/FreshRSS/data

--- a/ix-dev/community/freshrss/migrations/migrate_from_kubernetes
+++ b/ix-dev/community/freshrss/migrations/migrate_from_kubernetes
@@ -25,6 +25,12 @@ def migrate(values):
             "db_password": get_value_from_secret(
                 k8s_secrets, "postgres-creds", "POSTGRES_PASSWORD"
             ),
+            "db_user": get_value_from_secret(
+                k8s_secrets, "postgres-creds", "POSTGRES_USER"
+            ),
+            "db_name": get_value_from_secret(
+                k8s_secrets, "postgres-creds", "POSTGRES_DB"
+            ),
         },
         "network": {
             "web_port": config["freshrssNetwork"].get("webPort", 30027),

--- a/ix-dev/community/freshrss/questions.yaml
+++ b/ix-dev/community/freshrss/questions.yaml
@@ -49,6 +49,22 @@ questions:
             type: string
             default: "*/15"
             required: true
+        - variable: db_user
+          label: Database User
+          description: The user for the database.
+          schema:
+            type: string
+            default: "fresh_rss"
+            required: true
+            hidden: true
+        - variable: db_name
+          label: Database Name
+          description: The name for the database.
+          schema:
+            type: string
+            default: "fresh_rss"
+            required: true
+            hidden: true
         - variable: db_password
           label: Database Password
           description: The password for FreshRSS.

--- a/ix-dev/community/freshrss/templates/docker-compose.yaml
+++ b/ix-dev/community/freshrss/templates/docker-compose.yaml
@@ -76,9 +76,9 @@ services:
       "FRESHRSS_INSTALL": [
         "--default-user %s"|format(values.fresh_rss.default_admin_user),
         "--db-type pgsql",
-        "--db-base %s"|format(values.consts.db_name),
+        "--db-base %s"|format(values.fresh_rss.db_name),
         "--db-host %s"|format(values.consts.postgres_container_name),
-        "--db-user %s"|format(values.consts.db_user),
+        "--db-user %s"|format(values.fresh_rss.db_user),
         "--db-password %s"|format(values.fresh_rss.db_password),
       ]|join("\n"),
     } %}
@@ -99,7 +99,7 @@ services:
     "image": ix_lib.base.utils.get_image(images=values.images, name="postgres_image"),
     "volumes": pg_volume_mounts.items,
     "user": values.consts.pg_run_user, "group": values.consts.pg_run_group,
-    "db_user": values.consts.db_user, "db_name": values.consts.db_name,
+    "db_user": values.fresh_rss.db_user, "db_name": values.fresh_rss.db_name,
     "db_password": values.fresh_rss.db_password,
     "dns_opts": values.network.dns_opts, "resources": resource_without_gpus,
     "depends_on": {

--- a/ix-dev/community/freshrss/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/freshrss/templates/test_values/basic-values.yaml
@@ -9,6 +9,8 @@ fresh_rss:
   default_admin_user: 'admin'
   default_admin_password: 'password'
   cron_min: "*/15"
+  db_user: db-fresh-rss-user
+  db_name: db-fresh-rss
   db_password: db-fresh-rss-password
   additional_envs: []
 


### PR DESCRIPTION
Fixes #607 

Moves the 2 keys to questions as hidden 
and default to what we had on ix_values (this should keep existing users that installed fresh on EE to continue work without issues.

For users migrating from DF, we will pull those from helm secrets, and update the hidden fields in questions