### PR TITLE
renovate: fix config

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -277,7 +277,7 @@ module.exports = {
     ),
     customVersioning(
       // stable-e043ecf
-      "^stable-(?<build>[a-z0-9]+)$",
+      "^stable-(?<patch>[Z]?)(?<build>[a-z0-9]{7})$",
       ["ghcr.io/toeverything/affine-graphql"]
     ),
     customVersioning(


### PR DESCRIPTION
At least 1 semver group is required.
I've added one that is optional (and wont match ever) just to work around it