### PR TITLE
WIP: Make immich `upload/` mount optional

### DIFF
--- a/ix-dev/community/immich/questions.yaml
+++ b/ix-dev/community/immich/questions.yaml
@@ -215,6 +215,12 @@ questions:
                         type: hostpath
                         show_if: [["acl_enable", "=", false]]
                         required: true
+        - variable: enable_seperate_upload
+          label: Enable Seperate Upload Mount
+          description: Enable a seperate upload mount for Immich.
+          schema:
+            type: boolean
+            default: true
         - variable: uploads
           label: Immich Uploads Storage
           description: The path to store Immich Uploads.


### PR DESCRIPTION
This makes immich's `upload/` mount optional and disables it by default to follow the best practices in the official immich documentation.

Fixes #893

This is a WIP.