### PR TITLE
palworld: fix config initialization

### DIFF
--- a/ix-dev/community/palworld/app.yaml
+++ b/ix-dev/community/palworld/app.yaml
@@ -47,4 +47,4 @@ sources:
 - https://github.com/ich777/docker-steamcmd-server/tree/palworld
 title: Palworld
 train: community
-version: 1.1.9
+version: 1.1.10

--- a/ix-dev/community/palworld/templates/docker-compose.yaml
+++ b/ix-dev/community/palworld/templates/docker-compose.yaml
@@ -57,6 +57,7 @@
 
 {% do c1.add_storage(values.consts.steamcmd_path, values.storage.steamcmd) %}
 {% do c1.add_storage(values.consts.server_path, values.storage.server) %}
+{% do init.add_storage(values.consts.server_path, values.storage.server) %}
 {% for store in values.storage.additional_storage %}
   {% do c1.add_storage(store.mount_path, store) %}
 {% endfor %}


### PR DESCRIPTION
The config storage wasn't shared with the init container, which resulted that init container was only modifying a throw-away file.

Fixes #1527 