### PR TITLE
fix(Authentik): require redis password and fix label typo

### DIFF
--- a/ix-dev/community/authentik/app.yaml
+++ b/ix-dev/community/authentik/app.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/goauthentik/authentik
 title: Authentik
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/authentik/questions.yaml
+++ b/ix-dev/community/authentik/questions.yaml
@@ -58,7 +58,7 @@ questions:
           schema:
             type: string
             default: ""
-            required: false
+            required: true
             private: true
         - variable: secret_key
           label: Secret Key
@@ -112,7 +112,7 @@ questions:
             required: true
         - variable: group
           label: Group ID
-          description: The group id that Actual Budget files will be owned by.
+          description: The group id that Authentik files will be owned by.
           schema:
             type: int
             min: 568


### PR DESCRIPTION
closes: #1931 and #1932 