### PR TITLE
Add changelog_url strings for community apps >1000 in active use

### DIFF
--- a/ix-dev/community/bazarr/app.yaml
+++ b/ix-dev/community/bazarr/app.yaml
@@ -2,6 +2,7 @@ app_version: 1.5.1
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/morpheus65535/bazarr/releases
 date_added: '2024-07-31'
 description: Bazarr is a companion application to Sonarr and Radarr. It manages and
   downloads subtitles based on your requirements.
@@ -32,4 +33,4 @@ sources:
 - https://github.com/morpheus65535/bazarr
 title: Bazarr
 train: community
-version: 1.1.12
+version: 1.1.13

--- a/ix-dev/community/calibre/app.yaml
+++ b/ix-dev/community/calibre/app.yaml
@@ -12,6 +12,7 @@ capabilities:
   name: SETUID
 categories:
 - media
+changelog_url: https://calibre-ebook.com/whats-new
 date_added: '2024-11-19'
 description: Calibre is the one stop solution for all your e-book needs.
 home: https://calibre-ebook.com/
@@ -46,4 +47,4 @@ sources:
 - https://calibre-ebook.com/
 title: Calibre
 train: community
-version: 1.0.21
+version: 1.0.22

--- a/ix-dev/community/clamav/app.yaml
+++ b/ix-dev/community/clamav/app.yaml
@@ -12,6 +12,7 @@ capabilities:
   name: SETUID
 categories:
 - security
+changelog_url: https://github.com/Cisco-Talos/clamav/releases
 date_added: '2024-08-01'
 description: ClamAV is an open source (GPLv2) anti-virus toolkit.
 home: https://www.clamav.net/
@@ -39,4 +40,4 @@ sources:
 - https://www.clamav.net/
 title: ClamAV
 train: community
-version: 1.2.16
+version: 1.2.17

--- a/ix-dev/community/cloudflared/app.yaml
+++ b/ix-dev/community/cloudflared/app.yaml
@@ -2,6 +2,7 @@ app_version: 2025.4.0
 capabilities: []
 categories:
 - networking
+changelog_url: https://github.com/cloudflare/cloudflared/blob/master/RELEASE_NOTES
 date_added: '2024-08-02'
 description: Cloudflared is a client for Cloudflare Tunnel, a daemon that exposes
   private services through the Cloudflare edge.
@@ -31,4 +32,4 @@ sources:
 - https://hub.docker.com/r/cloudflare/cloudflared
 title: Cloudflared
 train: community
-version: 1.2.17
+version: 1.2.18

--- a/ix-dev/community/deluge/app.yaml
+++ b/ix-dev/community/deluge/app.yaml
@@ -12,6 +12,7 @@ capabilities:
   name: SETUID
 categories:
 - media
+changelog_url: https://git.deluge-torrent.org/deluge/log/
 date_added: '2024-08-02'
 description: Deluge is a lightweight, Free Software, cross-platform BitTorrent client.
 home: https://deluge-torrent.org
@@ -39,4 +40,4 @@ sources:
 - https://deluge-torrent.org/
 title: Deluge
 train: community
-version: 1.1.10
+version: 1.1.11

--- a/ix-dev/community/filebrowser/app.yaml
+++ b/ix-dev/community/filebrowser/app.yaml
@@ -2,6 +2,7 @@ app_version: v2.32.0
 capabilities: []
 categories:
 - storage
+changelog_url: https://github.com/filebrowser/filebrowser/releases
 date_added: '2024-08-02'
 description: File Browser provides a file managing interface within a specified directory
   and it can be used to upload, delete, preview, rename and edit your files.
@@ -33,4 +34,4 @@ sources:
 - https://hub.docker.com/r/filebrowser/filebrowser
 title: File Browser
 train: community
-version: 1.2.11
+version: 1.2.12

--- a/ix-dev/community/frigate/app.yaml
+++ b/ix-dev/community/frigate/app.yaml
@@ -14,6 +14,7 @@ capabilities:
   name: PERFMON
 categories:
 - security
+changelog_url: https://github.com/blakeblackshear/frigate/releases
 date_added: '2024-09-12'
 description: Frigate is an NVR With Realtime Object Detection for IP Cameras
 home: https://frigate.video/
@@ -43,4 +44,4 @@ sources:
 - https://github.com/blakeblackshear/frigate
 title: Frigate
 train: community
