### PR TITLE
esphome: set two platformio env vars to allow esphome to run as non-root

### DIFF
--- a/ix-dev/community/esphome/app.yaml
+++ b/ix-dev/community/esphome/app.yaml
@@ -27,4 +27,4 @@ sources:
 - https://github.com/esphome/esphome
 title: ESPHome
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/esphome/ix_values.yaml
+++ b/ix-dev/community/esphome/ix_values.yaml
@@ -7,3 +7,5 @@ consts:
   esphome_container_name: esphome
   perms_container_name: permissions
   config_path: /config
+  pio_path: /config/.esphome/.platformio
+  pio_globallib_path: /config/.esphome/piolibs

--- a/ix-dev/community/esphome/templates/docker-compose.yaml
+++ b/ix-dev/community/esphome/templates/docker-compose.yaml
@@ -10,6 +10,8 @@
 {% do c1.set_command(["dashboard", values.consts.config_path, "--port", values.network.web_port.port_number]) %}
 
 {% do c1.environment.add_env("ESPHOME_DASHBOARD_USE_PING", true) %}
+{% do c1.environment.add_env("PLATFORMIO_CORE_DIR", values.consts.pio_path) %}
+{% do c1.environment.add_env("PLATFORMIO_GLOBALLIB_DIR", values.consts.pio_globallib_path) %}
 {% do c1.environment.add_user_envs(values.esphome.additional_envs) %}
 
 {% do c1.add_port(values.network.web_port) %}
@@ -34,7 +36,6 @@
   {% do perm_container.activate() %}
   {% do c1.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
 {% endif %}
-
 
 {% do tpl.portals.add_portal({"port": values.network.web_port.port_number}) %}
 

--- a/ix-dev/community/esphome/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/esphome/templates/test_values/basic-values.yaml
@@ -28,4 +28,3 @@ storage:
       dataset_name: config
       create_host_path: true
   additional_storage: []
-  

--- a/ix-dev/community/esphome/templates/test_values/root-user.yaml
+++ b/ix-dev/community/esphome/templates/test_values/root-user.yaml
@@ -15,8 +15,8 @@ network:
     port_number: 36502
 
 run_as:
-  user: 568
-  group: 568
+  user: 0
+  group: 0
 
 ix_volumes:
   config: /opt/tests/mnt/config
@@ -28,4 +28,3 @@ storage:
       dataset_name: config
       create_host_path: true
   additional_storage: []
-  


### PR DESCRIPTION
ive tested compiling several device types with these settings. It would be a bit more clean if we could override permissions on /piolibs in the container. The platformio builds fail because they cant read that folder. When i set the env var PLATFORMIO_GLOBALLIB_DIR to any other dir, builds work. I assume it doesnt find that local cache in the container and downloads a new copy.

This is working though. I added a new test case for running as root (which also worked). If there is a way to force uid 568 on /piolibs im happy to update the PR.