### PR TITLE
Fix Homarr URL

### DIFF
--- a/ix-dev/community/homarr/app.yaml
+++ b/ix-dev/community/homarr/app.yaml
@@ -40,7 +40,7 @@ screenshots:
 - https://media.sys.truenas.net/apps/homarr/screenshots/screenshot3.png
 sources:
 - https://homarr.dev/
-- ghcr.io/homarr-labs/homarr
+- https://github.com/homarr-labs/homarr
 title: Homarr
 train: community
 version: 2.0.21


### PR DESCRIPTION
The URL in Homarr does not point to the Github repository, causing it to redirect to the Truenas instance.

If I need to run `ci.py` manually, I cannot do so myself and would need someone to do so for me. Thank you.