### PR TITLE
Add back custom user for playwright

### DIFF
--- a/ix-dev/community/playwright/app.yaml
+++ b/ix-dev/community/playwright/app.yaml
@@ -36,4 +36,4 @@ sources:
 - https://mcr.microsoft.com/en-us/artifact/mar/playwright
 title: Playwright
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/playwright/questions.yaml
+++ b/ix-dev/community/playwright/questions.yaml
@@ -74,6 +74,29 @@ questions:
                         type: string
                         required: true
 
+  - variable: run_as
+    label: ""
+    group: User and Group Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: user
+          label: User ID
+          description: The user id that Playwright files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+        - variable: group
+          label: Group ID
+          description: The group id that Playwright files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+
   - variable: network
     label: ""
     group: Network Configuration


### PR DESCRIPTION
Fix for playwright questions missing customer user entry.  I had removed it due to requiring npm cache to be overridden in order to use a user_id other than pwuser (1001).  That configuration was included in the final app design but missed adding back custom user entry.