### PR TITLE
adguard: healthcheck endpoint is not working

### DIFF
--- a/ix-dev/community/adguard-home/app.yaml
+++ b/ix-dev/community/adguard-home/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://hub.docker.com/r/adguard/adguardhome
 title: AdGuard Home
 train: community
-version: 1.0.21
+version: 1.0.22

--- a/ix-dev/community/adguard-home/templates/docker-compose.yaml
+++ b/ix-dev/community/adguard-home/templates/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
     {% if values.network.dns_opts %}
     dns_opt: {{ ix_lib.base.network.dns_opts(values.network.dns_opts) | tojson }}
     {% endif %}
-    {% set test = ix_lib.base.healthchecks.wget_test(port=values.network.web_port, path="/health-check", config={"scheme": "https" if values.adguard.use_https_probe else "http"}) %}
+    {% set test = ix_lib.base.healthchecks.wget_test(port=values.network.web_port, path="/", config={"scheme": "https" if values.adguard.use_https_probe else "http"}) %}
     healthcheck: {{ ix_lib.base.healthchecks.check_health(test) | tojson }}
     environment: {{ ix_lib.base.environment.envs(app={}, user=values.adguard.additional_envs,values=values) | tojson }}
     {% if not values.network.host_network and not values.network.dhcp_enabled %}


### PR DESCRIPTION
During the initial setup adguard redirects everything to `/install`
Which made me believe that the `/health-check` endpoint works (https://github.com/AdguardTeam/AdGuardHome/blob/41cce6259709d450b3c6c310cedd9610f4f82a69/internal/next/websvc/path.go#L8)

But it seems that it will exist in a `next` version?!

---

Switch back to using `/` for healthcheck