### PR TITLE
apps: allow selecting host-ip for ports with new config format

### DIFF
--- a/ix-dev/community/adguard-home/app.yaml
+++ b/ix-dev/community/adguard-home/app.yaml
@@ -42,4 +42,4 @@ sources:
 - https://hub.docker.com/r/adguard/adguardhome
 title: AdGuard Home
 train: community
-version: 1.1.13
+version: 1.1.14

--- a/ix-dev/community/adguard-home/questions.yaml
+++ b/ix-dev/community/adguard-home/questions.yaml
@@ -152,6 +152,20 @@ questions:
                             description: TCP
                           - value: "udp"
                             description: UDP
+                    - variable: host_ips
+                      label: Host IPs
+                      description: IPs on the host to bind this port
+                      schema:
+                        type: list
+                        default: []
+                        items:
+                          - variable: host_ip
+                            label: Host IP
+                            schema:
+                              type: string
+                              required: true
+                              $ref:
+                                - definitions/node_bind_ip
 
   - variable: storage
     label: ""

--- a/ix-dev/community/calibre-web/app.yaml
+++ b/ix-dev/community/calibre-web/app.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/janeczku/calibre-web
 title: Calibre Web
 train: community
-version: 2.0.2
+version: 2.0.3

--- a/ix-dev/community/calibre-web/questions.yaml
+++ b/ix-dev/community/calibre-web/questions.yaml
@@ -114,6 +114,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/esphome/app.yaml
+++ b/ix-dev/community/esphome/app.yaml
@@ -27,4 +27,4 @@ sources:
 - https://github.com/esphome/esphome
 title: ESPHome
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/esphome/questions.yaml
+++ b/ix-dev/community/esphome/questions.yaml
@@ -135,6 +135,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: additional_ports
           label: Additional Ports
           schema:
@@ -185,6 +199,20 @@ questions:
                             description: TCP
                           - value: "udp"
                             description: UDP
+                    - variable: host_ips
+                      label: Host IPs
+                      description: IPs on the host to bind this port
+                      schema:
+                        type: list
+                        default: []
+                        items:
+                          - variable: host_ip
+                            label: Host IP
+                            schema:
+                              type: string
+                              required: true
+                              $ref:
+                                - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/handbrake-web/app.yaml
+++ b/ix-dev/community/handbrake-web/app.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/TheNickOfTime/handbrake-web
 title: Handbrake Web
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/handbrake-web/questions.yaml
+++ b/ix-dev/community/handbrake-web/questions.yaml
@@ -112,6 +112,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
   - variable: storage
     label: ""
     group: Storage Configuration

--- a/ix-dev/community/homarr/app.yaml
+++ b/ix-dev/community/homarr/app.yaml
@@ -43,4 +43,4 @@ sources:
 - ghcr.io/homarr-labs/homarr
 title: Homarr
 train: community
-version: 2.0.4
+version: 2.0.5

--- a/ix-dev/community/homarr/questions.yaml
+++ b/ix-dev/community/homarr/questions.yaml
@@ -134,6 +134,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/invoice-ninja/app.yaml
+++ b/ix-dev/community/invoice-ninja/app.yaml
@@ -63,4 +63,4 @@ sources:
 - https://github.com/invoiceninja/dockerfiles
 title: Invoice Ninja
 train: community
-version: 1.0.12
+version: 1.0.13

--- a/ix-dev/community/invoice-ninja/questions.yaml
+++ b/ix-dev/community/invoice-ninja/questions.yaml
@@ -140,6 +140,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
 
   - variable: storage
     label: ""

--- a/ix-dev/community/it-tools/app.yaml
+++ b/ix-dev/community/it-tools/app.yaml
@@ -38,4 +38,4 @@ sources:
 - https://github.com/CorentinTh/it-tools/
 title: IT Tools
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/it-tools/questions.yaml
+++ b/ix-dev/community/it-tools/questions.yaml
@@ -88,6 +88,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/jelu/app.yaml
+++ b/ix-dev/community/jelu/app.yaml
@@ -30,4 +30,4 @@ sources:
 - https://hub.docker.com/repository/docker/wabayang/jelu
 title: Jelu
 train: community
-version: 1.0.7
+version: 1.0.8

--- a/ix-dev/community/jelu/questions.yaml
+++ b/ix-dev/community/jelu/questions.yaml
@@ -89,6 +89,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
   - variable: storage
     label: ""
     group: Storage Configuration

--- a/ix-dev/community/lyrion-music-server/app.yaml
+++ b/ix-dev/community/lyrion-music-server/app.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/lms-community/slimserver
 title: Lyrion Music Server
 train: community
-version: 1.0.4
+version: 1.0.5

--- a/ix-dev/community/lyrion-music-server/questions.yaml
+++ b/ix-dev/community/lyrion-music-server/questions.yaml
@@ -114,7 +114,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
-
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: cli_port
           label: CLI port
           schema:
@@ -149,6 +162,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: discovery_port
           label: Discovery Port
           schema:
@@ -184,7 +211,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
-
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
   - variable: storage
     label: ""
     group: Storage Configuration

