### PR TITLE
ci: run dev app validation on contributors as well

### DIFF
--- a/.github/workflows/dev_apps_validate.yml
+++ b/.github/workflows/dev_apps_validate.yml
@@ -2,6 +2,7 @@ name: dev_catalog_validation
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This workflow wasn't running for outside contributors. As the push event was happening on their fork.
