### PR TITLE
config: update incorrect screenshots of briefkasten

### DIFF
--- a/ix-dev/community/briefkasten/app.yaml
+++ b/ix-dev/community/briefkasten/app.yaml
@@ -27,12 +27,13 @@ run_as_context:
   uid: 999
   user_name: postgres
 screenshots:
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot1.png
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot2.png
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot3.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot1.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot2.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot3.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot4.png
 sources:
 - https://github.com/ndom91/briefkasten
 - https://docs.briefkastenhq.com/
 title: Briefkasten
 train: community
-version: 1.2.0
+version: 1.2.1

--- a/ix-dev/community/briefkasten/item.yaml
+++ b/ix-dev/community/briefkasten/item.yaml
@@ -2,8 +2,9 @@ categories:
 - productivity
 icon_url: https://media.sys.truenas.net/apps/briefkasten/icons/icon.svg
 screenshots:
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot1.png
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot2.png
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot3.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot1.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot2.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot3.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot4.png
 tags:
 - bookmark

--- a/trains/community/briefkasten/item.yaml
+++ b/trains/community/briefkasten/item.yaml
@@ -2,8 +2,9 @@ categories:
 - productivity
 icon_url: https://media.sys.truenas.net/apps/briefkasten/icons/icon.svg
 screenshots:
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot1.png
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot2.png
-- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot3.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot1.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot2.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot3.png
+- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot4.png
 tags:
 - bookmark

--- a/trains/community/briefkasten/item.yaml
+++ b/trains/community/briefkasten/item.yaml
@@ -2,9 +2,8 @@ categories:
 - productivity
 icon_url: https://media.sys.truenas.net/apps/briefkasten/icons/icon.svg
 screenshots:
-- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot1.png
-- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot2.png
-- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot3.png
-- https://media.sys.truenas.net/apps/briefkasten/screenshots/screenshot4.png
+- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot1.png
+- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot2.png
+- https://media.sys.truenas.net/apps/homarr/screenshots/screenshot3.png
 tags:
 - bookmark


### PR DESCRIPTION
Hi, I'm one of the Homarr developers 👋
The screenshot for "Briefkasten" seem to accidentally use the incorrect screenshots from our app and not Briefkasten.
![image](https://github.com/user-attachments/assets/bd5a1d25-25b4-4da6-b9bd-fdc421b321eb)

This commit copies the links from https://github.com/truenas/charts/blob/master/community/briefkasten/item.yaml  and removes the incorrect Homarr links.