-version: 1.1.18
+version: 1.1.19

--- a/ix-dev/community/handbrake/app.yaml
+++ b/ix-dev/community/handbrake/app.yaml
@@ -19,6 +19,7 @@ capabilities:
   name: KILL
 categories:
 - media
+changelog_url: https://github.com/jlesage/docker-handbrake/releases
 date_added: '2024-08-02'
 description: HandBrake is a tool for converting video from nearly any format to a
   selection of modern, widely supported codecs.
@@ -48,4 +49,4 @@ sources:
 - https://hub.docker.com/r/jlesage/handbrake
 title: Handbrake
 train: community
-version: 2.1.14
+version: 2.1.15

--- a/ix-dev/community/homarr/app.yaml
+++ b/ix-dev/community/homarr/app.yaml
@@ -12,6 +12,7 @@ capabilities:
   name: SETUID
 categories:
 - productivity
+changelog_url: https://github.com/homarr-labs/homarr/releases
 date_added: '2024-08-02'
 description: Homarr a modern and easy to use dashboard. 14+ integrations. 10K+ icons
   built in. Authentication out of the box. No YAML, drag and drop configuration.
@@ -44,4 +45,4 @@ sources:
 - https://github.com/homarr-labs/homarr
 title: Homarr
 train: community
-version: 2.0.24
+version: 2.0.25

--- a/ix-dev/community/jellyfin/app.yaml
+++ b/ix-dev/community/jellyfin/app.yaml
@@ -2,6 +2,7 @@ app_version: 10.10.7
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/jellyfin/jellyfin/releases
 date_added: '2024-07-30'
 description: Jellyfin is a Free Software Media System that puts you in control of
   managing and streaming your media.
@@ -36,4 +37,4 @@ sources:
 - https://jellyfin.org/
 title: Jellyfin
 train: community
-version: 1.1.23
+version: 1.1.24

--- a/ix-dev/community/lidarr/app.yaml
+++ b/ix-dev/community/lidarr/app.yaml
@@ -2,6 +2,7 @@ app_version: 2.11.0.4610
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/lidarr/Lidarr/releases
 date_added: '2024-07-31'
 description: Lidarr is a music collection manager for Usenet and BitTorrent users.
 home: https://github.com/Lidarr/Lidarr
@@ -32,4 +33,4 @@ sources:
 - https://github.com/Lidarr/Lidarr
 title: Lidarr
 train: community
-version: 1.2.24
+version: 1.2.25

--- a/ix-dev/community/mealie/app.yaml
+++ b/ix-dev/community/mealie/app.yaml
@@ -2,6 +2,7 @@ app_version: v2.8.0
 capabilities: []
 categories:
 - productivity
+changelog_url: https://github.com/mealie-recipes/mealie/releases
 date_added: '2024-08-22'
 description: Mealie is a self-hosted recipe manager and meal planner
 home: https://docs.mealie.io/
@@ -34,4 +35,4 @@ sources:
 - https://docs.mealie.io/
 title: Mealie
 train: community
-version: 1.4.19
+version: 1.4.20

--- a/ix-dev/community/minecraft/app.yaml
+++ b/ix-dev/community/minecraft/app.yaml
@@ -14,6 +14,7 @@ capabilities:
   name: NET_RAW
 categories:
 - games
+changelog_url: https://github.com/itzg/docker-minecraft-server/releases
 date_added: '2024-08-05'
 description: Minecraft dedicated server for Java platform.
 home: https://www.minecraft.net/en-us
@@ -41,4 +42,4 @@ sources:
 - https://github.com/itzg/docker-minecraft-server
 title: Minecraft Server (Java)
 train: community
-version: 1.12.21
+version: 1.12.22

--- a/ix-dev/community/mineos/app.yaml
+++ b/ix-dev/community/mineos/app.yaml
@@ -12,6 +12,7 @@ capabilities:
   name: SETUID
 categories:
 - games
+changelog_url: https://github.com/hexparrot/mineos-node/releases
 date_added: '2024-08-02'
 description: MineOS is a server front-end to ease managing Minecraft administrative
   tasks.
@@ -40,4 +41,4 @@ sources:
 - https://github.com/hexparrot/mineos-node
 title: MineOS
 train: community
