### PR TITLE
photoprism: handle gracefully some fields

### DIFF
--- a/ix-dev/stable/photoprism/app.yaml
+++ b/ix-dev/stable/photoprism/app.yaml
@@ -42,4 +42,4 @@ sources:
 - https://photoprism.app/
 title: Photoprism
 train: stable
-version: 1.1.11
+version: 1.1.12

--- a/ix-dev/stable/photoprism/migrations/migrate_from_kubernetes
+++ b/ix-dev/stable/photoprism/migrations/migrate_from_kubernetes
@@ -17,7 +17,7 @@ def migrate(values):
     new_values = {
         "photoprism": {
             "admin_password": config["photoprismConfig"].get("password", ""),
-            "site_url": config["photoprismConfig"]["siteURL"],
+            "site_url": config["photoprismConfig"].get("siteURL", ""),
             "public": config["photoprismConfig"]["public"],
             "additional_envs": config["photoprismConfig"].get("additionalEnvs", []),
         },
@@ -28,7 +28,7 @@ def migrate(values):
         "network": {
             "host_network": config["photoprismNetwork"].get("hostNetwork", False),
             "web_port": config["photoprismNetwork"].get("webPort", 32400),
-            "certificate_id": config["photoprismNetwork"].get("certificateID", ""),
+            "certificate_id": config["photoprismNetwork"].get("certificateID", None),
             "dns_opts": migrate_dns_config(config["podOptions"].get("dnsConfig", {})),
         },
         "storage": {


### PR DESCRIPTION
Fixes #623 

Given that only 2 fields were added on the latest photoprism questions compared to the user's version. We can handle that migration gracefully.