### PR TITLE
nginx-proxy-manager: revert to 2.12.3 due to upstream bug

### DIFF
--- a/ix-dev/community/nginx-proxy-manager/app.yaml
+++ b/ix-dev/community/nginx-proxy-manager/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: 2.12.4
+app_version: 2.12.3
 capabilities:
 - description: Nginx Proxy Manager is able to change file ownership arbitrarily
   name: CHOWN
@@ -46,4 +46,4 @@ sources:
 - https://hub.docker.com/r/jc21/nginx-proxy-manager
 title: Nginx Proxy Manager
 train: community
-version: 1.2.5
+version: 1.2.6

--- a/ix-dev/community/nginx-proxy-manager/ix_values.yaml
+++ b/ix-dev/community/nginx-proxy-manager/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: jc21/nginx-proxy-manager
-    tag: 2.12.4
+    tag: 2.12.3
 consts:
   npm_container_name: npm
   data_path: /data


### PR DESCRIPTION
resolves #2714 

I'm not sure if there's some way to pause updates for this file in CI.

https://github.com/NginxProxyManager/nginx-proxy-manager/issues/4629