### PR TITLE
renovate: enterprise versioning

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -74,8 +74,8 @@ module.exports = {
     },
     {
       matchDatasources: ["docker"],
-      groupName: "enterprise",
       labels: ["enterprise"],
+      minimumReleaseAge: "21 days",
       matchFileNames: ["ix-dev/enterprise/**"],
     },
     // Custom versioning matching


### PR DESCRIPTION
- Removes the group, so each enterprise app will be in a separate PR.
- The PR will include the latest release that is at least 21days out there.