### PR TITLE
pal: change upstream

### DIFF
--- a/ix-dev/community/plex-auto-languages/app.yaml
+++ b/ix-dev/community/plex-auto-languages/app.yaml
@@ -1,9 +1,9 @@
-app_version: v1.2.3
+app_version: latest
 capabilities: []
 categories:
 - media
 description: Plex Auto Languages offer automated language selection for Plex TV Shows
-home: https://github.com/RemiRigal/Plex-Auto-Languages
+home: https://github.com/JourneyDocker/Plex-Auto-Languages
 host_mounts: []
 icon: https://media.sys.truenas.net/apps/plex-auto-languages/icons/icon.svg
 keywords:
@@ -24,8 +24,7 @@ run_as_context:
   user_name: plex-auto-languages
 screenshots: []
 sources:
-- https://github.com/RemiRigal/Plex-Auto-Languages
-- https://hub.docker.com/r/remirigal/plex-auto-languages
+- https://github.com/JourneyDocker/Plex-Auto-Languages
 title: Plex Auto Languages
 train: community
-version: 1.1.0
+version: 1.2.0

--- a/ix-dev/community/plex-auto-languages/ix_values.yaml
+++ b/ix-dev/community/plex-auto-languages/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
-    repository: remirigal/plex-auto-languages
-    tag: v1.2.3
+    repository: ghcr.io/journeydocker/plex-auto-languages
+    tag: latest
 
 consts:
   plex_auto_languages_container_name: plex-auto-languages


### PR DESCRIPTION
Fixes #1113

New upstream does not have currently versioned tag, so switching to `latest` for now
