### PR TITLE
paperless: allow enabling js for gotenberg

### DIFF
--- a/ix-dev/community/paperless-ngx/app.yaml
+++ b/ix-dev/community/paperless-ngx/app.yaml
@@ -67,4 +67,4 @@ sources:
 - https://github.com/paperless-ngx/paperless-ngx
 title: Paperless-ngx
 train: community
-version: 1.2.15
+version: 1.2.16

--- a/ix-dev/community/paperless-ngx/app.yaml
+++ b/ix-dev/community/paperless-ngx/app.yaml
@@ -67,4 +67,4 @@ sources:
 - https://github.com/paperless-ngx/paperless-ngx
 title: Paperless-ngx
 train: community
-version: 1.2.14
+version: 1.2.15

--- a/ix-dev/community/paperless-ngx/questions.yaml
+++ b/ix-dev/community/paperless-ngx/questions.yaml
@@ -118,6 +118,15 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: gotenberg_chromium_disable_javascript
+          label: Gotenberg Chromium Disable Javascript
+          description: |
+            Disable Javascript in Chromium.</br>
+            When enabled, Gotenberg will not execute Javascript in Chromium.
+          schema:
+            show_if: [["enable_tika_gotenberg", "=", true]]
+            type: boolean
+            default: true
         - variable: additional_envs
           label: Additional Environment Variables
           description: Configure additional environment variables for Paperless-ngx.

--- a/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
+++ b/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
@@ -88,8 +88,10 @@
   {% set gotenberg_container = tpl.add_container(values.consts.gotenberg_container_name, "gotenberg_image") %}
   {% do gotenberg_container.set_user(values.consts.gotenberg_run_user, values.consts.gotenberg_run_user) %}
   {% do gotenberg_container.set_command([
-    "gotenberg", "--api-port=%d"|format(values.consts.gotenberg_port),
-    "--chromium-disable-javascript=true", "--chromium-allow-list=file:///tmp/.*"
+    "gotenberg",
+    "--api-port=%d"|format(values.consts.gotenberg_port),
+    "--chromium-disable-javascript=%s"|format(values.paperless.gotenberg_chromium_disable_javascript|string|lower),
+    "--chromium-allow-list=file:///tmp/.*",
   ]) %}
   {% do gotenberg_container.healthcheck.set_test("curl", {"port": values.consts.gotenberg_port, "path":"/health"}) %}
 

--- a/ix-dev/community/paperless-ngx/templates/test_values/tika-gotenberg-values.yaml
+++ b/ix-dev/community/paperless-ngx/templates/test_values/tika-gotenberg-values.yaml
@@ -15,6 +15,7 @@ paperless:
   admin_password: admin-password
   enable_trash: false
   enable_tika_gotenberg: true
+  gotenberg_chromium_disable_javascript: false
   additional_envs: []
 
 network:


### PR DESCRIPTION
Fixes #1357 