### PR TITLE
nextcloud: update trusted domains on start

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -66,4 +66,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/nextcloud
 title: Nextcloud
 train: stable
-version: 1.5.5
+version: 1.5.6

--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -99,7 +99,8 @@ questions:
             Examples: </br>
             cloud.domain.com:30001</br>
             cloud.domain.com (if you use port 443 externally)</br>
-            192.168.1.100:9001 (replace ip and port with your own)</br>
+            192.168.1.100:9001 (replace ip and port with your own)</br></br>
+            This will be appended to the trusted domains list, but changing that will not remove it from the list.</br>
           schema:
             type: string
             default: ""

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -1,4 +1,4 @@
-{% from "macros/nc.jinja.sh" import occ, hosts_update %}
+{% from "macros/nc.jinja.sh" import occ, hosts_update, trusted_domains_update %}
 {% from "macros/nc.jinja.conf" import opcache, php, limit_request_body, nginx_conf %}
 
 {% set tpl = ix_lib.base.render.Render(values) %}
@@ -130,6 +130,7 @@
 {% do nc_container.depends.add_dependency(values.consts.postgres_container_name, "service_healthy") %}
 {% do nc_container.depends.add_dependency(values.consts.redis_container_name, "service_healthy") %}
 {% do nc_container.configs.add("ix-update-hosts-script.sh", hosts_update(values), "/docker-entrypoint-hooks.d/before-starting/ix-update-hosts-script.sh", "0755") %}
+{% do nc_container.configs.add("ix-update-trusted-domains-script.sh", trusted_domains_update(), "/docker-entrypoint-hooks.d/before-starting/ix-update-trusted-domains-script.sh", "0755") %}
 {% for c in nc_confs %}
   {% do nc_container.configs.add(c[0], c[1], c[2], c[3]) %}
 {% endfor %}

--- a/ix-dev/stable/nextcloud/templates/macros/nc.jinja.sh
+++ b/ix-dev/stable/nextcloud/templates/macros/nc.jinja.sh
@@ -27,3 +27,45 @@ echo "Updating database and redis host in config.php"
 sed -i "s/\('dbhost' => '\)[^']*postgres:5432',/\1{{ values.consts.postgres_container_name }}:5432',/" "$config_file" || { echo "Failed to update database host. Exiting..."; exit 1; }
 occ config:system:set redis host --value="{{ values.consts.redis_container_name }}" || { echo "Failed to update redis host. Continuing..."; exit 0; }
 {%- endmacro -%}
+
+{% macro trusted_domains_update() -%}
+#!/bin/bash
+set_list() {
+  list_name="${1:?"list_name is unset"}"
+  space_delimited_values="${2:?"space_delimited_values is unset"}"
+
+  # Get current list
+  current_list="$(occ config:system:get "$list_name")"
+  # Convert newline separated values to space separated
+  current_list="$(echo "$current_list" | tr '\n' ' ')"
+  # Merge current list with new values
+  merged_list="$(echo "$current_list $space_delimited_values" | tr ' ' '\n' | xargs -I{} echo {})"
+  # Remove duplicate values
+  merged_list="$(echo "$merged_list" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
+
+  if [ -n "${merged_list}" ]; then
+    # Remove current list, so we can replace it with the new one
+    occ config:system:delete "$list_name" || return
+
+    IDX=0
+    # Replace spaces with newlines so the input can have
+    # mixed entries of space or new line separated values
+    echo "$merged_list" | tr ' ' '\n' | while IFS= read -r value; do
+        # Skip empty values
+        if [ -z "$value" ]; then
+          continue
+        fi
+
+        occ config:system:set "$list_name" $IDX --value="$value"
+
+        IDX=$((IDX+1))
+    done
+  fi
+}
+
+echo "Updating trusted domains. It will append new domains to the existing list."
+echo "If you see a domain that is not longer valid, you need to manually remove it from the list in the config.php file."
+
+set_list "trusted_domains" "${NEXTCLOUD_TRUSTED_DOMAINS}" || { echo "Failed to update trusted domains. Continuing..."; exit 0; }
+
+{%- endmacro -%}


### PR DESCRIPTION
Nextcloud ignores NEXTCLOUD_TRUSTED_DOMAINS after initial install.
This PR makes changes to update the trusted_domains key in the config.php file.

In order to not break custom domains added from user, we fetch existing domains, append the domains we set in the NEXTCLOUD_TRUSTED_DOMAINS, deduplicate and set the list of domains again.

While it will help a bit, it still might require manual changes on the config file if user wants to _remove_ a previous trusted domain that was added via the Host field from UI.