### PR TITLE
Gramps: Mount /.cache as a temp volume to allow usage of ML

### DIFF
--- a/ix-dev/community/gramps-web/app.yaml
+++ b/ix-dev/community/gramps-web/app.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/gramps-project/gramps-web
 title: Gramps Web
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/gramps-web/app.yaml
+++ b/ix-dev/community/gramps-web/app.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/gramps-project/gramps-web
 title: Gramps Web
 train: community
-version: 1.0.3
+version: 1.0.4

--- a/ix-dev/community/gramps-web/questions.yaml
+++ b/ix-dev/community/gramps-web/questions.yaml
@@ -234,6 +234,83 @@ questions:
                         type: hostpath
                         show_if: [["acl_enable", "=", false]]
                         required: true
+        - variable: cache
+          label: Gramps Web Cache Storage
+          description: Stores cache files, like ML models.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "cache"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
         - variable: additional_storage
           label: Additional Storage
           description: Additional storage for Gramps Web.

--- a/ix-dev/community/gramps-web/templates/docker-compose.yaml
+++ b/ix-dev/community/gramps-web/templates/docker-compose.yaml
@@ -50,7 +50,7 @@
 
   {% do c.add_storage(values.consts.data_path, values.storage.data) %}
   {% do c.add_storage("/tmp", tmp_config) %}
-  {% do instance.add_storage("/.cache", tpl.funcs.temp_config("temp-config")) %}
+  {% do c.add_storage("/.cache", cache_config) %}
 
   {% for store in values.storage.additional_storage %}
     {% do c.add_storage(store.mount_path, store) %}

--- a/ix-dev/community/gramps-web/templates/docker-compose.yaml
+++ b/ix-dev/community/gramps-web/templates/docker-compose.yaml
@@ -8,7 +8,6 @@
 {% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
 
 {% set tmp_config = {"type": "temporary", "volume_config": {"volume_name": "tmp-gramps"}} %}
-{% set cache_config = {"type": "temporary", "volume_config": {"volume_name": "tmp-cache-gramps"}} %}
 
 {% set redis_config = {
   "password": values.gramps.redis_password,
@@ -49,8 +48,8 @@
   {% do c.environment.add_user_envs(values.gramps.additional_envs) %}
 
   {% do c.add_storage(values.consts.data_path, values.storage.data) %}
+  {% do c.add_storage("/.cache", values.storage.cache) %}
   {% do c.add_storage("/tmp", tmp_config) %}
-  {% do c.add_storage("/.cache", cache_config) %}
 
   {% for store in values.storage.additional_storage %}
     {% do c.add_storage(store.mount_path, store) %}
@@ -58,7 +57,7 @@
 {% endfor %}
 
 {% do perm_container.add_or_skip_action("data", values.storage.data, perms_config) %}
-{% do perm_container.add_or_skip_action("tmp-cache-gramps", cache_config, perms_config) %}
+{% do perm_container.add_or_skip_action("cache", values.storage.cache, perms_config) %}
 {% do perm_container.add_or_skip_action("tmp-gramps", tmp_config, perms_config) %}
 
 {% for store in values.storage.additional_storage %}

--- a/ix-dev/community/gramps-web/templates/docker-compose.yaml
+++ b/ix-dev/community/gramps-web/templates/docker-compose.yaml
@@ -8,6 +8,7 @@
 {% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
 
 {% set tmp_config = {"type": "temporary", "volume_config": {"volume_name": "tmp-gramps"}} %}
+{% set cache_config = {"type": "temporary", "volume_config": {"volume_name": "tmp-cache-gramps"}} %}
 
 {% set redis_config = {
   "password": values.gramps.redis_password,
@@ -49,6 +50,7 @@
 
   {% do c.add_storage(values.consts.data_path, values.storage.data) %}
   {% do c.add_storage("/tmp", tmp_config) %}
+  {% do instance.add_storage("/.cache", tpl.funcs.temp_config("temp-config")) %}
 
   {% for store in values.storage.additional_storage %}
     {% do c.add_storage(store.mount_path, store) %}
@@ -56,6 +58,7 @@
 {% endfor %}
 
 {% do perm_container.add_or_skip_action("data", values.storage.data, perms_config) %}
+{% do perm_container.add_or_skip_action("tmp-cache-gramps", cache_config, perms_config) %}
 {% do perm_container.add_or_skip_action("tmp-gramps", tmp_config, perms_config) %}
 
 {% for store in values.storage.additional_storage %}

--- a/ix-dev/community/gramps-web/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/gramps-web/templates/test_values/basic-values.yaml
@@ -19,11 +19,17 @@ run_as:
 
 ix_volumes:
   data: /opt/tests/mnt/data
+  cache: /opt/tests/mnt/cache
 
 storage:
   data:
     type: ix_volume
     ix_volume_config:
       dataset_name: data
+      create_host_path: true
+  cache:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: cache
       create_host_path: true
   additional_storage: []


### PR DESCRIPTION
Gramps web allows running Machine Learning models within the container. It stores the models in a ./cache folder, which is not accessible when not run as a root. This PR mounts the ./cache folder as a temp volume and lets our permissions container take care of fixing the permissions of the directory.

Things to consider:
What is the lifetime of the temporary volume? Is it cleared on every reboot or duing container updates? If it gets cleared on every container reboot, we might want a different approach for this solution as models can be sometimes quire large. Clearing it on container updates seems right to me as a new update might include updated models and might not dispose of the old ones properly resulting in larger space being used.

closes: #2433 