### PR TITLE
Allow bind mode for DNS listening

### DIFF
--- a/ix-dev/stable/pihole/app.yaml
+++ b/ix-dev/stable/pihole/app.yaml
@@ -57,4 +57,4 @@ sources:
 - https://github.com/pi-hole/docker-pi-hole
 title: Pi-hole
 train: stable
-version: 1.2.25
+version: 1.2.26

--- a/ix-dev/stable/pihole/questions.yaml
+++ b/ix-dev/stable/pihole/questions.yaml
@@ -154,6 +154,8 @@ questions:
             enum:
               - value: "single"
                 description: Single
+              - value: "bind"
+                description: Bind 
               - value: "all"
                 description: All
         - variable: dhcp_config

--- a/ix-dev/stable/pihole/questions.yaml
+++ b/ix-dev/stable/pihole/questions.yaml
@@ -150,6 +150,7 @@ questions:
           schema:
             type: string
             default: "single"
+            show_if: [["host_network", "=", true], ["interface_name", "!=", ""]]
             required: true
             enum:
               - value: "single"


### PR DESCRIPTION
Bind mode was missing.
There is some kind of conflict now that there is some dnsmasq using port 53 on libvirt bridges. I guess that's related to incus integration.
Bind mode allows pi-hole to start its dnsmas on a specific interface. pi-hole container can now work on 25.04.