### PR TITLE
readarr: use elfhosted image

### DIFF
--- a/ix-dev/community/readarr/app.yaml
+++ b/ix-dev/community/readarr/app.yaml
@@ -1,4 +1,4 @@
-app_version: 0.3.32.2587
+app_version: 0.4.3.2665
 capabilities: []
 categories:
 - media
@@ -29,8 +29,8 @@ screenshots:
 - https://media.sys.truenas.net/apps/readarr/screenshots/screenshot2.png
 - https://media.sys.truenas.net/apps/readarr/screenshots/screenshot3.png
 sources:
-- https://github.com/onedr0p/containers/tree/main/apps/readarr
+- https://github.com/elfhosted/containers/tree/main/apps/readarr
 - https://github.com/Readarr/Readarr
 title: Readarr
 train: community
-version: 1.0.22
+version: 1.0.23

--- a/ix-dev/community/readarr/ix_values.yaml
+++ b/ix-dev/community/readarr/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
-    repository: ghcr.io/onedr0p/readarr-develop
-    tag: 0.3.32.2587
+    repository: ghcr.io/elfhosted/readarr-develop
+    tag: 0.4.3.2665
 
 consts:
   readarr_container_name: readarr

--- a/ix-dev/community/readarr/templates/docker-compose.yaml
+++ b/ix-dev/community/readarr/templates/docker-compose.yaml
@@ -13,7 +13,7 @@
   values=values, perm_opts={"mount_path": "/mnt/readarr/config", "mode": "check", "uid": values.run_as.user, "gid": values.run_as.group}
 )) %}
 {% do storage_items.items.append(ix_lib.base.storage.storage_item(data={"type": "temporary", "mount_path": "/tmp"},
-  perm_opts={"mount_path": "/mnt/qbittorrent/tmp", "mode": "check", "uid": values.run_as.user, "gid": values.run_as.group}
+  perm_opts={"mount_path": "/mnt/readarr/tmp", "mode": "check", "uid": values.run_as.user, "gid": values.run_as.group}
 )) %}
 
 {% for store in values.storage.additional_storage %}
@@ -54,8 +54,8 @@ services:
     {% set test = ix_lib.base.healthchecks.curl_test(port=values.network.web_port, path="/ping") %}
     healthcheck: {{ ix_lib.base.healthchecks.check_health(test) | tojson }}
     environment: {{ ix_lib.base.environment.envs(app={
-      "READARR__SERVER__PORT": values.network.web_port,
-      "READARR__APP__INSTANCENAME": values.readarr.instance_name,
+      "READARR__PORT": values.network.web_port,
+      "READARR__INSTANCE_NAME": values.readarr.instance_name,
     }, user=values.readarr.additional_envs, values=values) | tojson }}
     {% if not values.network.host_network %}
     ports:


### PR DESCRIPTION
Switch from onedr0p image for Readarr that is [delisted](https://github.com/onedr0p/containers/pull/1088), to elfhosted - similar as done with lidarr.  Updated to latest readarr version available on elfhosted.

Reference Issue: https://github.com/truenas/apps/issues/860

Elfhosted Readarr Project: https://github.com/elfhosted/containers/tree/main/apps/readarr
Elfhosted Readarr Containers: https://github.com/elfhosted/containers/pkgs/container/readarr-develop

The Dockerfile uses user "elfie" which is 568 in the base alpine so should line up with TrueNAS Scale's apps user & group.

My apologies if this is overstepping, I realize the readme still has the Contributions warning.  Thank you for consideration though!


P.S. Kudos on the Electric Eel transition!  Other than NPM proxy issues it was incredibly smooth and loving the improvements! 🎉🚀 