### PR TITLE
sftpgo: disable sftp if non are defined

### DIFF
--- a/ix-dev/community/sftpgo/app.yaml
+++ b/ix-dev/community/sftpgo/app.yaml
@@ -28,4 +28,4 @@ sources:
 - https://github.com/drakkan/sftpgo
 title: SFTPGo
 train: community
-version: 1.1.6
+version: 1.1.7

--- a/ix-dev/community/sftpgo/templates/docker-compose.yaml
+++ b/ix-dev/community/sftpgo/templates/docker-compose.yaml
@@ -42,6 +42,8 @@
   {% do c1.ports.add_port(svc.port, svc.port) %}
   {% do c1.environment.add_env("SFTPGO_SFTPD__BINDINGS__%d__PORT"|format(loop.index0), svc.port) %}
   {% do c1.environment.add_env("SFTPGO_SFTPD__BINDINGS__%d__ADDRESS"|format(loop.index0), "") %}
+{% else %}
+  {% do c1.environment.add_env("SFTPGO_SFTPD__BINDINGS__0__PORT", 0) %}
 {% endfor %}
 
 {% for svc in values.network.ftpd_services if svc.enabled %}

--- a/ix-dev/community/sftpgo/templates/test_values/nosftp-values.yaml
+++ b/ix-dev/community/sftpgo/templates/test_values/nosftp-values.yaml
@@ -1,0 +1,53 @@
+resources:
+  limits:
+    cpus: 2.0
+    memory: 4096
+
+sftpgo:
+  image_selector: image
+  stop_grace_period: 60
+  additional_envs: []
+
+network:
+  host_network: false
+  web_port: 8080
+  certificate_id:
+  webdavd_services:
+    - enabled: true
+      port: 2022
+  sftpd_services: []
+  ftpd_services:
+    - enabled: true
+      port: 2024
+    - enabled: true
+      port: 2025
+  ftpd_passive_port_range:
+    start: 50000
+    end: 50010
+
+run_as:
+  user: 568
+  group: 568
+
+ix_volumes:
+  config: /opt/tests/mnt/config
+  data: /opt/tests/mnt/data
+  backups: /opt/tests/mnt/backups
+
+storage:
+  config:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: config
+      create_host_path: true
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: data
+      create_host_path: true
+  backups:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: backups
+      create_host_path: true
+  additional_storage: []


### PR DESCRIPTION
Disables the default sftp configuration as there is already a list to define additional sftp configurations in the UI form