### PR TITLE
plex: handle some very niche case for migration

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -50,6 +50,11 @@ module.exports = {
       },
     },
     {
+      matchManagers: ["github-actions"],
+      addLabels: ["actions"],
+      groupName: "gh-actions",
+    },
+    {
       matchDatasources: ["docker"],
       matchUpdateTypes: ["major"],
       labels: ["major"],

--- a/ix-dev/stable/plex/app.yaml
+++ b/ix-dev/stable/plex/app.yaml
@@ -48,4 +48,4 @@ sources:
 - https://hub.docker.com/r/plexinc/pms-docker
 title: Plex
 train: stable
-version: 1.0.23
+version: 1.0.24

--- a/ix-dev/stable/plex/migrations/migrate_from_kubernetes
+++ b/ix-dev/stable/plex/migrations/migrate_from_kubernetes
@@ -20,7 +20,7 @@ def migrate(values):
     for env in config["plexConfig"].get("additionalEnvs", []):
         if env["name"] == "ALLOWED_NETWORKS":
             allowed_networks = env["value"].split(",")
-        else:
+        elif env["name"] != "NVIDIA_VISIBLE_DEVICES":
             envs.append(env)
 
     new_values = {


### PR DESCRIPTION
We validate that user's wont try to override variables that we automatically set.
In this case a user had this variable set when migrating from kubernetes and the template generation was failing after the migration.

We did have some validation in k8s for this as well, but there was a small escape hatch apparently.
We might see this issue in other apps that can potentially utilize nvidia gpu's, even if we didnt expose the setting.