### PR TITLE
storj: check early if configdir is writable

### DIFF
--- a/ix-dev/stable/storj/app.yaml
+++ b/ix-dev/stable/storj/app.yaml
@@ -37,4 +37,4 @@ sources:
 - https://www.storj.io
 title: Storj
 train: stable
-version: 1.1.12
+version: 1.1.13

--- a/ix-dev/stable/storj/templates/macros/init.sh
+++ b/ix-dev/stable/storj/templates/macros/init.sh
@@ -6,6 +6,8 @@
 {%- set id_tool_dir_files = values.consts.identity_tool_dir_files %}
 {%- set flags = "--identity-dir %s"|format(id_path) %}
 
+[ ! -w {{ config_dir }} ] && { echo "Config directory is not writable."; exit 1; }
+
 echo "Checking for identity certificate..."
 if ! [ -f "{{ id_path }}/ca.cert" ] && ! [ -f "{{ id_path }}/identity.cert" ]; then
   echo "Downloading identity generator tool..."; mkdir -p {{ id_tool_dir }}

--- a/ix-dev/stable/storj/templates/macros/init.sh
+++ b/ix-dev/stable/storj/templates/macros/init.sh
@@ -6,7 +6,8 @@
 {%- set id_tool_dir_files = values.consts.identity_tool_dir_files %}
 {%- set flags = "--identity-dir %s"|format(id_path) %}
 
-[ ! -w {{ config_dir }} ] && { echo "Config directory is not writable."; exit 1; }
+[ ! -w {{ values.consts.config_dir }} ] && { echo "Config directory is not writable."; exit 1; }
+[ ! -r {{ id_path }} ] && { echo "Identity directory is not readable."; exit 1; }
 
 echo "Checking for identity certificate..."
 if ! [ -f "{{ id_path }}/ca.cert" ] && ! [ -f "{{ id_path }}/identity.cert" ]; then


### PR DESCRIPTION
Closes #788 

Checks if the directory is writable early, before the whole identity generation process happens.