### PR TITLE
bitcoind: fix show_if filters

### DIFF
--- a/ix-dev/community/bitcoind/app.yaml
+++ b/ix-dev/community/bitcoind/app.yaml
@@ -30,4 +30,4 @@ sources:
 - https://github.com/sethforprivacy/docker-bitcoind
 title: Bitcoin Node
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -34,7 +34,6 @@ questions:
             type: string
             required: true
             default: truenas
-            show_if: [["rpc_enabled", "=", "true"]]
         - variable: rpc_password
           label: RPC Password
           description: The password for RPC auth.
@@ -42,7 +41,6 @@ questions:
             type: string
             required: true
             private: true
-            show_if: [["rpc_enabled", "=", "true"]]
         - variable: rpc_work_queue_size
           label: RPC Work Queue Size
           description: |
@@ -55,7 +53,6 @@ questions:
             required: true
             default: 128
             min: 0
-            show_if: [["rpc_enabled", "=", "true"]]
         - variable: clearnet_outgoing_enabled
           label: Clearnet Outgoing Connections
           description: Connect to peers available on the clearnet (publicly accessible internet).

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -115,11 +115,13 @@ questions:
             required: true
             show_if:
               [
-                "OR",
                 [
-                  ["tor_outgoing_enabled", "=", true],
-                  ["clearnet_outgoing_via_tor_enabled", "=", true],
-                  ["tor_incoming_enabled", "=", true],
+                  "OR",
+                  [
+                    ["tor_outgoing_enabled", "=", true],
+                    ["clearnet_outgoing_via_tor_enabled", "=", true],
+                    ["tor_incoming_enabled", "=", true],
+                  ],
                 ],
               ]
         - variable: tor_port

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -100,27 +100,25 @@ questions:
             show_if: [["tor_incoming_enabled", "=", true]]
         - variable: tor_ip
           label: Tor IP
-          description: Enter the local IP of this machine if you are running the Arti TrueNAS App.
+          description: |
+            Enter the local IP of this machine if you are running the Arti TrueNAS App.</br>
+            Required if:
+            - Tor Outgoing Connections is enabled
+            - Tor Incoming Connections is enabled
+            - Clearnet Outgoing Connections via Tor is enabled
           schema:
             type: ipaddr
-            required: true
-            show_if:
-              - - OR
-                - - ["tor_outgoing_enabled", "=", true]
-                  - ["clearnet_outgoing_via_tor_enabled", "=", true]
-                  - ["tor_incoming_enabled", "=", true]
         - variable: tor_port
           label: Tor port
+          description: |
+            Required if:
+            - Tor Outgoing Connections is enabled
+            - Tor Incoming Connections is enabled
+            - Clearnet Outgoing Connections via Tor is enabled
           schema:
             type: int
             min: 1
             max: 65535
-            required: true
-            show_if:
-              - - OR
-                - - ["tor_outgoing_enabled", "=", true]
-                  - ["clearnet_outgoing_via_tor_enabled", "=", true]
-                  - ["tor_incoming_enabled", "=", true]
         - variable: i2p_outgoing_enabled
           label: I2P Outgoing Connections
           description: Connect to peers available on the I2P network.
@@ -137,25 +135,23 @@ questions:
             default: false
         - variable: i2p_ip
           label: I2P IP
-          description: Enter the local IP of this machine if you are running the Arti TrueNAS App.
+          description: |
+            Enter the local IP of this machine if you are running the Arti TrueNAS App.</br>
+            Required if:
+            - I2P Outgoing Connections is enabled
+            - I2P Incoming Connections is enabled
           schema:
             type: ipaddr
-            required: true
-            show_if:
-              - - OR
-                - - ["i2p_outgoing_enabled", "=", true]
-                  - ["i2p_incoming_enabled", "=", true]
         - variable: i2p_port
           label: I2P SAM port
+          description: |
+            Required if:
+            - I2P Outgoing Connections is enabled
+            - I2P Incoming Connections is enabled
           schema:
             type: int
             min: 1
             max: 65535
-            required: true
-            show_if:
-              - - OR
-                - - ["i2p_outgoing_enabled", "=", true]
-                  - ["i2p_incoming_enabled", "=", true]
         - variable: public_rest_api_enabled
           label: Public REST API
           description: |

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -27,12 +27,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: rpc_enabled
-          label: RPC Enabled
-          description: Enable RPC.
-          schema:
-            type: boolean
-            default: true
         - variable: rpc_user
           label: RPC User
           description: The username for RPC auth.

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -102,19 +102,19 @@ questions:
           label: Tor IP
           description: |
             Enter the local IP of this machine if you are running the Arti TrueNAS App.</br>
-            Required if:
-            - Tor Outgoing Connections is enabled
-            - Tor Incoming Connections is enabled
-            - Clearnet Outgoing Connections via Tor is enabled
+            Required if any of the following is enabled:
+            - Tor Outgoing Connections
+            - Tor Incoming Connections
+            - Clearnet Outgoing Connections via Tor
           schema:
             type: ipaddr
         - variable: tor_port
           label: Tor port
           description: |
