### PR TITLE
immich: change "uploads" to "upload" in storage migration guide

### DIFF
--- a/ix-dev/community/immich/app.yaml
+++ b/ix-dev/community/immich/app.yaml
@@ -43,4 +43,4 @@ sources:
 - https://github.com/immich-app/immich
 title: Immich
 train: community
-version: 1.9.0
+version: 1.9.1

--- a/ix-dev/community/immich/ix_values.yaml
+++ b/ix-dev/community/immich/ix_values.yaml
@@ -43,6 +43,6 @@ consts:
     `/mnt/tank/immich/data` and `/mnt/tank/immich/postgres-data`
 
     Now inside the `/mnt/tank/immich/data` directory create the following directories (**NOT** datasets):
-    `mkdir -p /mnt/tank/immich/data/{uploads,thumbs,library,profile,backups,encoded-video}`
+    `mkdir -p /mnt/tank/immich/data/{upload,thumbs,library,profile,backups,encoded-video}`
     Then you have to move your data from the old separate dataset/directories to the new ones.
-    For example `/mnt/tank/old-immich-data/uploads` to `/mnt/tank/immich/data/uploads`.
+    For example `/mnt/tank/old-immich-data/upload` to `/mnt/tank/immich/data/upload`.


### PR DESCRIPTION
After following the storage migration from 1.9.0, the server did not start up at first. I saw the following error printed:

```
[Nest] 7  - 06/14/2025, 3:14:40 PM   ERROR [Microservices:StorageService] Failed to read upload/upload/.immich: Error: ENOENT: no such file or directory, open 'upload/upload/.immich'
```

I had made a subdirectory called `uploads` on my new unified dataset, but it seems like it was supposed to be named `upload` instead. Renaming it to `upload` fixed the problem so I think the example command here should be updated.

I haven't contributed here before so please let me know if something's wrong or I need to do anything else to enable this change.

edit: I just noticed there are two other comments in the issue confirming this is necessary:

- https://github.com/truenas/apps/issues/893#issuecomment-2972786480
- https://github.com/truenas/apps/issues/893#issuecomment-2973148128