-version: 1.1.9
+version: 1.1.10

--- a/ix-dev/community/netbootxyz/app.yaml
+++ b/ix-dev/community/netbootxyz/app.yaml
@@ -18,6 +18,7 @@ capabilities:
   name: KILL
 categories:
 - networking
+changelog_url: https://github.com/netbootxyz/docker-netbootxyz/tags
 date_added: '2024-08-02'
 description: netboot.xyz lets you PXE boot various operating system installers or
   utilities from a single tool over the network.
@@ -51,4 +52,4 @@ sources:
 - https://netboot.xyz
 title: Netboot.xyz
 train: community
-version: 1.1.12
+version: 1.1.13

--- a/ix-dev/community/nginx-proxy-manager/app.yaml
+++ b/ix-dev/community/nginx-proxy-manager/app.yaml
@@ -14,6 +14,7 @@ capabilities:
   name: DAC_OVERRIDE
 categories:
 - networking
+changelog_url: https://github.com/NginxProxyManager/nginx-proxy-manager/releases
 date_added: '2024-08-02'
 description: Expose your services easily and securely
 home: https://nginxproxymanager.com/
@@ -45,4 +46,4 @@ sources:
 - https://hub.docker.com/r/jc21/nginx-proxy-manager
 title: Nginx Proxy Manager
 train: community
-version: 1.1.13
+version: 1.1.14

--- a/ix-dev/community/ollama/app.yaml
+++ b/ix-dev/community/ollama/app.yaml
@@ -2,6 +2,7 @@ app_version: 0.6.5
 capabilities: []
 categories:
 - ai
+changelog_url: https://github.com/ollama/ollama/releases
 date_added: '2024-10-24'
 description: Get up and running with Llama 3.2, Mistral, Gemma 2, and other large
   language models.
@@ -29,4 +30,4 @@ sources:
 - https://github.com/ollama/ollama
 title: Ollama
 train: community
-version: 1.0.44
+version: 1.0.45

--- a/ix-dev/community/open-speed-test/app.yaml
+++ b/ix-dev/community/open-speed-test/app.yaml
@@ -2,6 +2,7 @@ app_version: v2.0.6
 capabilities: []
 categories:
 - networking
+changelog_url: https://github.com/openspeedtest/Docker-Image/tags
 date_added: '2025-02-05'
 description: "SpeedTest by OpenSpeedTest\u2122 is a Free and Open-Source HTML5 Network\
   \ Performance Estimation Tool"
@@ -29,4 +30,4 @@ sources:
 - https://github.com/openspeedtest/Speed-Test
 title: Open Speed Test
 train: community
-version: 1.0.6
+version: 1.0.7

--- a/ix-dev/community/open-webui/app.yaml
+++ b/ix-dev/community/open-webui/app.yaml
@@ -2,6 +2,7 @@ app_version: v0.6.2
 capabilities: []
 categories:
 - ai
+changelog_url: https://github.com/open-webui/open-webui/releases
 date_added: '2024-10-24'
 description: Open WebUI is an extensible, feature-rich, and user-friendly self-hosted
   WebUI designed to operate entirely offline. It supports various LLM runners, including
@@ -33,4 +34,4 @@ sources:
 - https://github.com/open-webui/open-webui
 title: Open WebUI
 train: community
-version: 1.0.45
+version: 1.0.46

--- a/ix-dev/community/overseerr/app.yaml
+++ b/ix-dev/community/overseerr/app.yaml
@@ -2,6 +2,7 @@ app_version: 1.34.0
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/sct/overseerr/releases
 date_added: '2024-08-02'
 description: Overseerr is a free and open source software application for managing
   requests for your media library.
@@ -29,4 +30,4 @@ sources:
 - https://github.com/sct/overseerr
 title: Overseerr
 train: community
-version: 1.1.11
+version: 1.1.12

--- a/ix-dev/community/paperless-ngx/app.yaml
+++ b/ix-dev/community/paperless-ngx/app.yaml
@@ -12,6 +12,7 @@ capabilities:
   name: SETUID
 categories:
 - productivity
+changelog_url: https://github.com/paperless-ngx/paperless-ngx/releases
 date_added: '2024-09-10'
 description: Paperless-ngx is a document management system that transforms your physical
   documents into a searchable online archive so you can keep, well, less paper.
