### PR TITLE
rsyncd: fix conf bool values and validate module's aux params

### DIFF
--- a/ix-dev/community/rsyncd/app.yaml
+++ b/ix-dev/community/rsyncd/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://hub.docker.com/r/ixsystems/rsyncd
 title: Rsync Daemon
 train: community
-version: 1.0.11
+version: 1.0.12

--- a/ix-dev/community/rsyncd/templates/rsync_macros/rsyncd.conf
+++ b/ix-dev/community/rsyncd/templates/rsync_macros/rsyncd.conf
@@ -28,8 +28,8 @@ log file = /dev/stdout
   {%- if mod.comment %}
   comment = {{ mod.comment }}
   {%- endif %}
-  write only = {{ true if mod.access_mode == "WO" else false }}
-  read only = {{ true if mod.access_mode == "RO" else false }}
+  write only = {{ "true" if mod.access_mode == "WO" else "false" }}
+  read only = {{ "true" if mod.access_mode == "RO" else "false" }}
   {%- if mod.hosts_allow %}
   hosts allow = {{ mod.hosts_allow | join(" ") }}
   {%- endif %}

--- a/ix-dev/community/rsyncd/templates/rsync_macros/rsyncd.conf
+++ b/ix-dev/community/rsyncd/templates/rsync_macros/rsyncd.conf
@@ -38,6 +38,9 @@ log file = /dev/stdout
   {%- endif %}
 
   {%- for aux in mod.aux_params %}
+    {%- if aux.param in values.consts.reserved_params %}
+      {%- do ix_lib.base.utils.throw_error("Parameter [%s] is reserved and cannot be used."|format(aux.param)) -%}
+    {%- endif %}
   {{ "%s = %s"|format(aux.param, aux.value) }}
   {%- endfor %}
 {%- else %}


### PR DESCRIPTION
- We were validating the top level aux params but not per module
- bool values have to be `true` and not `True`