-            Required if:
-            - Tor Outgoing Connections is enabled
-            - Tor Incoming Connections is enabled
-            - Clearnet Outgoing Connections via Tor is enabled
+            Required if any of the following is enabled:
+            - Tor Outgoing Connections
+            - Tor Incoming Connections
+            - Clearnet Outgoing Connections via Tor
           schema:
             type: int
             min: 1
@@ -137,17 +137,17 @@ questions:
           label: I2P IP
           description: |
             Enter the local IP of this machine if you are running the Arti TrueNAS App.</br>
-            Required if:
-            - I2P Outgoing Connections is enabled
-            - I2P Incoming Connections is enabled
+            Required if any of the following is enabled:
+            - I2P Outgoing Connections
+            - I2P Incoming Connections
           schema:
             type: ipaddr
         - variable: i2p_port
           label: I2P SAM port
           description: |
-            Required if:
-            - I2P Outgoing Connections is enabled
-            - I2P Incoming Connections is enabled
+            Required if any of the following is enabled:
+            - I2P Outgoing Connections
+            - I2P Incoming Connections
           schema:
             type: int
             min: 1

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -131,11 +131,13 @@ questions:
             required: true
             show_if:
               [
-                "OR",
                 [
-                  ["tor_outgoing_enabled", "=", true],
-                  ["clearnet_outgoing_via_tor_enabled", "=", true],
-                  ["tor_incoming_enabled", "=", true],
+                  "OR",
+                  [
+                    ["tor_outgoing_enabled", "=", true],
+                    ["clearnet_outgoing_via_tor_enabled", "=", true],
+                    ["tor_incoming_enabled", "=", true],
+                  ],
                 ],
               ]
         - variable: i2p_outgoing_enabled
@@ -160,10 +162,12 @@ questions:
             required: true
             show_if:
               [
-                "OR",
                 [
-                  ["i2p_outgoing_enabled", "=", true],
-                  ["i2p_incoming_enabled", "=", true],
+                  "OR",
+                  [
+                    ["i2p_outgoing_enabled", "=", true],
+                    ["i2p_incoming_enabled", "=", true],
+                  ],
                 ],
               ]
         - variable: i2p_port
@@ -174,8 +178,15 @@ questions:
             max: 65535
             required: true
             show_if:
-              - ["i2p_outgoing_enabled", "=", true]
-              - ["i2p_incoming_enabled", "=", true]
+              [
+                [
+                  "OR",
+                  [
+                    ["i2p_outgoing_enabled", "=", true],
+                    ["i2p_incoming_enabled", "=", true],
+                  ],
+                ],
+              ]
         - variable: public_rest_api_enabled
           label: Public REST API
           description: |

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -338,7 +338,7 @@ questions:
             required: true
             default: 83
             min: 1
-            show_if: [["op_return_txs_relay_enabled", "=", "true"]]
+            show_if: [["op_return_txs_relay_enabled", "=", true]]
         - variable: bare_multisig_txs_relay_enabled
           label: Relay Bare Multisig Transactions
           description: Relay non-P2SH multisig transactions.

--- a/ix-dev/community/bitcoind/questions.yaml
+++ b/ix-dev/community/bitcoind/questions.yaml
@@ -108,16 +108,10 @@ questions:
             type: ipaddr
             required: true
             show_if:
-              [
-                [
-                  "OR",
-                  [
-                    ["tor_outgoing_enabled", "=", true],
-                    ["clearnet_outgoing_via_tor_enabled", "=", true],
-                    ["tor_incoming_enabled", "=", true],
-                  ],
-                ],
-              ]
+              - - OR
+                - - ["tor_outgoing_enabled", "=", true]
+                  - ["clearnet_outgoing_via_tor_enabled", "=", true]
+                  - ["tor_incoming_enabled", "=", true]
         - variable: tor_port
           label: Tor port
           schema:
@@ -126,16 +120,10 @@ questions:
             max: 65535
             required: true
             show_if:
-              [
-                [
-                  "OR",
-                  [
-                    ["tor_outgoing_enabled", "=", true],
-                    ["clearnet_outgoing_via_tor_enabled", "=", true],
-                    ["tor_incoming_enabled", "=", true],
-                  ],
-                ],
-              ]
+              - - OR
+                - - ["tor_outgoing_enabled", "=", true]
+                  - ["clearnet_outgoing_via_tor_enabled", "=", true]
+                  - ["tor_incoming_enabled", "=", true]
         - variable: i2p_outgoing_enabled
           label: I2P Outgoing Connections
           description: Connect to peers available on the I2P network.
@@ -157,15 +145,9 @@ questions:
             type: ipaddr
             required: true
             show_if:
