### PR TITLE
rsyncd : allow uid/gid > 65535

### DIFF
--- a/ix-dev/community/rsyncd/app.yaml
+++ b/ix-dev/community/rsyncd/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://hub.docker.com/r/ixsystems/rsyncd
 title: Rsync Daemon
 train: community
-version: 1.0.18
+version: 1.0.19

--- a/ix-dev/community/rsyncd/questions.yaml
+++ b/ix-dev/community/rsyncd/questions.yaml
@@ -117,7 +117,7 @@ questions:
                               type: int
                               default: 0
                               min: 0
-                              max: 65535
+                              max: 4294967295
                               required: true
                           - variable: gid
                             label: GID
@@ -126,7 +126,7 @@ questions:
                               type: int
                               default: 0
                               min: 0
-                              max: 65535
+                              max: 4294967295
                               required: true
                           - variable: hosts_allow
                             label: Hosts Allow


### PR DESCRIPTION
UID/GID can be > 65535, for example in some AD domain situations. This PR allows UID/GID to be up to max int32 (4294967295) in rsyncd module UI