### PR TITLE
nextcloud: allow changing storage type

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -73,4 +73,4 @@ sources:
 - https://github.com/truenas/charts/tree/master/charts/nextcloud
 title: Nextcloud
 train: stable
-version: 1.6.10
+version: 1.6.11

--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -360,7 +360,6 @@ questions:
                 schema:
                   type: string
                   required: true
-                  immutable: true
                   default: "ix_volume"
                   enum:
                     - value: "host_path"
@@ -438,7 +437,6 @@ questions:
                 schema:
                   type: string
                   required: true
-                  immutable: true
                   default: "ix_volume"
                   enum:
                     - value: "host_path"
@@ -516,7 +514,6 @@ questions:
                 schema:
                   type: string
                   required: true
-                  immutable: true
                   default: "ix_volume"
                   enum:
                     - value: "host_path"


### PR DESCRIPTION
In order to be able to migrate a deprecated configuration when using ix-volumes, changing storage type is allowed now.

Closes https://github.com/truenas/apps/issues/1382