### PR TITLE
gramps: fix relation tree

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -120,6 +120,7 @@ words:
   - goipde
   - gotenberg
   - graalvm
+  - grampsdb
   - grampsweb
   - gunicorn
   - harverster

--- a/ix-dev/community/gramps-web/app.yaml
+++ b/ix-dev/community/gramps-web/app.yaml
@@ -21,11 +21,11 @@ maintainers:
   url: https://www.truenas.com/
 name: gramps-web
 run_as_context:
-- description: Gramps Web runs as any non-root user.
-  gid: 568
-  group_name: grampsweb
-  uid: 568
-  user_name: grampsweb
+- description: Gramps Web runs as root user.
+  gid: 0
+  group_name: root
+  uid: 0
+  user_name: root
 - description: Redis runs as a non-root user and root group.
   gid: 0
   group_name: root
@@ -36,4 +36,4 @@ sources:
 - https://github.com/gramps-project/gramps-web
 title: Gramps Web
 train: community
-version: 1.0.9
+version: 1.1.0

--- a/ix-dev/community/gramps-web/ix_values.yaml
+++ b/ix-dev/community/gramps-web/ix_values.yaml
@@ -12,4 +12,3 @@ consts:
   perms_container_name: permissions
   redis_container_name: redis
   internal_web_port: 5000
-  data_path: /root

--- a/ix-dev/community/gramps-web/ix_values.yaml
+++ b/ix-dev/community/gramps-web/ix_values.yaml
@@ -12,4 +12,4 @@ consts:
   perms_container_name: permissions
   redis_container_name: redis
   internal_web_port: 5000
-  data_path: /data
+  data_path: /root

--- a/ix-dev/community/gramps-web/questions.yaml
+++ b/ix-dev/community/gramps-web/questions.yaml
@@ -1,8 +1,6 @@
 groups:
   - name: Gramps Web Configuration
     description: Configure Gramps Web
-  - name: User and Group Configuration
-    description: Configure User and Group for Gramps Web
   - name: Network Configuration
     description: Configure Network for Gramps Web
   - name: Storage Configuration
@@ -78,29 +76,6 @@ questions:
                       schema:
                         type: string
 
-  - variable: run_as
-    label: ""
-    group: User and Group Configuration
-    schema:
-      type: dict
-      attrs:
-        - variable: user
-          label: User ID
-          description: The user id that Gramps Web files will be owned by.
-          schema:
-            type: int
-            min: 568
-            default: 568
-            required: true
-        - variable: group
-          label: Group ID
-          description: The group id that Gramps Web files will be owned by.
-          schema:
-            type: int
-            min: 568
-            default: 568
-            required: true
-
   - variable: network
     label: ""
     group: Network Configuration
@@ -162,9 +137,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: data
-          label: Gramps Web Data Storage
-          description: The path to store Gramps Web Data.
+        - variable: index
+          label: Index Storage
           schema:
             type: dict
             attrs:
@@ -206,7 +180,84 @@ questions:
                         required: true
                         immutable: true
                         hidden: true
-                        default: "data"
+                        default: "index"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: thumbnail_cache
+          label: Thumbnail Cache Storage
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  immutable: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "thumbnail_cache"
                     - variable: acl_entries
                       label: ACL Configuration
                       schema:
@@ -241,8 +292,7 @@ questions:
                         show_if: [["acl_enable", "=", false]]
                         required: true
         - variable: cache
-          label: Gramps Web Cache Storage
-          description: Stores cache files, like ML models.
+          label: Cache Storage
           schema:
             type: dict
             attrs:
@@ -254,6 +304,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ix_volume"
                   enum:
                     - value: "host_path"
@@ -284,6 +335,160 @@ questions:
                         immutable: true
                         hidden: true
                         default: "cache"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: media
+          label: Media Storage
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  immutable: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "media"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: grampsdb
+          label: Gramps Database Storage
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  immutable: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        immutable: true
+                        hidden: true
+                        default: "grampsdb"
                     - variable: acl_entries
                       label: ACL Configuration
                       schema:

--- a/ix-dev/community/gramps-web/templates/docker-compose.yaml
+++ b/ix-dev/community/gramps-web/templates/docker-compose.yaml
@@ -5,7 +5,6 @@
 {% set containers = [web, celery] %}
 
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
-{% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
 
 {% set tmp_config = {"type": "temporary", "volume_config": {"volume_name": "tmp-gramps"}} %}
 
@@ -23,24 +22,11 @@
 ]) %}
 
 {% for c in containers %}
-  {% do c.set_user(values.run_as.user, values.run_as.group) %}
-
   {% do c.depends.add_dependency(values.consts.redis_container_name, "service_healthy") %}
 
   {% do c.environment.add_env("GRAMPSWEB_TREE", "gramps") %}
   {% do c.environment.add_env("GRAMPSWEB_SECRET_KEY", values.gramps.app_key) %}
   {% do c.environment.add_env("GRAMPSWEB_DISABLE_TELEMETRY", values.gramps.disable_telemetry) %}
