### PR TITLE
syncthing/stable: remove restriction on user/group ids

### DIFF
--- a/ix-dev/stable/syncthing/app.yaml
+++ b/ix-dev/stable/syncthing/app.yaml
@@ -50,4 +50,4 @@ sources:
 - https://hub.docker.com/r/syncthing/syncthing
 title: Syncthing
 train: stable
-version: 1.0.24
+version: 1.0.25

--- a/ix-dev/stable/syncthing/questions.yaml
+++ b/ix-dev/stable/syncthing/questions.yaml
@@ -50,7 +50,7 @@ questions:
           description: The user id that Syncthing files will be owned by.
           schema:
             type: int
-            min: 568
+            min: 0
             default: 568
             required: true
         - variable: group
@@ -58,7 +58,7 @@ questions:
           description: The group id that Syncthing files will be owned by.
           schema:
             type: int
-            min: 568
+            min: 0
             default: 568
             required: true
 


### PR DESCRIPTION
We didn't had such restriction on k8s, so it was breaking some migrations.