### PR TITLE
Fix Newt user+group

### DIFF
--- a/ix-dev/community/newt/app.yaml
+++ b/ix-dev/community/newt/app.yaml
@@ -34,4 +34,4 @@ sources:
 - https://hub.docker.com/r/fosrl/newt
 title: Newt
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/newt/templates/docker-compose.yaml
+++ b/ix-dev/community/newt/templates/docker-compose.yaml
@@ -4,7 +4,7 @@
 {# FIXME: https://github.com/fosrl/newt/issues/31 #}
 {% do c1.healthcheck.set_custom_test("pgrep newt") %}
 
-{% do c1.set_user(values.run_as.user, values.run_as.group) %}
+{% do c1.set_user(568, 568) %}
 
 {% do c1.environment.add_env("PANGOLIN_ENDPOINT", values.newt.pangolin_endpoint) %}
 {% do c1.environment.add_env("NEWT_ID", values.newt.newt_id) %}


### PR DESCRIPTION
This is not exposed as a variable in the UI and also doesn't make sense to expose.

Without setting it here creation fails with: jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'run_as'