### PR TITLE
lidarr: switch upstream image source

### DIFF
--- a/ix-dev/community/lidarr/app.yaml
+++ b/ix-dev/community/lidarr/app.yaml
@@ -1,4 +1,4 @@
-app_version: 2.5.2.4316
+app_version: 2.6.2.4379
 capabilities: []
 categories:
 - media
@@ -27,8 +27,8 @@ screenshots:
 - https://media.sys.truenas.net/apps/lidarr/screenshots/screenshot2.png
 - https://media.sys.truenas.net/apps/lidarr/screenshots/screenshot3.png
 sources:
-- https://github.com/onedr0p/containers/tree/main/apps/lidarr
+- https://github.com/elfhosted/containers/tree/main/apps/lidarr
 - https://github.com/Lidarr/Lidarr
 title: Lidarr
 train: community
-version: 1.1.7
+version: 1.1.8

--- a/ix-dev/community/lidarr/ix_values.yaml
+++ b/ix-dev/community/lidarr/ix_values.yaml
@@ -1,6 +1,6 @@
 images:
   image:
-    repository: ghcr.io/onedr0p/lidarr-develop
+    repository: ghcr.io/elfhosted/lidarr-develop
     tag: 2.6.2.4379
 
 consts:

--- a/ix-dev/community/lidarr/ix_values.yaml
+++ b/ix-dev/community/lidarr/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/onedr0p/lidarr-develop
-    tag: 2.5.2.4316
+    tag: 2.6.2.4379
 
 consts:
   lidarr_container_name: lidarr

--- a/ix-dev/community/lidarr/templates/docker-compose.yaml
+++ b/ix-dev/community/lidarr/templates/docker-compose.yaml
@@ -54,8 +54,8 @@ services:
     {% set test = ix_lib.base.healthchecks.curl_test(port=values.network.web_port, path="/ping") %}
     healthcheck: {{ ix_lib.base.healthchecks.check_health(test) | tojson }}
     environment: {{ ix_lib.base.environment.envs(app={
-      "LIDARR__SERVER__PORT": values.network.web_port,
-      "LIDARR__APP__INSTANCENAME": values.lidarr.instance_name,
+      "LIDARR__PORT": values.network.web_port,
+      "LIDARR__INSTANCE_NAME": values.lidarr.instance_name,
     }, user=values.lidarr.additional_envs, values=values) | tojson }}
     {% if not values.network.host_network %}
     ports:


### PR DESCRIPTION
Old image source deprecated the lidarr image.
Switching to a drop-in replacement that is currently maintained