### PR TITLE
fix(nextcloud): Rename network.nginx.use_different_access_port to network.nginx.use_different_port

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -66,4 +66,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/nextcloud
 title: Nextcloud
 train: stable
-version: 1.5.1
+version: 1.5.2

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -108,7 +108,6 @@
     else "%s:%d"|format(values.nextcloud.host, values.network.web_port)
   ) %}
 {% endif %}
-{% do nc_env.x.append(("NEXTCLOUD_TRUSTED_DOMAINS", trusted_domains.x|unique|list|join(" "))) %}
 {% if values.network.certificate_id %}
   {% do nc_env.x.append(("APACHE_DISABLE_REWRITE_IP", 1)) %}
   {% do nc_env.x.append(("OVERWRITEPROTOCOL", "https")) %}
@@ -117,11 +116,13 @@
     {% set host = namespace(x="%s:%d"|format(values.nextcloud.host, values.network.web_port)) %}
     {% if ":" in values.nextcloud.host %}
       {% set host.x = values.nextcloud.host %}
-    {% elif values.network.nginx.use_different_access_port %}
+    {% elif values.network.nginx.use_different_port %}
       {% set host.x = "%s:%d"|format(values.nextcloud.host, values.network.nginx.external_port) %}
     {% endif %}
     {% do nc_env.x.append(("OVERWRITEHOST", host.x)) %}
+    {% do trusted_domains.x.append(host.x) %}
   {% endif %}
+{% do nc_env.x.append(("NEXTCLOUD_TRUSTED_DOMAINS", trusted_domains.x|unique|list|join(" "))) %}
 {% endif %}
 
 {% do nc_container.build_image(nc_custom_image.x) %}

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -102,28 +102,26 @@
   ("POSTGRES_USER", values.nextcloud.db_user),
 ]) %}
 {% set trusted_domains = namespace(x=["127.0.0.1", "localhost", values.consts.nextcloud_container_name]) %}
+
+{% set host = namespace(x="") %}
 {% if values.nextcloud.host %}
-  {% do trusted_domains.x.append(
-    values.nextcloud.host if ":" in values.nextcloud.host
-    else "%s:%d"|format(values.nextcloud.host, values.network.web_port)
-  ) %}
+  {% set host.x = values.nextcloud.host if ":" in values.nextcloud.host else "%s:%d"|format(values.nextcloud.host, values.network.web_port) %}
 {% endif %}
+
 {% if values.network.certificate_id %}
   {% do nc_env.x.append(("APACHE_DISABLE_REWRITE_IP", 1)) %}
   {% do nc_env.x.append(("OVERWRITEPROTOCOL", "https")) %}
   {% do nc_env.x.append(("TRUSTED_PROXIES", ["127.0.0.1", "192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"] | join(" "))) %}
-  {% if values.nextcloud.host %}
-    {% set host = namespace(x="%s:%d"|format(values.nextcloud.host, values.network.web_port)) %}
-    {% if ":" in values.nextcloud.host %}
-      {% set host.x = values.nextcloud.host %}
-    {% elif values.network.nginx.use_different_port %}
-      {% set host.x = "%s:%d"|format(values.nextcloud.host, values.network.nginx.external_port) %}
-    {% endif %}
+  {% if values.nextcloud.host and values.network.nginx.use_different_port %}
+    {% set host.x = "%s:%d"|format(values.nextcloud.host, values.network.nginx.external_port) %}
     {% do nc_env.x.append(("OVERWRITEHOST", host.x)) %}
-    {% do trusted_domains.x.append(host.x) %}
   {% endif %}
-{% do nc_env.x.append(("NEXTCLOUD_TRUSTED_DOMAINS", trusted_domains.x|unique|list|join(" "))) %}
 {% endif %}
+
+{% if host.x %}
+  {% do trusted_domains.x.append(host.x) %}
+{% endif %}
+{% do nc_env.x.append(("NEXTCLOUD_TRUSTED_DOMAINS", trusted_domains.x|unique|list|join(" "))) %}
 
 {% do nc_container.build_image(nc_custom_image.x) %}
 {% do nc_container.set_user(0,0) %}

--- a/ix-dev/stable/nextcloud/templates/macros/nc.jinja.conf
+++ b/ix-dev/stable/nextcloud/templates/macros/nc.jinja.conf
@@ -13,7 +13,7 @@ LimitRequestBody {{ values.nextcloud.php_upload_limit * bytes_gb }}
 
 {% macro nginx_conf(values) -%}
 {%- set port = namespace(x=":$server_port") -%}
-{%- if values.network.nginx.use_different_access_port -%}
+{%- if values.network.nginx.use_different_port -%}
   {%- set port.x = ":%d"|format(values.network.nginx.external_port) -%}
 {%- endif -%}
 {%- if port.x == ":443" -%}

--- a/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
@@ -32,7 +32,7 @@ network:
   certificate_id:
   nginx:
     proxy_timeout: 60
-    use_different_access_port: false
+    use_different_port: false
 
 ix_volumes:
   postgres_data: /opt/tests/mnt/postgres_data

--- a/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
@@ -12,7 +12,7 @@ nextcloud:
     - smbclient
   tesseract_languages:
     - eng
-  host: localhost:8080
+  host: nextcloud.example.com
   data_dir_path: /var/www/html/data
   redis_password: password
   db_user: nextcloud
@@ -30,7 +30,8 @@ network:
   certificate_id: "2"
   nginx:
     proxy_timeout: 60
-    use_different_access_port: false
+    use_different_port: true
+    external_port: 8443
 
 ix_volumes:
   postgres_data: /opt/tests/mnt/postgres_data

--- a/ix-dev/stable/nextcloud/templates/test_values/no-cron-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/no-cron-values.yaml
@@ -32,7 +32,7 @@ network:
   certificate_id:
   nginx:
     proxy_timeout: 60
-    use_different_access_port: false
+    use_different_port: false
 
 ix_volumes:
   postgres_data: /opt/tests/mnt/postgres_data

--- a/ix-dev/stable/nextcloud/templates/test_values/same-vol-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/same-vol-values.yaml
@@ -28,7 +28,7 @@ network:
   certificate_id:
   nginx:
     proxy_timeout: 60
-    use_different_access_port: false
+    use_different_port: false
 
 ix_volumes:
   postgres_data: /opt/tests/mnt/postgres_data


### PR DESCRIPTION
This PR renames `network.nginx.use_different_access_port` to `network.nginx.use_different_port` to fix the use of the different port as it is not picked up at the moment.

It also adds the domain with the different port to `NEXTCLOUD_TRUSTED_DOMAINS`.