### PR TITLE
add directus to the catalog of truenas apps

### DIFF
--- a/ix-dev/community/directus/README.md
+++ b/ix-dev/community/directus/README.md
@@ -1,0 +1,3 @@
+# Plex Auto Languages
+
+[Directus](https://github.com/directus/directus) is a real-time API and App dashboard for managing SQL database content.

--- a/ix-dev/community/directus/app.yaml
+++ b/ix-dev/community/directus/app.yaml
@@ -1,0 +1,32 @@
+app_version: 11.8.0
+capabilities: []
+categories:
+- media
+date_added: '2025-05-30'
+description: Directus is a real-time API and App dashboard for managing SQL database content.
+home: https://directus.io/
+host_mounts: []
+icon: https://media.sys.truenas.net/apps/directus/icons/icon.svg # change?
+keywords:
+- directus
+lib_version: 2.1.16
+lib_version_hash: dac15686f882b9ce65b8549a3d5c0ed7bafe2df7a9028880d1a99b0ff4af1eff
+maintainers:
+- email: dev@ixsystems.com
+  name: truenas
+  url: https://www.truenas.com/
+name: directus
+run_as_context:
+- description: Directus runs as any non-root user.
+  gid: 568
+  group_name: directus
+  uid: 568
+  user_name: directus
+screenshots: []
+sources:
+- https://github.com/directus/directus
+- https://directus.io/
+- https://directus.io/docs/
+title: Directus
+train: community
+version: 1.0.0

--- a/ix-dev/community/directus/item.yaml
+++ b/ix-dev/community/directus/item.yaml
@@ -1,0 +1,6 @@
+categories:
+- media
+icon_url: https://media.sys.truenas.net/apps/directus/icons/icon.svg
+screenshots: []
+tags:
+- directus

--- a/ix-dev/community/directus/ix_values.yaml
+++ b/ix-dev/community/directus/ix_values.yaml
@@ -1,0 +1,7 @@
+images:
+  image:
+    repository: ghcr.io/directus/directus
+    tag: 11.8.0
+
+consts:
+  directus_container_name: directus

--- a/ix-dev/community/directus/questions.yaml
+++ b/ix-dev/community/directus/questions.yaml
@@ -1,0 +1,593 @@
+groups:
+  - name: Directus Configuration
+    description: Configure Directus
+  - name: User and Group Configuration
+    description: Configure User and Group for Directus
+  - name: Network Configuration
+    description: Configure Network for Directus
+  - name: Storage Configuration
+    description: Configure Storage for Directus
+  - name: Labels Configuration
+    description: Configure Labels for Directus
+  - name: Resources Configuration
+    description: Configure Resources for Directus
+
+questions:
+  - variable: TZ
+    group: Directus Configuration
+    label: Timezone
+    schema:
+      type: string
+      default: "Etc/UTC"
+      required: true
+      $ref:
+        - "definitions/timezone"
+
+  - variable: directus
+    label: ""
+    group: Directus Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: SECRET
+          label: Secret Key
+          description: |
+            Secret key for Directus. This should be a secure random value.</br>
+            Used for generating tokens and encrypting data.
+          schema:
+            type: string
+            required: true
+            private: true
+            default: "replace-with-secure-random-value"
+        - variable: ADMIN_EMAIL
+          label: Admin Email
+          description: Email address for the initial admin user.
+          schema:
+            type: string
+            required: true
+            default: "admin@example.com"
+        - variable: ADMIN_PASSWORD
+          label: Admin Password
+          description: Password for the initial admin user.
+          schema:
+            type: string
+            required: true
+            private: true
+            default: "d1r3ctu5"
+        - variable: DB_CLIENT
+          label: Database Client
+          description: Database client to use for Directus.
+          schema:
+            type: string
+            required: true
+            default: "sqlite3"
+            enum:
+              - value: "sqlite3"
+                description: SQLite
+              - value: "mysql"
+                description: MySQL
+              - value: "pg"
+                description: PostgreSQL
+        - variable: DB_FILENAME
+          label: Database Filename
+          description: Filename for the SQLite database (only used when DB_CLIENT is sqlite3).
+          schema:
+            type: string
+            required: true
+            default: "/app/database/data.db"
+            show_if: [["DB_CLIENT", "=", "sqlite3"]]
+        - variable: WEBSOCKETS_ENABLED
+          label: Enable WebSockets
+          description: Enable WebSockets for real-time updates.
+          schema:
+            type: boolean
+            default: true
+        - variable: additional_envs
+          label: Additional Environment Variables
+          description: Configure additional environment variables for Directus.
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: env
+                label: Environment Variable
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: Name
+                      schema:
+                        type: string
+                        required: true
+                    - variable: value
+                      label: Value
+                      schema:
+                        type: string
+                        required: true
+
+  - variable: run_as
+    label: ""
+    group: User and Group Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: user
+          label: User ID
+          description: The user id that Directus files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+        - variable: group
+          label: Group ID
+          description: The group id that Directus files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+
+  - variable: network
+    label: ""
+    group: Network Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: web_port
+          label: Web Port
+          description: Port for Directus web interface.
+          schema:
+            type: int
+            default: 8080
+            min: 9000
+            max: 65535
+            required: true
+        - variable: host_network
+          label: Host Network
+          description: |
+            Bind to the host network. It's recommended to keep this disabled.
+          schema:
+            type: boolean
+            default: false
+
+  - variable: storage
+    label: ""
+    group: Storage Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: database
+          label: Directus Database Storage
+          description: The path to store Directus Database.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  immutable: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "database"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: uploads
+          label: Directus Uploads Storage
+          description: The path to store Directus uploads and media files.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  immutable: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "uploads"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: extensions
+          label: Directus Extensions Storage
+          description: The path to store Directus extensions.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  immutable: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "extensions"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: additional_storage
+          label: Additional Storage
+          description: Additional storage for Directus.
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: storageEntry
+                label: Storage Entry
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: type
+                      label: Type
+                      description: |
+                        ixVolume: Is dataset created automatically by the system.</br>
+                        Host Path: Is a path that already exists on the system.</br>
+                        SMB Share: Is a SMB share that is mounted to as a volume.
+                      schema:
+                        type: string
+                        required: true
+                        default: "ix_volume"
+                        immutable: true
+                        enum:
+                          - value: "host_path"
+                            description: Host Path (Path that already exists on the system)
+                          - value: "ix_volume"
+                            description: ixVolume (Dataset created automatically by the system)
+                          - value: "cifs"
+                            description: SMB/CIFS Share (Mounts a volume to a SMB share)
+                    - variable: read_only
+                      label: Read Only
+                      description: Mount the volume as read only.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: mount_path
+                      label: Mount Path
+                      description: The path inside the container to mount the storage.
+                      schema:
+                        type: path
+                        required: true
+                    - variable: host_path_config
+                      label: Host Path Configuration
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "host_path"]]
+                        attrs:
+                          - variable: acl_enable
+                            label: Enable ACL
+                            description: Enable ACL for the storage.
+                            schema:
+                              type: boolean
+                              default: false
+                          - variable: acl
+                            label: ACL Configuration
+                            schema:
+                              type: dict
+                              show_if: [["acl_enable", "=", true]]
+                              attrs: []
+                              $ref:
+                                - "normalize/acl"
+                          - variable: path
+                            label: Host Path
+                            description: The host path to use for storage.
+                            schema:
+                              type: hostpath
+                              show_if: [["acl_enable", "=", false]]
+                              required: true
+                    - variable: ix_volume_config
+                      label: ixVolume Configuration
+                      description: The configuration for the ixVolume dataset.
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "ix_volume"]]
+                        $ref:
+                          - "normalize/ix_volume"
+                        attrs:
+                          - variable: acl_enable
+                            label: Enable ACL
+                            description: Enable ACL for the storage.
+                            schema:
+                              type: boolean
+                              default: false
+                          - variable: dataset_name
+                            label: Dataset Name
+                            description: The name of the dataset to use for storage.
+                            schema:
+                              type: string
+                              required: true
+                              immutable: true
+                              default: "storage_entry"
+                          - variable: acl_entries
+                            label: ACL Configuration
+                            schema:
+                              type: dict
+                              show_if: [["acl_enable", "=", true]]
+                              attrs: []
+                              $ref:
+                                - "normalize/acl"
+                    - variable: cifs_config
+                      label: SMB Configuration
+                      description: The configuration for the SMB dataset.
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "cifs"]]
+                        attrs:
+                          - variable: server
+                            label: Server
+                            description: The server to mount the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                          - variable: path
+                            label: Path
+                            description: The path to mount the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                          - variable: username
+                            label: Username
+                            description: The username to use for the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                          - variable: password
+                            label: Password
+                            description: The password to use for the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                              private: true
+                          - variable: domain
+                            label: Domain
+                            description: The domain to use for the SMB share.
+                            schema:
+                              type: string
+
+  - variable: labels
+    label: ""
+    group: Labels Configuration
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: label
+          label: Label
+          schema:
+            type: dict
+            attrs:
+              - variable: key
+                label: Key
+                schema:
+                  type: string
+                  required: true
+              - variable: value
+                label: Value
+                schema:
+                  type: string
+                  required: true
+              - variable: containers
+                label: Containers
+                description: Containers where the label should be applied
+                schema:
+                  type: list
+                  items:
+                    - variable: container
+                      label: Container
+                      schema:
+                        type: string
+                        required: true
+                        enum:
+                          - value: directus
+                            description: directus
+
+  - variable: resources
+    label: ""
+    group: Resources Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: limits
+          label: Limits
+          schema:
+            type: dict
+            attrs:
+              - variable: cpus
+                label: CPUs
+                description: CPUs limit for Directus.
+                schema:
+                  type: int
+                  default: 2
+                  required: true
+              - variable: memory
+                label: Memory (in MB)
+                description: Memory limit for Directus.
+                schema:
+                  type: int
+                  default: 4096
+                  required: true

