### PR TITLE
fix outline schema for updatability

### DIFF
--- a/trains/community/outline/app_versions.json
+++ b/trains/community/outline/app_versions.json
@@ -154,8 +154,8 @@
                                 "schema": {
                                     "type": "string",
                                     "default": "",
-                                    "min_length": 64,
-                                    "max_length": 64,
+                                    "min_length": 32,
+                                    "max_length": 32,
                                     "required": true,
                                     "private": true
                                 }
@@ -167,8 +167,8 @@
                                 "schema": {
                                     "type": "string",
                                     "default": "",
-                                    "min_length": 64,
-                                    "max_length": 64,
+                                    "min_length": 32,
+                                    "max_length": 32,
                                     "required": true,
                                     "private": true
                                 }


### PR DESCRIPTION
This change should allow Outline to be updated again.
Fixes one of the problems mentioned in https://github.com/truenas/apps/issues/2086

change secret_key to 32 length
change utils_secret to 32 length