@@ -68,4 +69,4 @@ sources:
 - https://github.com/paperless-ngx/paperless-ngx
 title: Paperless-ngx
 train: community
-version: 1.2.33
+version: 1.2.34

--- a/ix-dev/community/portainer/app.yaml
+++ b/ix-dev/community/portainer/app.yaml
@@ -18,6 +18,7 @@ capabilities:
   name: SETFCAP
 categories:
 - management
+changelog_url: https://github.com/portainer/portainer/releases
 date_added: '2024-08-07'
 description: Container management made easy
 home: https://www.portainer.io
@@ -50,4 +51,4 @@ sources:
 - https://github.com/portainer/portainer
 title: Portainer
 train: community
-version: 1.3.23
+version: 1.3.24

--- a/ix-dev/community/prowlarr/app.yaml
+++ b/ix-dev/community/prowlarr/app.yaml
@@ -2,6 +2,7 @@ app_version: 1.33.2.5002
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/Prowlarr/Prowlarr/releases
 date_added: '2024-07-31'
 description: Prowlarr is an indexer manager/proxy to integrate with your various PVR
   apps.
@@ -30,4 +31,4 @@ sources:
 - https://prowlarr.com
 title: Prowlarr
 train: community
-version: 1.3.29
+version: 1.3.30

--- a/ix-dev/community/qbittorrent/app.yaml
+++ b/ix-dev/community/qbittorrent/app.yaml
@@ -2,6 +2,7 @@ app_version: 5.0.4
 capabilities: []
 categories:
 - media
+changelog_url: https://www.qbittorrent.org/news
 date_added: '2024-07-30'
 description: The qBittorrent project aims to provide an open-source software alternative
   to mTorrent.
@@ -32,4 +33,4 @@ sources:
 - https://www.qbittorrent.org/
 title: qBittorrent
 train: community
-version: 1.1.20
+version: 1.1.21

--- a/ix-dev/community/radarr/app.yaml
+++ b/ix-dev/community/radarr/app.yaml
@@ -2,6 +2,7 @@ app_version: 5.22.1.9832
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/Radarr/Radarr/releases
 date_added: '2024-07-30'
 description: Radarr is a movie collection manager for Usenet and BitTorrent users.
 home: https://github.com/Radarr/Radarr
@@ -33,4 +34,4 @@ sources:
 - https://github.com/Radarr/Radarr
 title: Radarr
 train: community
-version: 1.2.22
+version: 1.2.23

--- a/ix-dev/community/readarr/app.yaml
+++ b/ix-dev/community/readarr/app.yaml
@@ -2,6 +2,7 @@ app_version: 0.4.13.2760
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/Readarr/Readarr/releases
 date_added: '2024-07-31'
 description: Readarr is an ebook and audiobook collection manager for Usenet and BitTorrent
   users.
@@ -34,4 +35,4 @@ sources:
 - https://github.com/Readarr/Readarr
 title: Readarr
 train: community
-version: 1.1.20
+version: 1.1.21

--- a/ix-dev/community/sabnzbd/app.yaml
+++ b/ix-dev/community/sabnzbd/app.yaml
@@ -2,6 +2,7 @@ app_version: 4.5.0
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/sabnzbd/sabnzbd/releases
 date_added: '2024-09-11'
 description: SABnzbd is an Open Source Binary Newsreader written in Python.
 home: https://sabnzbd.org/
@@ -33,4 +34,4 @@ sources:
 - https://sabnzbd.org/
 title: SABnzbd
 train: community
-version: 1.1.13
+version: 1.1.14

--- a/ix-dev/community/scrutiny/app.yaml
+++ b/ix-dev/community/scrutiny/app.yaml
@@ -14,6 +14,7 @@ capabilities:
   name: SETUID
 categories:
 - monitoring
+changelog_url: https://github.com/AnalogJ/scrutiny/releases
 date_added: '2024-11-11'
 description: Scrutiny is tool for Hard Drive S.M.A.R.T Monitoring, Historical Trends
   & Real World Failure Thresholds
@@ -46,4 +47,4 @@ sources:
 - https://github.com/AnalogJ/scrutiny
 title: Scrutiny
 train: community
-version: 1.1.1
+version: 1.1.11