--- a/ix-dev/community/directus/templates/docker-compose.yaml
+++ b/ix-dev/community/directus/templates/docker-compose.yaml
@@ -1,0 +1,26 @@
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{% set c1 = tpl.add_container(values.consts.directus_container_name, "image") %}
+
+{% do c1.set_user(0, 0) %}
+{% do c1.add_storage("/app/database", values.storage.database) %}
+{% do c1.add_storage("/app/uploads", values.storage.uploads) %}
+{% do c1.add_storage("/app/extensions", values.storage.extensions) %}
+
+{% do c1.healthcheck.set_test("curl", {"port": values.network.web_port, "path": "/admin"}) %}
+
+{% do c1.environment.add_env("CONTAINERIZED", true) %}
+{% do c1.environment.add_env("SECRET", values.directus.SECRET) %}
+{% do c1.environment.add_env("ADMIN_EMAIL", values.directus.ADMIN_EMAIL) %}
+{% do c1.environment.add_env("ADMIN_PASSWORD", values.directus.ADMIN_PASSWORD) %}
+{% do c1.environment.add_env("DB_CLIENT", values.directus.DB_CLIENT) %}
+{% do c1.environment.add_env("DB_FILENAME", values.directus.DB_FILENAME) %}
+{% do c1.environment.add_env("WEBSOCKETS_ENABLED", values.directus.WEBSOCKETS_ENABLED) %}
+{% do c1.environment.add_env("PORT", values.network.web_port) %}
+{% do c1.environment.add_user_envs(values.directus.additional_envs) %}
+
+{% do c1.ports.add_port(values.network.web_port, values.network.web_port) %}
+
+{% do tpl.portals.add_portal({"port": values.network.web_port}) %}
+
+{{ tpl.render() | tojson }}

