### PR TITLE
feat(scrutiny): Add default InfluxDB credentials to notes body

### DIFF
--- a/ix-dev/community/scrutiny/app.yaml
+++ b/ix-dev/community/scrutiny/app.yaml
@@ -65,4 +65,4 @@ sources:
 - https://github.com/AnalogJ/scrutiny
 title: Scrutiny
 train: community
-version: 1.2.3
+version: 1.2.4

--- a/ix-dev/community/scrutiny/ix_values.yaml
+++ b/ix-dev/community/scrutiny/ix_values.yaml
@@ -8,3 +8,7 @@ consts:
   config_dir: /opt/scrutiny/config
   internal_influxdb_port: 8086
   internal_web_port: 8080
+  notes_body: |
+    Default InfluxDB Credentials:
+    - Username: admin
+    - Password: password12345

--- a/ix-dev/community/scrutiny/templates/docker-compose.yaml
+++ b/ix-dev/community/scrutiny/templates/docker-compose.yaml
@@ -49,4 +49,6 @@
 {% do tpl.portals.add(values.network.web_port, {"port": values.consts.internal_web_port if values.network.host_network else None}) %}
 {% do tpl.portals.add(values.network.influxdb_port, {"name": "InfluxDB", "port": values.consts.internal_influxdb_port if values.network.host_network else None}) %}
 
+{% do tpl.notes.set_body(values.consts.notes_body) %}
+
 {{ tpl.render() | tojson }}


### PR DESCRIPTION
Added default influxDB credentials to the notes body.

BTW, i tried setting the influxdb port binding to "Export port for inter-container communication" and I couldn't as the template wouldn't render. This is the case for the majority of the apps. Is this known, will this be mass-patched for all apps at once?