### PR TITLE
bump jellyfin to 10.10.7

### DIFF
--- a/ix-dev/community/jellyfin/app.yaml
+++ b/ix-dev/community/jellyfin/app.yaml
@@ -1,4 +1,4 @@
-app_version: 10.10.6
+app_version: 10.10.7
 capabilities: []
 categories:
 - media
@@ -35,4 +35,4 @@ sources:
 - https://jellyfin.org/
 title: Jellyfin
 train: community
-version: 1.1.21
+version: 1.1.22

--- a/ix-dev/community/jellyfin/ix_values.yaml
+++ b/ix-dev/community/jellyfin/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: jellyfin/jellyfin
-    tag: 10.10.6
+    tag: 10.10.7
 
 consts:
   jellyfin_container_name: jellyfin


### PR DESCRIPTION
Bump the Version of the Jellyfin to the latest version on Docker-Hub.
Related to https://github.com/truenas/apps/issues/2017

This is my first ever contribution to the TrueNAS App catalogue - if I missed anything, please let me know!
Kind regards