### PR TITLE
Set Lyrion Music Server to v9.0.2

### DIFF
--- a/ix-dev/community/lyrion-music-server/app.yaml
+++ b/ix-dev/community/lyrion-music-server/app.yaml
@@ -1,4 +1,4 @@
-app_version: 9.1.0
+app_version: 9.0.2
 capabilities:
 - description: LMS is able to chown files.
   name: CHOWN


### PR DESCRIPTION
Unfortunately, LMS pushes a version tag for the develop branch, even though it's not released.

This will make automated updating problematic.

Closes #1348