### PR TITLE
rsyncd: fix to add capabilities in compose template

### DIFF
--- a/ix-dev/community/rsyncd/app.yaml
+++ b/ix-dev/community/rsyncd/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://hub.docker.com/r/ixsystems/rsyncd
 title: Rsync Daemon
 train: community
-version: 1.0.14
+version: 1.0.15

--- a/ix-dev/community/rsyncd/templates/docker-compose.yaml
+++ b/ix-dev/community/rsyncd/templates/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
     {% endif %}
     {% set caps = ix_lib.base.security.get_caps(add=["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID", "SYS_CHROOT"]) %}
     cap_add: {{ caps.add | tojson }}
-    cap_drop: {{ ix_lib.base.security.get_caps().drop | tojson }}
+    cap_drop: {{ caps.drop | tojson }}
     security_opt: {{ ix_lib.base.security.get_sec_opts() | tojson }}
     {% if values.network.dns_opts %}
     dns_opt: {{ ix_lib.base.network.dns_opts(values.network.dns_opts) | tojson }}

--- a/ix-dev/community/rsyncd/templates/docker-compose.yaml
+++ b/ix-dev/community/rsyncd/templates/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
     network_mode: host
     {% endif %}
     {% set caps = ix_lib.base.security.get_caps(add=["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID", "SYS_CHROOT"]) %}
+    cap_add: {{ caps.add | tojson }}
     cap_drop: {{ ix_lib.base.security.get_caps().drop | tojson }}
     security_opt: {{ ix_lib.base.security.get_sec_opts() | tojson }}
     {% if values.network.dns_opts %}


### PR DESCRIPTION
See a description in Issue #705.

I'm not entirely sure how to switch to another repo to get apps from yet, but I did try making the same change locally in `/mnt/.ix-apps/app_configs/rsyncd/versions/1.0.14/templates/docker-compose.yaml` then made a config change to the app so it redeployed and it appears to have the correct capabilities now and I can use the rsync daemon on the version of Electric Eel mentioned in the issue.

I did see that the repo says no PRs right now, but figured this should be pretty straightfoward and I may as well submit a single line change.