### PR TITLE
Monero LWS: fixes

### DIFF
--- a/ix-dev/community/monero-lws/app.yaml
+++ b/ix-dev/community/monero-lws/app.yaml
@@ -33,4 +33,4 @@ sources:
 - https://github.com/MAGICGrants/monero-lws-docker
 title: Monero LWS
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/monero-lws/templates/docker-compose.yaml
+++ b/ix-dev/community/monero-lws/templates/docker-compose.yaml
@@ -6,7 +6,11 @@
 
 {% set lws = tpl.add_container(values.consts.lws_container_name, "image") %}
 {% do lws.set_user(values.consts.run_as_user, values.consts.run_as_group) %}
-{% do lws.healthcheck.set_test("tcp", {"port": values.network.basic_rest_server_port.port_number}) %}
+{% if values.ci %}
+  {% do lws.healthcheck.disable() %}
+{% else %}
+  {% do lws.healthcheck.set_test("tcp", {"port": values.network.basic_rest_server_port.port_number}) %}
+{% endif %}
 
 {% for flag in values.lws.additional_flags %}
   {% for reserved_flag in values.consts.reserved_flags %}

--- a/ix-dev/community/monero-lws/templates/docker-compose.yaml
+++ b/ix-dev/community/monero-lws/templates/docker-compose.yaml
@@ -6,7 +6,7 @@
 
 {% set lws = tpl.add_container(values.consts.lws_container_name, "image") %}
 {% do lws.set_user(values.consts.run_as_user, values.consts.run_as_group) %}
-{% do lws.healthcheck.disable() %}
+{% do lws.healthcheck.set_test("tcp", {"port": values.network.basic_rest_server_port.port_number}) %}
 
 {% for flag in values.lws.additional_flags %}
   {% for reserved_flag in values.consts.reserved_flags %}

--- a/ix-dev/community/monero-lws/templates/docker-compose.yaml
+++ b/ix-dev/community/monero-lws/templates/docker-compose.yaml
@@ -6,11 +6,7 @@
 
 {% set lws = tpl.add_container(values.consts.lws_container_name, "image") %}
 {% do lws.set_user(values.consts.run_as_user, values.consts.run_as_group) %}
-{% if values.ci %}
-  {% do lws.healthcheck.disable() %}
-{% else %}
-  {% do lws.healthcheck.set_test("curl", {"port": values.network.basic_rest_server_port.port_number}) %}
-{% endif %}
+{% do lws.healthcheck.disable() %}
 
 {% for flag in values.lws.additional_flags %}
   {% for reserved_flag in values.consts.reserved_flags %}
@@ -53,6 +49,7 @@
 {% endfor %}
 
 {% do lws.add_port(values.network.basic_rest_server_port) %}
+{% do lws.add_port(values.network.admin_rest_server_port) %}
 {% do lws.add_extra_host("host.docker.internal", "host-gateway") %}
 
 {% if perm_container.has_actions() %}

--- a/ix-dev/community/monero-lws/templates/macros/entrypoint.sh
+++ b/ix-dev/community/monero-lws/templates/macros/entrypoint.sh
@@ -1,6 +1,8 @@
 {% macro entrypoint(values) -%}
 #!/bin/sh
 
+mkdir -p $HOME/.bitmonero/light_wallet_server
+
 {% for account in values.lws.accounts %}
 echo "Adding account {{ account.address }}"
 monero-lws-admin add_account "{{ account.address }}" "{{ account.view_key }}"

--- a/ix-dev/community/monero-lws/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/monero-lws/templates/test_values/basic-values.yaml
@@ -3,7 +3,6 @@ resources:
     cpus: 2.0
     memory: 4096
 
-ci: true
 TZ: UTC
 
 lws:

--- a/ix-dev/community/monero-lws/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/monero-lws/templates/test_values/basic-values.yaml
@@ -3,6 +3,7 @@ resources:
     cpus: 2.0
     memory: 4096
 
+ci: true
 TZ: UTC
 
 lws:


### PR DESCRIPTION
We're disabling healthchecks since there isn't a good endpoint for that, all of them require auth, by mistake I thought `/` would work.