### PR TITLE
plex: set mode for tmpfs

### DIFF
--- a/ix-dev/stable/plex/app.yaml
+++ b/ix-dev/stable/plex/app.yaml
@@ -48,4 +48,4 @@ sources:
 - https://hub.docker.com/r/plexinc/pms-docker
 title: Plex
 train: stable
-version: 1.1.14
+version: 1.1.15

--- a/ix-dev/stable/plex/templates/docker-compose.yaml
+++ b/ix-dev/stable/plex/templates/docker-compose.yaml
@@ -18,12 +18,12 @@
 {% do c1.add_storage("/config", values.storage.config) %}
 {% do perm_container.add_or_skip_action("config", values.storage.config, perm_config) %}
 
-{% set static_log_options = {"volume_config": {"volume_name": "plex-logs", "mode": "0775"}} %}
+{% set static_log_options = {"volume_config": {"volume_name": "plex-logs"}, "tmpfs_config": {"mode": "0775"}} %}
 {% set logs_storage = dict(values.storage.logs, **static_log_options) %}
 {% do c1.add_storage("/config/Library/Application Support/Plex Media Server/Logs", logs_storage) %}
 {% do perm_container.add_or_skip_action("logs", logs_storage, perm_config) %}
 
-{% set static_transcode_options = {"volume_config": {"volume_name": "plex-transcodes", "mode": "0775"}} %}
+{% set static_transcode_options = {"volume_config": {"volume_name": "plex-transcodes"}, "tmpfs_config": {"mode": "0775"}} %}
 {% set transcodes_storage = dict(values.storage.transcode, **static_transcode_options) %}
 {% do c1.add_storage("/transcode", transcodes_storage) %}
 {% do perm_container.add_or_skip_action("transcode", transcodes_storage, perm_config) %}

--- a/ix-dev/stable/plex/templates/docker-compose.yaml
+++ b/ix-dev/stable/plex/templates/docker-compose.yaml
@@ -18,12 +18,12 @@
 {% do c1.add_storage("/config", values.storage.config) %}
 {% do perm_container.add_or_skip_action("config", values.storage.config, perm_config) %}
 
-{% set static_log_options = {"volume_config": {"volume_name": "plex-logs", "mode": "0777"}} %}
+{% set static_log_options = {"volume_config": {"volume_name": "plex-logs", "mode": "0775"}} %}
 {% set logs_storage = dict(values.storage.logs, **static_log_options) %}
 {% do c1.add_storage("/config/Library/Application Support/Plex Media Server/Logs", logs_storage) %}
 {% do perm_container.add_or_skip_action("logs", logs_storage, perm_config) %}
 
-{% set static_transcode_options = {"volume_config": {"volume_name": "plex-transcodes", "mode": "0777"}} %}
+{% set static_transcode_options = {"volume_config": {"volume_name": "plex-transcodes", "mode": "0775"}} %}
 {% set transcodes_storage = dict(values.storage.transcode, **static_transcode_options) %}
 {% do c1.add_storage("/transcode", transcodes_storage) %}
 {% do perm_container.add_or_skip_action("transcode", transcodes_storage, perm_config) %}

--- a/ix-dev/stable/plex/templates/docker-compose.yaml
+++ b/ix-dev/stable/plex/templates/docker-compose.yaml
@@ -18,12 +18,12 @@
 {% do c1.add_storage("/config", values.storage.config) %}
 {% do perm_container.add_or_skip_action("config", values.storage.config, perm_config) %}
 
-{% set static_log_options = {"volume_config": {"volume_name": "plex-logs"}} %}
+{% set static_log_options = {"volume_config": {"volume_name": "plex-logs", "mode": "0777"}} %}
 {% set logs_storage = dict(values.storage.logs, **static_log_options) %}
 {% do c1.add_storage("/config/Library/Application Support/Plex Media Server/Logs", logs_storage) %}
 {% do perm_container.add_or_skip_action("logs", logs_storage, perm_config) %}
 
-{% set static_transcode_options = {"volume_config": {"volume_name": "plex-transcodes"}} %}
+{% set static_transcode_options = {"volume_config": {"volume_name": "plex-transcodes", "mode": "0777"}} %}
 {% set transcodes_storage = dict(values.storage.transcode, **static_transcode_options) %}
 {% do c1.add_storage("/transcode", transcodes_storage) %}
 {% do perm_container.add_or_skip_action("transcode", transcodes_storage, perm_config) %}


### PR DESCRIPTION
Closes #1570
Closes #1579

---

Plex starts sub-processes as different uid, so that uid cant write to tmpfs as docker creates it as root.
Set mode to allow "others" to rw.