### PR TITLE
calibre-web: switch upstreams

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -84,7 +84,12 @@ module.exports = {
       // We still limit major to 1 digit, as we don't want to match "24.08.0" as a major version
       // This is something that we need to investigate if one of the images start having 2 digit major versions
       "^(?<major>\\d{1})\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      ["linuxserver/deluge", "linuxserver/diskover", "linuxserver/transmission"]
+      [
+        "linuxserver/deluge",
+        "linuxserver/diskover",
+        "linuxserver/transmission",
+        "linuxserver/calibre-web",
+      ]
     ),
     customVersioning(
       // v0.8.1-omnibus

--- a/ix-dev/community/calibre-web/app.yaml
+++ b/ix-dev/community/calibre-web/app.yaml
@@ -1,33 +1,44 @@
-app_version: 0.6.22
-capabilities: []
+app_version: 0.6.24
+capabilities:
+- description: Calibre Web is able to chown files.
+  name: CHOWN
+- description: Calibre Web is able to bypass permission checks.
+  name: DAC_OVERRIDE
+- description: Calibre Web is able bypass permission checks for it's sub-processes.
+  name: FOWNER
+- description: Calibre Web is able to set group ID for it's sub-processes.
+  name: SETGID
+- description: Calibre Web is able to set user ID for it's sub-processes.
+  name: SETUID
 categories:
-- media
-description: Calibre Web is a web app for browsing, reading and downloading eBooks
+  - media
+description:
+  Calibre Web is a web app for browsing, reading and downloading eBooks
   stored in a Calibre database
 home: https://github.com/janeczku/calibre-web
 host_mounts: []
 icon: https://media.sys.truenas.net/apps/calibre-web/icons/icon.svg
 keywords:
-- media
-- ebooks
+  - media
+  - ebooks
 lib_version: 2.1.9
 lib_version_hash: 6bd4d433db7dce2d4b8cc456a0f7874b45d52a6e2b145d5a1f48f327654a7125
 maintainers:
-- email: dev@ixsystems.com
-  name: truenas
-  url: https://www.truenas.com/
+  - email: dev@ixsystems.com
+    name: truenas
+    url: https://www.truenas.com/
 name: calibre-web
 run_as_context:
-- description: Calibre Web runs as any non-root user.
-  gid: 568
-  group_name: calibre-web
-  uid: 568
-  user_name: calibre-web
+  - description: Calibre Web runs as root user.
+    gid: 0
+    group_name: root
+    uid: 0
+    user_name: root
 screenshots:
-- https://media.sys.truenas.net/apps/calibre-web/screenshots/screenshot1.png
+  - https://media.sys.truenas.net/apps/calibre-web/screenshots/screenshot1.png
 sources:
-- https://github.com/elfhosted/containers/tree/main/apps/calibre-web
-- https://github.com/janeczku/calibre-web
+  - https://hub.docker.com/r/linuxserver/calibre-web
+  - https://github.com/janeczku/calibre-web
 title: Calibre Web
 train: community
-version: 1.0.9
+version: 2.0.0

--- a/ix-dev/community/calibre-web/ix_values.yaml
+++ b/ix-dev/community/calibre-web/ix_values.yaml
@@ -1,11 +1,10 @@
 images:
   image:
-    repository: ghcr.io/elfhosted/calibre-web
-    tag: 0.6.22
+    repository: linuxserver/calibre-web
+    tag: 0.6.24
 
 consts:
   calibre_web_container_name: calibre-web
-  perms_container_name: permissions
   internal_web_port: 8083
   notes_body: |
     Default credentials:

--- a/ix-dev/community/calibre-web/questions.yaml
+++ b/ix-dev/community/calibre-web/questions.yaml
@@ -82,14 +82,37 @@ questions:
       attrs:
         - variable: web_port
           label: WebUI Port
-          description: The port for Calibre Web WebUI
           schema:
-            type: int
-            default: 31067
-            show_if: [["host_network", "=", false]]
-            required: true
-            $ref:
-              - definitions/port
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  show_if: [["bind_mode", "==", "exposed"]]
+                  default: 31067
+                  required: true
+                  $ref:
+                    - definitions/port
         - variable: host_network
           label: Host Network
           description: |
@@ -148,6 +171,84 @@ questions:
                         immutable: true
                         hidden: true
                         default: "config"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: books
+          label: Calibre Web Books Storage
+          description: The path to store Calibre Web Books.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  immutable: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "books"
                     - variable: acl_entries
                       label: ACL Configuration
                       schema:

--- a/ix-dev/community/calibre-web/questions.yaml
+++ b/ix-dev/community/calibre-web/questions.yaml
@@ -108,7 +108,7 @@ questions:
                 label: Port Number
                 schema:
                   type: int
-                  show_if: [["bind_mode", "==", "exposed"]]
+                  show_if: [["bind_mode", "=", "exposed"]]
                   default: 31067
                   required: true
                   $ref:

--- a/ix-dev/community/calibre-web/templates/docker-compose.yaml
+++ b/ix-dev/community/calibre-web/templates/docker-compose.yaml
@@ -1,31 +1,21 @@
 {% set tpl = ix_lib.base.render.Render(values) %}
 
 {% set c1 = tpl.add_container(values.consts.calibre_web_container_name, "image") %}
-{% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
-{% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
 
-{% do c1.set_user(values.run_as.user, values.run_as.group) %}
+{% do c1.add_caps(["CHOWN", "SETGID", "SETUID", "DAC_OVERRIDE", "FOWNER"]) %}
 {% do c1.healthcheck.set_test("curl", {"port": values.consts.internal_web_port, "path": "/static/css/upload.css"}) %}
-{# CALIBRE_PORT is used ONLY on the first run #}
-{% do c1.environment.add_env("CALIBRE_PORT", values.consts.internal_web_port) %}
 {% do c1.environment.add_user_envs(values.calibre_web.additional_envs) %}
 
-{% do c1.ports.add_port(values.network.web_port, values.consts.internal_web_port) %}
+{% do c1.add_port(values.network.web_port, {"container_port": values.consts.internal_web_port}) %}
 
 {% do c1.add_storage("/config", values.storage.config) %}
-{% do perm_container.add_or_skip_action("config", values.storage.config, perms_config) %}
+{% do c1.add_storage("/books", values.storage.books) %}
 
 {% for store in values.storage.additional_storage %}
   {% do c1.add_storage(store.mount_path, store) %}
-  {% do perm_container.add_or_skip_action(store.mount_path, store, perms_config) %}
 {% endfor %}
 
-{% if perm_container.has_actions() %}
-  {% do perm_container.activate() %}
-  {% do c1.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
-{% endif %}
-
-{% do tpl.portals.add_portal({"port": values.consts.internal_web_port if values.network.host_network else values.network.web_port, "protocol": "http"}) %}
+{% do tpl.portals.add_portal({"port": values.consts.internal_web_port if values.network.host_network else values.network.web_port.port_number, "protocol": "http"}) %}
 {% do tpl.notes.set_body(values.consts.notes_body) %}
 
 {{ tpl.render() | tojson }}

--- a/ix-dev/community/calibre-web/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/calibre-web/templates/test_values/basic-values.yaml
@@ -8,7 +8,9 @@ calibre_web:
 
 network:
   host_network: false
-  web_port: 8080
+  web_port:
+    bind_mode: published
+    port_number: 8080
 
 run_as:
   user: 568
@@ -16,11 +18,17 @@ run_as:
 
 ix_volumes:
   config: /opt/tests/mnt/config
+  books: /opt/tests/mnt/books
 
 storage:
   config:
     type: ix_volume
     ix_volume_config:
       dataset_name: config
+      create_host_path: true
+  books:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: books
       create_host_path: true
   additional_storage: []


### PR DESCRIPTION
Fixes https://github.com/truenas/apps/issues/1133

Previous upstream removed support for calibre-web, so bug wont be fixed nor updates would flow through.

This is a breaking change, hence the major version bump.