### PR TITLE
immich: update vectorchord

### DIFF
--- a/ix-dev/community/immich/app.yaml
+++ b/ix-dev/community/immich/app.yaml
@@ -43,4 +43,4 @@ sources:
 - https://github.com/immich-app/immich
 title: Immich
 train: community
-version: 1.9.3
+version: 1.9.4

--- a/ix-dev/community/immich/ix_values.yaml
+++ b/ix-dev/community/immich/ix_values.yaml
@@ -16,7 +16,7 @@ images:
     tag: v1.135.0-openvino
   pgvecto_image:
     repository: ghcr.io/immich-app/postgres
-    tag: 15-vectorchord0.3.0-pgvectors0.2.0
+    tag: 15-vectorchord0.4.2-pgvectors0.2.0
   redis_image:
     repository: bitnami/redis
     tag: 8.0.2


### PR DESCRIPTION
According to immich release notes, it is recommended to update the vectorchord version. (not required though)

https://github.com/immich-app/immich/releases/tag/v1.135.0