-              [
-                [
-                  "OR",
-                  [
-                    ["i2p_outgoing_enabled", "=", true],
-                    ["i2p_incoming_enabled", "=", true],
-                  ],
-                ],
-              ]
+              - - OR
+                - - ["i2p_outgoing_enabled", "=", true]
+                  - ["i2p_incoming_enabled", "=", true]
         - variable: i2p_port
           label: I2P SAM port
           schema:
@@ -174,15 +156,9 @@ questions:
             max: 65535
             required: true
             show_if:
-              [
-                [
-                  "OR",
-                  [
-                    ["i2p_outgoing_enabled", "=", true],
-                    ["i2p_incoming_enabled", "=", true],
-                  ],
-                ],
-              ]
+              - - OR
+                - - ["i2p_outgoing_enabled", "=", true]
+                  - ["i2p_incoming_enabled", "=", true]
         - variable: public_rest_api_enabled
           label: Public REST API
           description: |

--- a/ix-dev/community/bitcoind/templates/docker-compose.yaml
+++ b/ix-dev/community/bitcoind/templates/docker-compose.yaml
@@ -1,6 +1,26 @@
 {% from "macros/setup.py.jinja" import setup_script %}
 {% set tpl = ix_lib.base.render.Render(values) %}
 
+{% if values.bitcoin.tor_outgoing_enabled or values.bitcoin.tor_incoming_enabled or values.bitcoin.clearnet_outgoing_via_tor_enabled %}
+  {% if not values.bitcoin.tor_ip %}
+    {% do tpl.funcs.fail("Bitcoin Tor IP is required with the given configuration.") %}
+  {% endif %}
+
+  {% if not values.bitcoin.tor_port %}
+    {% do tpl.funcs.fail("Bitcoin Tor Port is required with the given configuration.") %}
+  {% endif %}
+{% endif %}
+
+{% if values.bitcoin.i2p_outgoing_enabled or values.bitcoin.i2p_incoming_enabled %}
+  {% if not values.bitcoin.i2p_ip %}
+    {% do tpl.funcs.fail("Bitcoin I2P IP is required with the given configuration.") %}
+  {% endif %}
+
+  {% if not values.bitcoin.i2p_port %}
+    {% do tpl.funcs.fail("Bitcoin I2P Port is required with the given configuration.") %}
+  {% endif %}
+{% endif %}
+
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
 {% set perm_config = {"uid": values.consts.run_as_user, "gid": values.consts.run_as_group, "mode": "check"} %}
 

--- a/ix-dev/community/bitcoind/templates/docker-compose.yaml
+++ b/ix-dev/community/bitcoind/templates/docker-compose.yaml
@@ -2,23 +2,13 @@
 {% set tpl = ix_lib.base.render.Render(values) %}
 
 {% if values.bitcoin.tor_outgoing_enabled or values.bitcoin.tor_incoming_enabled or values.bitcoin.clearnet_outgoing_via_tor_enabled %}
-  {% if not values.bitcoin.tor_ip %}
-    {% do tpl.funcs.fail("Bitcoin Tor IP is required with the given configuration.") %}
-  {% endif %}
-
-  {% if not values.bitcoin.tor_port %}
-    {% do tpl.funcs.fail("Bitcoin Tor Port is required with the given configuration.") %}
-  {% endif %}
+  {% if not values.bitcoin.tor_ip %}{% do tpl.funcs.fail("Tor IP is required with the given configuration.") %}{% endif %}
+  {% if not values.bitcoin.tor_port %}{% do tpl.funcs.fail("Tor Port is required with the given configuration.") %}{% endif %}
 {% endif %}
 
 {% if values.bitcoin.i2p_outgoing_enabled or values.bitcoin.i2p_incoming_enabled %}
-  {% if not values.bitcoin.i2p_ip %}
-    {% do tpl.funcs.fail("Bitcoin I2P IP is required with the given configuration.") %}
-  {% endif %}
-
-  {% if not values.bitcoin.i2p_port %}
-    {% do tpl.funcs.fail("Bitcoin I2P Port is required with the given configuration.") %}
-  {% endif %}
+  {% if not values.bitcoin.i2p_ip %}{% do tpl.funcs.fail("I2P IP is required with the given configuration.") %}{% endif %}
+  {% if not values.bitcoin.i2p_port %}{% do tpl.funcs.fail("I2P Port is required with the given configuration.") %}{% endif %}
 {% endif %}
 
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}

--- a/ix-dev/community/bitcoind/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/bitcoind/templates/test_values/basic-values.yaml
@@ -5,7 +5,6 @@ resources:
 TZ: UTC
 
 bitcoin:
-  rpc_enabled: true
   rpc_user: truenas
   rpc_password: truenas
   rpc_work_queue_size: 128


### PR DESCRIPTION
@Keeqler While I found the correct syntax, UI currently does not take `OR` into account.
Removed the show_if completely, and shifted the validation to jinja.

For future ref, this is the correct format

```yaml
show_if:
  - - OR
    - - ["tor_outgoing_enabled", "=", true]
      - ["clearnet_outgoing_via_tor_enabled", "=", true]
      - ["tor_incoming_enabled", "=", true]
```