### PR TITLE
zigbee: revert schema type

### DIFF
--- a/ix-dev/community/zigbee2mqtt/app.yaml
+++ b/ix-dev/community/zigbee2mqtt/app.yaml
@@ -31,4 +31,4 @@ sources:
 - https://github.com/Koenkk/zigbee2mqtt
 title: Zigbee2MQTT
 train: community
-version: 1.0.9
+version: 1.0.10

--- a/ix-dev/community/zigbee2mqtt/questions.yaml
+++ b/ix-dev/community/zigbee2mqtt/questions.yaml
@@ -46,7 +46,7 @@ questions:
                   The MQTT server to use for Zigbee2MQTT.</br>
                   Example: mqtt://server.ip:1883
                 schema:
-                  type: uri
+                  type: string
                   required: true
               - variable: user
                 label: User


### PR DESCRIPTION
Looks like URI does not accept mqtt as scheme.
