### PR TITLE
Fix run_as_context

### DIFF
--- a/ix-dev/community/actual-budget/app.yaml
+++ b/ix-dev/community/actual-budget/app.yaml
@@ -18,11 +18,11 @@ maintainers:
   url: https://www.truenas.com/
 name: actual-budget
 run_as_context:
-- description: Tautulli runs as any non-root user.
-  gid: 568
-  group_name: tautulli
-  uid: 568
-  user_name: tautulli
+- description: Actual Budget runs as any non-root user.
+  gid: 1001
+  group_name: actual
+  uid: 1001
+  user_name: actual
 screenshots:
 - https://media.sys.truenas.net/apps/actual-budget/screenshots/screenshot1.png
 - https://media.sys.truenas.net/apps/actual-budget/screenshots/screenshot2.png


### PR DESCRIPTION
Although the current `run_as_context` works, it appears to be an small overlooked cut-and-paste from the [tuatulli app](https://github.com/truenas/apps/blob/master/ix-dev/community/tautulli/app.yaml).   Correcting this should avoid possible confusions.

The values I am proposing correspond to what I see in my running Actual Budget app container (accessed via the Truenas Applications web UI.)
```
$ cat /etc/passwd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
node:x:1000:1000::/home/node:/bin/bash
actual:x:1001:1001::/home/actual:/bin/sh              <--------- this would make more sense
$ id
uid=568 gid=568 groups=568
$ 
```

Not sure if/how/when you update the `lib_version` and `version` strings, so I will leave that up to the maintainers.