-
-  {% do c.environment.add_env("GRAMPSHOME", values.consts.data_path) %}
-  {% do c.environment.add_env("GRAMPSWEB_MEDIA_BASE_DIR", "%s/media"|format(values.consts.data_path)) %}
-  {% do c.environment.add_env("GRAMPSWEB_EXPORT_DIR", "%s/export"|format(values.consts.data_path)) %}
-  {% do c.environment.add_env("GRAMPSWEB_REPORT_DIR", "%s/report"|format(values.consts.data_path)) %}
-  {% do c.environment.add_env("GRAMPS_DATABASE_PATH", "%s/db"|format(values.consts.data_path)) %}
-
-  {% do c.environment.add_env("GRAMPSWEB_THUMBNAIL_CACHE_CONFIG__CACHE_DIR", "%s/thumbnail_cache"|format(values.consts.data_path)) %}
-
-  {% do c.environment.add_env("GRAMPSWEB_SEARCH_INDEX_DB_URI", "sqlite:///%s/search_index.sqlite"|format(values.consts.data_path)) %}
-  {% do c.environment.add_env("GRAMPSWEB_USER_DB_URI", "sqlite:///%s/users.sqlite"|format(values.consts.data_path)) %}
 
   {% do c.environment.add_env("GRAMPSWEB_CELERY_CONFIG__broker_url", "%s/0"|format(redis.get_url("redis"))) %}
   {% do c.environment.add_env("GRAMPSWEB_CELERY_CONFIG__result_backend", "%s/0"|format(redis.get_url("redis"))) %}
@@ -48,8 +34,11 @@
 
   {% do c.environment.add_user_envs(values.gramps.additional_envs) %}
 
-  {% do c.add_storage(values.consts.data_path, values.storage.data) %}
-  {% do c.add_storage("/.cache", values.storage.cache) %}
+  {% do c.add_storage("/app/indexdir", values.storage.index) %}
+  {% do c.add_storage("/app/thumbnail_cache", values.storage.thumbnail_cache) %}
+  {% do c.add_storage("/app/cache", values.storage.cache) %}
+  {% do c.add_storage("/root/.gramps/grampsdb", values.storage.grampsdb) %}
+  {% do c.add_storage("/app/media", values.storage.media) %}
   {% do c.add_storage("/tmp", tmp_config) %}
 
   {% for store in values.storage.additional_storage %}
@@ -57,22 +46,11 @@
   {% endfor %}
 {% endfor %}
 
-{% do perm_container.add_or_skip_action("data", values.storage.data, perms_config) %}
-{% do perm_container.add_or_skip_action("cache", values.storage.cache, perms_config) %}
-{% do perm_container.add_or_skip_action("tmp-gramps", tmp_config, perms_config) %}
-
-{% for store in values.storage.additional_storage %}
-  {% do perm_container.add_or_skip_action(store.mount_path, store, perms_config) %}
-{% endfor %}
-
 {% do web.add_port(values.network.web_port, {"container_port": values.consts.internal_web_port}) %}
 
 {% if perm_container.has_actions() %}
   {% do perm_container.activate() %}
   {% do redis.container.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
-  {% for c in containers %}
-    {% do c.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
-  {% endfor %}
 {% endif %}
 
 {% do tpl.portals.add(values.network.web_port) %}

--- a/ix-dev/community/gramps-web/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/gramps-web/templates/test_values/basic-values.yaml
@@ -14,23 +14,37 @@ network:
     bind_mode: published
     port_number: 8080
 
-run_as:
-  user: 568
-  group: 568
-
 ix_volumes:
-  data: /opt/tests/mnt/data
-  cache: /opt/tests/mnt/cache
+  index: /opt/tests/mnt/gramps/index
+  thumbnail_cache: /opt/tests/mnt/gramps/thumbnail_cache
+  cache: /opt/tests/mnt/gramps/cache
+  media: /opt/tests/mnt/gramps/media
+  grampsdb: /opt/tests/mnt/gramps/grampsdb
 
 storage:
-  data:
+  index:
     type: ix_volume
     ix_volume_config:
-      dataset_name: data
+      dataset_name: index
+      create_host_path: true
+  thumbnail_cache:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: thumbnail_cache
       create_host_path: true
   cache:
     type: ix_volume
     ix_volume_config:
       dataset_name: cache
+      create_host_path: true
+  media:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: media
+      create_host_path: true
+  grampsdb:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: grampsdb
       create_host_path: true
   additional_storage: []


### PR DESCRIPTION
Running non-root causes lots of issues, that there is no known way to fix/workaround without modifying upstream code.
This PR changes to using root user for this app and also keeps the directory structure as is from upstream.
This means that users have to re-install and configure the storage from scratch.

If their current app works or at least partly works, they can probably export data from within the app UI and re-import on new install

Fixes #2514 