### PR TITLE
tailscale: dont restrict auth key format

### DIFF
--- a/ix-dev/community/tailscale/app.yaml
+++ b/ix-dev/community/tailscale/app.yaml
@@ -42,4 +42,4 @@ sources:
 - https://hub.docker.com/r/tailscale/tailscale
 title: Tailscale
 train: community
-version: 1.1.11
+version: 1.1.12

--- a/ix-dev/community/tailscale/templates/docker-compose.yaml
+++ b/ix-dev/community/tailscale/templates/docker-compose.yaml
@@ -9,8 +9,6 @@
 {# Stores the perms container dirs #}
 {% set perms_dirs = namespace(items=[]) %}
 
-{% do ix_lib.community.tailscale.util.validate(values=values) %}
-
 {% do storage_items.items.append(ix_lib.base.storage.storage_item(data=dict(values.storage.state, **{"mount_path": values.consts.state_path}),
   values=values, perm_opts={"mount_path": "/mnt/tailscale/state", "mode": "always", "uid": 568, "gid": 568}
 )) %}

--- a/ix-dev/community/tailscale/templates/library/community/tailscale/v1_1_12/util.py
+++ b/ix-dev/community/tailscale/templates/library/community/tailscale/v1_1_12/util.py
@@ -7,18 +7,10 @@ def get_args(data):
     if data.get("advertise_exit_node"):
         args.append("--advertise-exit-node")
 
-    reserved_keys = ["--advertise-exit-node", "--hostname"]
+    reserved_keys = ["--advertise-exit-node", "--hostname", "--authkey"]
     for arg in data.get("extra_args", []):
         for key in reserved_keys:
             if arg.startswith(key):
                 utils.throw_error(f"Please use the dedicated field for {key}")
         args.append(arg)
     return " ".join(args)
-
-
-def validate(values):
-    key = values.get("tailscale", {}).get("auth_key") or ""
-    if not key.startswith("tskey-"):
-        utils.throw_error(
-            f"The auth key must start with 'tskey-', but starts with '{key[:8]}'"
-        )


### PR DESCRIPTION
Fixes #616 


- Removes the validation for auth key format, as third party servers might user different format
- Makes sure that `--authkey` can't be passed via extra params, as users should use the dedicated fields.