--- a/ix-dev/community/sonarr/app.yaml
+++ b/ix-dev/community/sonarr/app.yaml
@@ -2,6 +2,7 @@ app_version: 4.0.14.2938
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/Sonarr/Sonarr/releases
 date_added: '2024-07-31'
 description: Sonarr is a PVR for Usenet and BitTorrent users.
 home: https://github.com/Sonarr/Sonarr
@@ -32,4 +33,4 @@ sources:
 - https://github.com/Sonarr/Sonarr
 title: Sonarr
 train: community
-version: 1.1.16
+version: 1.1.17

--- a/ix-dev/community/tailscale/app.yaml
+++ b/ix-dev/community/tailscale/app.yaml
@@ -14,6 +14,7 @@ capabilities:
   name: DAC_OVERRIDE
 categories:
 - networking
+changelog_url: https://tailscale.com/changelog#client
 date_added: '2024-07-30'
 description: Secure remote access to shared resources
 home: https://tailscale.com/
@@ -43,4 +44,4 @@ sources:
 - https://hub.docker.com/r/tailscale/tailscale
 title: Tailscale
 train: community
-version: 1.2.16
+version: 1.2.17

--- a/ix-dev/community/tdarr/app.yaml
+++ b/ix-dev/community/tdarr/app.yaml
@@ -11,6 +11,7 @@ capabilities:
   name: SETUID
 categories:
 - media
+changelog_url: https://home.tdarr.io/download
 date_added: '2024-09-17'
 description: Tdarr is a Distributed Transcoding System
 home: https://home.tdarr.io/
@@ -41,4 +42,4 @@ sources:
 - https://docs.tdarr.io/docs
 title: Tdarr
 train: community
-version: 1.1.21
+version: 1.1.22

--- a/ix-dev/community/transmission/app.yaml
+++ b/ix-dev/community/transmission/app.yaml
@@ -2,6 +2,7 @@ app_version: 4.0.6
 capabilities: []
 categories:
 - media
+changelog_url: https://github.com/transmission/transmission/releases/
 date_added: '2024-09-19'
 description: Transmission is designed for easy, powerful use.
 home: https://transmissionbt.com/
@@ -30,4 +31,4 @@ sources:
 - https://transmissionbt.com/
 title: Transmission
 train: community
-version: 1.1.11
+version: 1.1.12

--- a/ix-dev/community/unifi-controller/app.yaml
+++ b/ix-dev/community/unifi-controller/app.yaml
@@ -2,6 +2,7 @@ app_version: 9.0.114
 capabilities: []
 categories:
 - networking
+changelog_url: https://github.com/goofball222/unifi/releases
 date_added: '2024-08-01'
 description: Unifi Controller is a network management controller for Unifi Equipment.
 home: https://github.com/goofball222/unifi
@@ -30,4 +31,4 @@ sources:
 - https://hub.docker.com/r/goofball222/unifi
 title: Unifi Controller
 train: community
-version: 1.3.14
+version: 1.3.15

--- a/ix-dev/community/vaultwarden/app.yaml
+++ b/ix-dev/community/vaultwarden/app.yaml
@@ -2,6 +2,7 @@ app_version: 1.33.2
 capabilities: []
 categories:
 - security
+changelog_url: https://github.com/dani-garcia/vaultwarden/releases
 date_added: '2024-09-19'
 description: Alternative implementation of the Bitwarden server API written in Rust
   and compatible with upstream Bitwarden clients.
@@ -35,4 +36,4 @@ sources:
 - https://github.com/dani-garcia/vaultwarden
 title: Vaultwarden
 train: community
-version: 1.2.16
+version: 1.2.17

--- a/ix-dev/community/zerotier/app.yaml
+++ b/ix-dev/community/zerotier/app.yaml
@@ -25,6 +25,7 @@ capabilities:
   name: SYS_ADMIN
 categories:
 - networking
+changelog_url: https://github.com/zerotier/ZeroTierOne/blob/dev/RELEASE-NOTES.md
 date_added: '2024-08-09'
 description: Securely connect any device, anywhere.
 home: https://www.zerotier.com
@@ -54,4 +55,4 @@ sources:
 - https://hub.docker.com/r/zerotier/zerotier
 title: Zerotier
 train: community
-version: 1.1.11
+version: 1.1.12


### PR DESCRIPTION
This is my starting point to get changelog links added for apps that have the most active use. The eventual goal is to get them added to all apps.