### PR TITLE
tailscale: correct tailscaled args env name

### DIFF
--- a/ix-dev/community/tailscale/app.yaml
+++ b/ix-dev/community/tailscale/app.yaml
@@ -42,4 +42,4 @@ sources:
 - https://hub.docker.com/r/tailscale/tailscale
 title: Tailscale
 train: community
-version: 1.2.5
+version: 1.2.6

--- a/ix-dev/community/tailscale/templates/docker-compose.yaml
+++ b/ix-dev/community/tailscale/templates/docker-compose.yaml
@@ -30,7 +30,7 @@
 {% do c1.environment.add_env("TS_AUTHKEY", values.tailscale.auth_key) %}
 {% do c1.environment.add_env("TS_SOCKET", "/var/run/tailscale/tailscaled.sock") %}
 {% if values.tailscale.tailscaled_args %}
-  {% do c1.environment.add_env("TS_EXTRA_ARGS", values.tailscale.tailscaled_args|unique|list|join(" ")) %}
+  {% do c1.environment.add_env("TS_TAILSCALED_EXTRA_ARGS", values.tailscale.tailscaled_args|unique|list|join(" ")) %}
 {% endif %}
 {% if values.tailscale.advertise_routes %}
   {% do c1.environment.add_env("TS_ROUTES", values.tailscale.advertise_routes|unique|list|join(",")) %}


### PR DESCRIPTION
as https://tailscale.com/kb/1282/docker#ts_tailscaled_extra_args say, we should pass tailscaled_args as env `TS_TAILSCALED_EXTRA_ARGS` instead of `TS_EXTRA_ARGS`