### PR TITLE
set renovate logs to debug

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: renovatebot/github-action@v40.2.5
         env:
           RENOVATE_PR_HOURLY_LIMIT: 10
+          LOG_LEVEL: debug
         with:
           configurationFile: .github/renovate-config.js
           # TODO: https://github.com/renovatebot/github-action/tree/main?tab=readme-ov-file


### PR DESCRIPTION
Sets renovate log level to debug.
I'm trying to debug why it won't open a PR for some apps.