### PR TITLE
Add correct link to documentation for Gaseous in Notes

### DIFF
--- a/ix-dev/community/gaseous-server/app.yaml
+++ b/ix-dev/community/gaseous-server/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://github.com/gaseous-project/gaseous-server
 title: Gaseous Server
 train: community
-version: 1.0.6
+version: 1.0.7

--- a/ix-dev/community/gaseous-server/ix_values.yaml
+++ b/ix-dev/community/gaseous-server/ix_values.yaml
@@ -13,3 +13,15 @@ consts:
   db_user: gaseous
   db_name: gaseous
   internal_web_port: 80
+  notes_header:
+  notes_body: |
+    ## Gaseous Server
+
+    Thank you for installing Gaseous Server!
+
+    For information on how to use Gaseous, as well as adding roms,
+    please visit the official wiki documentation.
+
+    https://github.com/gaseous-project/gaseous-server/wiki
+  notes_footer:
+~

--- a/ix-dev/community/gaseous-server/ix_values.yaml
+++ b/ix-dev/community/gaseous-server/ix_values.yaml
@@ -20,8 +20,6 @@ consts:
     Thank you for installing Gaseous Server!
 
     For information on how to use Gaseous, as well as adding roms,
-    please visit the official wiki documentation.
-
-    https://github.com/gaseous-project/gaseous-server/wiki
+    please visit the [official documentation](https://github.com/gaseous-project/gaseous-server/wiki).
   notes_footer:
 ~

--- a/ix-dev/community/gaseous-server/ix_values.yaml
+++ b/ix-dev/community/gaseous-server/ix_values.yaml
@@ -13,12 +13,6 @@ consts:
   db_user: gaseous
   db_name: gaseous
   internal_web_port: 80
-  notes_header:
   notes_body: |
-    ## Gaseous Server
-
-    Thank you for installing Gaseous Server!
-
     For information on how to use Gaseous, as well as adding roms,
     please visit the [official documentation](https://github.com/gaseous-project/gaseous-server/wiki).
-  notes_footer:

--- a/ix-dev/community/gaseous-server/ix_values.yaml
+++ b/ix-dev/community/gaseous-server/ix_values.yaml
@@ -22,4 +22,3 @@ consts:
     For information on how to use Gaseous, as well as adding roms,
     please visit the [official documentation](https://github.com/gaseous-project/gaseous-server/wiki).
   notes_footer:
-~

--- a/ix-dev/community/gaseous-server/templates/docker-compose.yaml
+++ b/ix-dev/community/gaseous-server/templates/docker-compose.yaml
@@ -40,4 +40,7 @@
   {% do mariadb_container.container.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
 {% endif %}
 
+{% do tpl.notes.set_body(values.consts.notes_body) %}
+
 {{ tpl.render() | tojson }}
+


### PR DESCRIPTION
@stavros-k can you confirm I did this right? Not sure how to preview this locally. If I can use markdown in the YAML, that would be awesome as well. I'll update if so. 