### PR TITLE
minio: add option to set host ip

### DIFF
--- a/ix-dev/stable/minio/questions.yaml
+++ b/ix-dev/stable/minio/questions.yaml
@@ -106,6 +106,15 @@ questions:
     schema:
       type: dict
       attrs:
+        - variable: api_ip
+          label: API IP
+          description: The IP for the MinIO API.
+          schema:
+            type: string
+            default: 0.0.0.0
+            required: true
+            $ref:
+              - definitions/ip
         - variable: api_port
           label: API Port
           description: The port for the MinIO API.
@@ -115,6 +124,15 @@ questions:
             required: true
             $ref:
               - definitions/port
+        - variable: console_ip
+          label: Console IP (Web UI)
+          description: The IP for the MinIO web UI.
+          schema:
+            type: string
+            default: 0.0.0.0
+            required: true
+            $ref:
+              - definitions/ip
         - variable: console_port
           label: Console Port (Web UI)
           description: The port for the MinIO Web UI.

--- a/ix-dev/stable/minio/templates/docker-compose.yaml
+++ b/ix-dev/stable/minio/templates/docker-compose.yaml
@@ -69,8 +69,8 @@
 {% endfor %}
 {% do c1.environment.add_user_envs(values.minio.additional_envs) %}
 
-{% do c1.ports.add_port(values.network.console_port, values.network.console_port) %}
-{% do c1.ports.add_port(values.network.api_port, values.network.api_port) %}
+{% do c1.ports.add_port(values.network.console_port, values.network.console_port, {"host_ip": values.network.console_ip}) %}
+{% do c1.ports.add_port(values.network.api_port, values.network.api_port, {"host_ip": values.network.api_ip}) %}
 
 
 {% if perm_container.has_actions() %}

--- a/ix-dev/stable/minio/templates/test_values/basic-values.yaml
+++ b/ix-dev/stable/minio/templates/test_values/basic-values.yaml
@@ -14,7 +14,9 @@ run_as:
   group: 568
 
 network:
+  api_ip: 127.0.0.1
   api_port: 9000
+  console_ip: 127.0.0.1
   console_port: 9001
   certificate_id: null
   domain: ''

--- a/ix-dev/stable/minio/templates/test_values/https-values.yaml
+++ b/ix-dev/stable/minio/templates/test_values/https-values.yaml
@@ -14,7 +14,9 @@ run_as:
   group: 568
 
 network:
+  api_ip: 127.0.0.1
   api_port: 9000
+  console_ip: 127.0.0.1
   console_port: 9001
   certificate_id: "1"
   domain: ''


### PR DESCRIPTION
This PR adds options to Minio to let users configure on which IP the app should be listening on the host.

#### known issues

This doesn't let you bind to ports that are already in use (even if they are listening on a completely different ip).
So if the Truenas webui is listening on `192.168.1.1:443` you're not able to let Minio listen on port `443` on for example `192.168.1.2`. This issue seems to be related [this line](https://github.com/truenas/middleware/blob/1b71ee8eb2df72dd97609ad1db584cc8c1f29215/src/middlewared/middlewared/plugins/apps/schema_validation.py#L137) in the [truenas/middleware](https://github.com/truenas/middleware) apps schema validator