### PR TITLE
nextcloud: fix trusted-proxies warning

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -66,4 +66,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/nextcloud
 title: Nextcloud
 train: stable
-version: 1.4.2
+version: 1.4.3

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -107,7 +107,7 @@
 {% if values.network.certificate_id %}
   {% do nc_env.x.append(("APACHE_DISABLE_REWRITE_IP", 1)) %}
   {% do nc_env.x.append(("OVERWRITEPROTOCOL", "https")) %}
-  {% do nc_env.x.append(("TRUSTED_PROXIES", ["127.0.0.1", values.consts.nginx_container_name]|unique|list|join(" "))) %}
+  {% do nc_env.x.append(("TRUSTED_PROXIES", ["127.0.0.1", "192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"] | join(" "))) %}
   {% if values.nextcloud.host %}
     {% set host = namespace(x="%s:%d"|format(values.nextcloud.host, values.network.web_port)) %}
     {% if ":" in values.nextcloud.host %}


### PR DESCRIPTION
Fixes https://github.com/truenas/charts/issues/2908

Nextcloud does not resolve hosts in trusted proxies.
Considering this is an **install only** env-variable, I'll set the trusted proxies to all private network ranges.
From there users can adapt to their preferred values,