### PR TITLE
paperless-ngx: use encoded url and allow changing the allow-list for chromium/gotenberg

### DIFF
--- a/ix-dev/community/paperless-ngx/app.yaml
+++ b/ix-dev/community/paperless-ngx/app.yaml
@@ -67,4 +67,4 @@ sources:
 - https://github.com/paperless-ngx/paperless-ngx
 title: Paperless-ngx
 train: community
-version: 1.2.16
+version: 1.2.17

--- a/ix-dev/community/paperless-ngx/questions.yaml
+++ b/ix-dev/community/paperless-ngx/questions.yaml
@@ -127,6 +127,15 @@ questions:
             show_if: [["enable_tika_gotenberg", "=", true]]
             type: boolean
             default: true
+        - variable: gotenberg_chromium_allow_list_regex
+          label: Gotenberg Chromium Allow List Regex
+          description: |
+            Allow List of URLs that Gotenberg will allow to be rendered.</br>
+            When empty, Gotenberg will allow all URLs to be rendered.
+          schema:
+            show_if: [["enable_tika_gotenberg", "=", true]]
+            type: string
+            default: "^file:///tmp/.*"
         - variable: additional_envs
           label: Additional Environment Variables
           description: Configure additional environment variables for Paperless-ngx.

--- a/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
+++ b/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
@@ -47,7 +47,7 @@
 {% do paperless_container.environment.add_env("PAPERLESS_DBNAME", values.consts.db_name) %}
 {% do paperless_container.environment.add_env("PAPERLESS_DBUSER", values.consts.db_user) %}
 {% do paperless_container.environment.add_env("PAPERLESS_DBPASS", values.paperless.db_password) %}
-{% do paperless_container.environment.add_env("PAPERLESS_REDIS", "redis://default:%s@%s:6379" | format(values.paperless.redis_password, values.consts.redis_container_name)) %}
+{% do paperless_container.environment.add_env("PAPERLESS_REDIS", redis.get_url("redis")) %}
 
 {% do paperless_container.environment.add_user_envs(values.paperless.additional_envs) %}
 

--- a/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
+++ b/ix-dev/community/paperless-ngx/templates/docker-compose.yaml
@@ -91,7 +91,7 @@
     "gotenberg",
     "--api-port=%d"|format(values.consts.gotenberg_port),
     "--chromium-disable-javascript=%s"|format(values.paperless.gotenberg_chromium_disable_javascript|string|lower),
-    "--chromium-allow-list=file:///tmp/.*",
+    "--chromium-allow-list=%s"|format(values.paperless.gotenberg_chromium_allow_list_regex or '""'),
   ]) %}
   {% do gotenberg_container.healthcheck.set_test("curl", {"port": values.consts.gotenberg_port, "path":"/health"}) %}
 

--- a/ix-dev/community/paperless-ngx/templates/test_values/tika-gotenberg-values.yaml
+++ b/ix-dev/community/paperless-ngx/templates/test_values/tika-gotenberg-values.yaml
@@ -16,6 +16,7 @@ paperless:
   enable_trash: false
   enable_tika_gotenberg: true
   gotenberg_chromium_disable_javascript: false
+  gotenberg_chromium_allow_list_regex: ""
   additional_envs: []
 
 network:


### PR DESCRIPTION
Fixes #1426