--- a/ix-dev/community/minecraft-bedrock/app.yaml
+++ b/ix-dev/community/minecraft-bedrock/app.yaml
@@ -28,4 +28,4 @@ sources:
 - https://github.com/itzg/docker-minecraft-bedrock-server
 title: Minecraft Bedrock
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/minecraft-bedrock/questions.yaml
+++ b/ix-dev/community/minecraft-bedrock/questions.yaml
@@ -288,6 +288,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/portainer/app.yaml
+++ b/ix-dev/community/portainer/app.yaml
@@ -49,4 +49,4 @@ sources:
 - https://github.com/portainer/portainer
 title: Portainer
 train: community
-version: 1.3.13
+version: 1.3.14

--- a/ix-dev/community/portainer/questions.yaml
+++ b/ix-dev/community/portainer/questions.yaml
@@ -125,6 +125,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: certificate_id
           label: Certificate
           description: The certificate to use for Portainer.

--- a/ix-dev/community/romm/app.yaml
+++ b/ix-dev/community/romm/app.yaml
@@ -33,4 +33,4 @@ sources:
 - https://github.com/rommapp/romm
 title: Romm
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/romm/questions.yaml
+++ b/ix-dev/community/romm/questions.yaml
@@ -183,6 +183,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
   - variable: storage
     label: ""
     group: Storage Configuration

--- a/ix-dev/community/satisfactory-server/app.yaml
+++ b/ix-dev/community/satisfactory-server/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://github.com/wolveix/satisfactory-server
 title: Satisfactory Server
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/satisfactory-server/questions.yaml
+++ b/ix-dev/community/satisfactory-server/questions.yaml
@@ -113,6 +113,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/steam-headless/app.yaml
+++ b/ix-dev/community/steam-headless/app.yaml
@@ -58,4 +58,4 @@ sources:
 - https://github.com/Steam-Headless/docker-steam-headless
 title: Steam Headless
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/steam-headless/questions.yaml
+++ b/ix-dev/community/steam-headless/questions.yaml
@@ -217,6 +217,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: Bind to the host network.

--- a/ix-dev/community/terraria/app.yaml
+++ b/ix-dev/community/terraria/app.yaml
@@ -32,4 +32,4 @@ sources:
 - https://github.com/ryansheehan/terraria
 title: Terraria
 train: community
-version: 1.1.7
+version: 1.1.8

--- a/ix-dev/community/terraria/questions.yaml
+++ b/ix-dev/community/terraria/questions.yaml
@@ -235,6 +235,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/tianji/app.yaml
+++ b/ix-dev/community/tianji/app.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/msgbyte/tianji
 title: Tianji
 train: community
-version: 1.0.3
+version: 1.0.4

--- a/ix-dev/community/tianji/questions.yaml
+++ b/ix-dev/community/tianji/questions.yaml
@@ -126,7 +126,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
-
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
   - variable: storage
     label: ""
     group: Storage Configuration

--- a/ix-dev/community/umami/app.yaml
+++ b/ix-dev/community/umami/app.yaml
@@ -33,4 +33,4 @@ sources:
 - https://github.com/umami-software/umami
 title: Umami
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/umami/questions.yaml
+++ b/ix-dev/community/umami/questions.yaml
@@ -120,7 +120,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
-
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
   - variable: storage
     label: ""
     group: Storage Configuration

--- a/ix-dev/community/urbackup/app.yaml
+++ b/ix-dev/community/urbackup/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://hub.docker.com/r/uroni/urbackup-server
 title: UrBackup
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/urbackup/questions.yaml
+++ b/ix-dev/community/urbackup/questions.yaml
@@ -113,6 +113,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: backup_port_1
           label: Backup Port 1
           schema:
@@ -147,6 +161,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: backup_port_2
           label: Backup Port 2
           schema:
@@ -181,6 +209,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: backup_port_3
           label: Backup Port 3
           schema:
@@ -215,6 +257,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/zigbee2mqtt/app.yaml
+++ b/ix-dev/community/zigbee2mqtt/app.yaml
@@ -31,4 +31,4 @@ sources:
 - https://github.com/Koenkk/zigbee2mqtt
 title: Zigbee2MQTT
 train: community
-version: 1.0.4
+version: 1.0.5

--- a/ix-dev/community/zigbee2mqtt/questions.yaml
+++ b/ix-dev/community/zigbee2mqtt/questions.yaml
@@ -178,6 +178,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/stable/emby/app.yaml
+++ b/ix-dev/stable/emby/app.yaml
@@ -49,4 +49,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/emby
 title: Emby Server
 train: stable
-version: 1.2.13
+version: 1.2.14

--- a/ix-dev/stable/emby/questions.yaml
+++ b/ix-dev/stable/emby/questions.yaml
@@ -121,6 +121,20 @@ questions:
                   required: true
                   $ref:
                     - definitions/port
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |


### PR DESCRIPTION
New apps and new ports on existing apps that added using the new config format, can now select ip to bind that port.
When 25.04 is released, migrations for existing apps/ports will follow. 

Host IP features will also work on 24.10 as well.
For the apps/ports that need migration (that will come later), 25.04 will be **required**

Relates to https://github.com/truenas/apps/issues/787, but not fully completes it yet.