--- a/ix-dev/community/directus/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/directus/templates/test_values/basic-values.yaml
@@ -1,0 +1,40 @@
+resources:
+  limits:
+    cpus: 2.0
+    memory: 4096
+
+directus:
+  SECRET: "replace-with-secure-random-value"
+  ADMIN_EMAIL: "admin@example.com"
+  ADMIN_PASSWORD: "d1r3ctu5"
+  DB_CLIENT: "sqlite3"
+  DB_FILENAME: "/app/database/data.db"
+  WEBSOCKETS_ENABLED: "true"
+  additional_envs: []
+
+network:
+  web_port: 8080
+  host_network: false
+
+ix_volumes:
+  database: /opt/tests/mnt/database
+  uploads: /opt/tests/mnt/uploads
+  extensions: /opt/tests/mnt/extensions
+
+storage:
+  database:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: database
+      create_host_path: true
+  uploads:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: uploads
+      create_host_path: true
+  extensions:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: extensions
+      create_host_path: true
+  additional_storage: []


### PR DESCRIPTION
## New Community App: Directus
I've been wanting to use TrueNAS to deploy Directus. I tried my best going through the [contributors guide](https://github.com/truenas/apps/blob/master/CONTRIBUTIONS.md). Here's what works: `./.github/scripts/ci.py --app directus --train community --test-file basic-values.yaml --wait=true`

But I wasn't able to test that my questions.yaml is correct. I couldn't find a way to test this, other than manually examining the YAML by hand. If there is a way, please let me know and I can do the verification. Ideally, if I could get the same screen on TrueNAS Scale when I am about to deploy the new app, that would be nice.

I also wasn't sure about the `icon` field in the `app.yaml`, and how that gets populated. And, I'm also not certain how to load images.

Additionally, do I have to commit the copied `templates/libary` files?