### PR TITLE
terraria: remove env var

### DIFF
--- a/ix-dev/community/terraria/app.yaml
+++ b/ix-dev/community/terraria/app.yaml
@@ -32,4 +32,4 @@ sources:
 - https://github.com/ryansheehan/terraria
 title: Terraria
 train: community
-version: 1.1.16
+version: 1.1.17

--- a/ix-dev/community/terraria/app.yaml
+++ b/ix-dev/community/terraria/app.yaml
@@ -32,4 +32,4 @@ sources:
 - https://github.com/ryansheehan/terraria
 title: Terraria
 train: community
-version: 1.1.15
+version: 1.1.16

--- a/ix-dev/community/terraria/templates/docker-compose.yaml
+++ b/ix-dev/community/terraria/templates/docker-compose.yaml
@@ -29,10 +29,9 @@
   {% do cmd.x.extend(["-seed", values.terraria.world_seed]) %}
 {% endif %}
 
-{% set world_path = "%s/%s.wld" | format(values.consts.world_path, values.terraria.world_name) %}
 {% do cmd.x.extend([
   "-port", values.network.server_port,
-  "-world", world_path,
+  "-world", "%s/%s.wld" | format(values.consts.world_path, values.terraria.world_name),
   "-additionalplugins", values.consts.plugins_path,
   "-maxplayers", values.terraria.max_players,
 ]) %}
@@ -71,7 +70,6 @@
 {% do c1.set_command(cmd.x) %}
 
 {% do c1.environment.add_env("CONFIGPATH", values.consts.config_path) %}
-{% do c1.environment.add_env("WORLDPATH", world_path) %}
 {% do c1.environment.add_user_envs(values.terraria.additional_envs) %}
 {% do c1.ports.add_port(values.network.server_port, values.network.server_port) %}
 {% do c1.add_port(values.network.tshock_api_port) %}

--- a/ix-dev/community/terraria/templates/docker-compose.yaml
+++ b/ix-dev/community/terraria/templates/docker-compose.yaml
@@ -29,9 +29,10 @@
   {% do cmd.x.extend(["-seed", values.terraria.world_seed]) %}
 {% endif %}
 
+{% set world_path = "%s/%s.wld" | format(values.consts.world_path, values.terraria.world_name) %}
 {% do cmd.x.extend([
   "-port", values.network.server_port,
-  "-world", "%s/%s.wld" | format(values.consts.world_path, values.terraria.world_name),
+  "-world", world_path,
   "-additionalplugins", values.consts.plugins_path,
   "-maxplayers", values.terraria.max_players,
 ]) %}
@@ -70,7 +71,7 @@
 {% do c1.set_command(cmd.x) %}
 
 {% do c1.environment.add_env("CONFIGPATH", values.consts.config_path) %}
-{% do c1.environment.add_env("WORLDPATH", values.consts.world_path) %}
+{% do c1.environment.add_env("WORLDPATH", world_path) %}
 {% do c1.environment.add_user_envs(values.terraria.additional_envs) %}
 {% do c1.ports.add_port(values.network.server_port, values.network.server_port) %}
 {% do c1.add_port(values.network.tshock_api_port) %}


### PR DESCRIPTION
`WORLD_PATH` env var is set explicitly by the entrypoint script but never actually used anyway in our case.
it is only used under certain circumstances. 
So removing this var and setting the `WORLD_FILENAME` to empty, to make sure entrypoint always follows the same path, and make sure a user wont break that accidentaly