### PR TITLE
Enforce nextcloud nginx port

### DIFF
--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -113,9 +113,8 @@ questions:
           description: |
             Nextcloud host to create application URLs</br>
             Examples: </br>
-            cloud.domain.com:30001</br>
-            cloud.domain.com (if you use port 443 externally)</br>
-            192.168.1.100:9001 (replace ip and port with your own)</br></br>
+            cloud.domain.com</br>
+            192.168.1.100 (replace with your own ip)</br></br>
             This will be appended to the trusted domains list, but changing that will not remove it from the list.</br>
           schema:
             type: string
@@ -294,24 +293,26 @@ questions:
                   min: 30
                   default: 60
                   required: true
-              - variable: use_different_port
-                label: Use different port for URL rewrites
-                description: |
-                  If enabled, the URL rewrite will use [Access Port] defined below instead of the [Node Port].</br>
-                  Note that Nextcloud will still listen on the [Node Port]. (Default 9001)
-                schema:
-                  type: boolean
-                  default: false
+              # - variable: use_different_port
+              #   label: Use different port for URL rewrites
+                # description: |
+                #   If enabled, the URL rewrite will use [Access Port] defined below instead of the [Node Port].</br>
+                #   Note that Nextcloud will still listen on the [Node Port]. (Default 9001)
+              #   schema:
+              #     type: boolean
+              #     default: false
               - variable: external_port
                 label: External Port
-                description: The external port for Nginx.
+                description: |
+                  The external port for Nginx.
+                  Note that Nextcloud will still listen on the [Node Port]. (Default 9001)
                 schema:
                   type: int
-                  default: 443
+                  default: 30027 # 443 used by host
                   min: 443
                   max: 65535
-                  show_if: [["use_different_port", "=", true]]
-                  required: true
+                  # show_if: [["use_different_port", "=", true]]
+                  # required: true
               - variable: custom_confs
                 label: Custom Nginx Configurations
                 description: List of custom Nginx configurations.

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -117,7 +117,7 @@
   {% do nc_env.x.append(("OVERWRITEPROTOCOL", "https")) %}
   {% do nc_env.x.append(("TRUSTED_PROXIES", ["127.0.0.1", "192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"] | join(" "))) %}
   {% do nc_confs.append(("logformat.conf", use_x_real_ip_in_logs(), "/etc/apache2/conf-enabled/logformat.conf", "")) %}
-  {% if values.nextcloud.host and values.network.nginx.use_different_port %}
+  {% if values.nextcloud.host %}
     {% set host.x = "%s:%d"|format(values.nextcloud.host, values.network.nginx.external_port) %}
     {% do nc_env.x.append(("OVERWRITEHOST", host.x)) %}
   {% endif %}


### PR DESCRIPTION
Use nginx port instead host port for https access (host port ignored by nginx config)