### PR TITLE
scrutiny: run privileged for automatic disk detection

### DIFF
--- a/ix-dev/community/scrutiny/app.yaml
+++ b/ix-dev/community/scrutiny/app.yaml
@@ -2,6 +2,8 @@ app_version: v0.8.1
 capabilities:
 - description: Scrutiny is able to use raw I/O.
   name: SYS_RAWIO
+- description: Scrutiny is able to perform privileged operations.
+  name: SYS_ADMIN
 - description: Scrutiny is able to bypass permission checks for it's sub-processes.
   name: FOWNER
 - description: Scrutiny is able to bypass permission checks.
@@ -18,6 +20,8 @@ home: https://github.com/AnalogJ/scrutiny
 host_mounts:
 - description: Scrutiny needs to access the udev device information. (Read Only)
   host_path: /run/udev
+- description: Scrutiny needs to access the host device information. (Read Only)
+  host_path: /dev
 icon: https://media.sys.truenas.net/apps/scrutiny/icons/icon.svg
 keywords:
 - disk
@@ -41,4 +45,4 @@ sources:
 - https://github.com/AnalogJ/scrutiny
 title: Scrutiny
 train: community
-version: 1.0.14
+version: 1.1.0

--- a/ix-dev/community/scrutiny/questions.yaml
+++ b/ix-dev/community/scrutiny/questions.yaml
@@ -27,12 +27,16 @@ questions:
             Use at your own risk.
           schema:
             type: boolean
+            # TODO: remove with migrations
+            hidden: true
             default: false
         - variable: disks
           label: "Disks"
           description: "Disks for Scrutiny."
           schema:
             type: list
+            # TODO: remove with migrations
+            hidden: true
             min: 1
             required: true
             default: []

--- a/ix-dev/community/scrutiny/templates/docker-compose.yaml
+++ b/ix-dev/community/scrutiny/templates/docker-compose.yaml
@@ -3,21 +3,16 @@
 {% set c1 = tpl.add_container(values.consts.scrutiny_container_name, "image") %}
 
 {% do c1.set_user(0,0) %}
-{% do c1.add_caps(["SYS_RAWIO", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"]) %}
-{% if values.scrutiny.elevate_privileges %}
-  {% do c1.add_caps(["SYS_ADMIN"]) %}
-{% endif %}
+{% do c1.set_privileged(true) %}
+{% do c1.clear_caps() %}
 
 {% do c1.add_storage("/run/udev", {"type": "host_path", "read_only": True, "host_path_config": {"path": "/run/udev"}}) %}
+{% do c1.add_storage("/dev", {"type": "host_path", "read_only": True, "host_path_config": {"path": "/dev"}}) %}
 {% do c1.add_storage(values.consts.config_dir, values.storage.config) %}
 {% do c1.add_storage("/opt/scrutiny/influxdb", values.storage.influxdb) %}
 
 {% for store in values.storage.additional_storage %}
   {% do c1.add_storage(store.mount_path, store) %}
-{% endfor %}
-
-{% for disk in values.scrutiny.disks %}
-  {% do c1.devices.add_device(disk.host_device, disk.container_device, "r") %}
 {% endfor %}
 
 {% do c1.ports.add_port(values.network.web_port, values.consts.internal_web_port) %}


### PR DESCRIPTION
It was requested to let scrutiny auto detect disks, instead of passing them one-by-one by hand