### PR TITLE
add description for game privileges fields

### DIFF
--- a/ix-dev/community/minecraft-bedrock/app.yaml
+++ b/ix-dev/community/minecraft-bedrock/app.yaml
@@ -28,4 +28,4 @@ sources:
 - https://github.com/itzg/docker-minecraft-bedrock-server
 title: Minecraft Bedrock
 train: community
-version: 1.0.8
+version: 1.0.9

--- a/ix-dev/community/minecraft-bedrock/questions.yaml
+++ b/ix-dev/community/minecraft-bedrock/questions.yaml
@@ -170,7 +170,7 @@ questions:
           description: |
             Sets operator permissions for listed players.</br>
             https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions</br>
-            One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
+            One XUID per field. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
             default: []
@@ -186,7 +186,7 @@ questions:
           description: |
             Sets member permissions for listed players.</br>
             https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions </br>
-            One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
+            One XUID per field. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
             default: []
@@ -202,7 +202,7 @@ questions:
           description: |
             Sets visitor permissions for listed players. </br>
             https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions </br>
-            One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
+            One XUID per field. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
             default: []

--- a/ix-dev/community/minecraft-bedrock/questions.yaml
+++ b/ix-dev/community/minecraft-bedrock/questions.yaml
@@ -167,6 +167,10 @@ questions:
                 description: Operator
         - variable: ops
           label: Operators
+          description:
+            Sets operator permissions for listed players.</br>
+            https://itzg.github.io/docker-minecraft Bedrock-docs/java/configuration/ops </br>
+            One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
             default: []
@@ -179,6 +183,9 @@ questions:
                   required: true
         - variable: members
           label: Members
+            Sets member permissions for listed players.</br>
+            https://itzg.github.io/docker-minecraft Bedrock-docs/java/configuration/members </br>
+            One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
             default: []
@@ -191,6 +198,9 @@ questions:
                   required: true
         - variable: visitors
           label: Visitors
+            Sets visitor permissions for listed players. </br>
+            https://itzg.github.io/docker-minecraft Bedrock-docs/java/configuration/visitor </br>
+            One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
             default: []

--- a/ix-dev/community/minecraft-bedrock/questions.yaml
+++ b/ix-dev/community/minecraft-bedrock/questions.yaml
@@ -167,7 +167,7 @@ questions:
                 description: Operator
         - variable: ops
           label: Operators
-          description:
+          description: |
             Sets operator permissions for listed players.</br>
             https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions</br>
             One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
@@ -183,6 +183,7 @@ questions:
                   required: true
         - variable: members
           label: Members
+          description: |
             Sets member permissions for listed players.</br>
             https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions </br>
             One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
@@ -198,6 +199,7 @@ questions:
                   required: true
         - variable: visitors
           label: Visitors
+          description: |
             Sets visitor permissions for listed players. </br>
             https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions </br>
             One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)

--- a/ix-dev/community/minecraft-bedrock/questions.yaml
+++ b/ix-dev/community/minecraft-bedrock/questions.yaml
@@ -169,7 +169,7 @@ questions:
           label: Operators
           description:
             Sets operator permissions for listed players.</br>
-            https://itzg.github.io/docker-minecraft Bedrock-docs/java/configuration/ops </br>
+            https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions</br>
             One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
@@ -184,7 +184,7 @@ questions:
         - variable: members
           label: Members
             Sets member permissions for listed players.</br>
-            https://itzg.github.io/docker-minecraft Bedrock-docs/java/configuration/members </br>
+            https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions </br>
             One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list
@@ -199,7 +199,7 @@ questions:
         - variable: visitors
           label: Visitors
             Sets visitor permissions for listed players. </br>
-            https://itzg.github.io/docker-minecraft Bedrock-docs/java/configuration/visitor </br>
+            https://hub.docker.com/r/itzg/minecraft-bedrock-server -> Permissions </br>
             One XUID per box. (Xbox User ID can be found at https://www.cxkes.me/xbox/xuid)
           schema:
             type: list


### PR DESCRIPTION
In this [TrueNas forum](https://forums.truenas.com/t/minecraft-bedrock-app-not-recognizing-me-as-an-operator-in-game/35282?u=remdg) we can see that the set privilege field confuses people. 

This pull request add a description indicating how field have to be used, including the need to fill a player field with XUID. (People might have tried with gamertag, IP address or something else)

I also added the [URL ](https://www.cxkes.me/xbox/xuid) of a website that is able to extract the Xbox User ID from a gamertag and some links to the docker image documentation about permissions. 
