### PR TITLE
Immich: Update vectorchor to 0.4.2

### DIFF
--- a/ix-dev/community/immich/ix_values.yaml
+++ b/ix-dev/community/immich/ix_values.yaml
@@ -16,7 +16,7 @@ images:
     tag: v1.135.0-openvino
   pgvecto_image:
     repository: ghcr.io/immich-app/postgres
-    tag: 15-vectorchord0.3.0-pgvectors0.2.0
+    tag: 15-vectorchord0.4.2-pgvectors0.2.0
   redis_image:
     repository: bitnami/redis
     tag: 8.0.2


### PR DESCRIPTION
As mentioned in https://github.com/immich-app/immich/releases/tag/v1.135.0, immich still supports vectorchord 0.3.0 but now defaults to 0.4.2.

Note that 0.4.3 is already available, and immich has started building images with it as well, but it hasn't been made the default version yet.