### PR TITLE
nextcloud: don't make container restart if occ is not available

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -66,4 +66,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/nextcloud
 title: Nextcloud
 train: stable
-version: 1.5.4
+version: 1.5.5

--- a/ix-dev/stable/nextcloud/templates/macros/nc.jinja.sh
+++ b/ix-dev/stable/nextcloud/templates/macros/nc.jinja.sh
@@ -21,10 +21,9 @@ run_as "$@"
 
 {% macro hosts_update(values) -%}
 #!/bin/bash
-set -e
 config_file="/var/www/html/config/config.php"
 {# Reason for sed: https://github.com/nextcloud/server/issues/44924 #}
 echo "Updating database and redis host in config.php"
-sed -i "s/\('dbhost' => '\)[^']*postgres:5432',/\1{{ values.consts.postgres_container_name }}:5432',/" "$config_file"
-occ config:system:set redis host --value="{{ values.consts.redis_container_name }}"
+sed -i "s/\('dbhost' => '\)[^']*postgres:5432',/\1{{ values.consts.postgres_container_name }}:5432',/" "$config_file" || { echo "Failed to update database host. Exiting..."; exit 1; }
+occ config:system:set redis host --value="{{ values.consts.redis_container_name }}" || { echo "Failed to update redis host. Continuing..."; exit 0; }
 {%- endmacro -%}


### PR DESCRIPTION
When nextcloud fails to fully complete an upgrade, some occ commands are not available.
Lets not exit and let container start so use can manually complete the upgrade.

Closes https://github.com/truenas/apps/issues/1156