### PR TITLE
Change FreshRSS healthcheck to /api/

### DIFF
--- a/ix-dev/community/freshrss/templates/docker-compose.yaml
+++ b/ix-dev/community/freshrss/templates/docker-compose.yaml
@@ -18,7 +18,7 @@
 {% do c1.set_user(0, 0) %}
 {% do c1.add_caps(["CHOWN", "SETGID", "SETUID"]) %}
 {% do c1.depends.add_dependency(values.consts.postgres_container_name, "service_healthy") %}
-{% do c1.healthcheck.set_test("http", {"port": values.network.web_port.port_number, "path": "/i/"}) %}
+{% do c1.healthcheck.set_test("http", {"port": values.network.web_port.port_number, "path": "/api/"}) %}
 
 {% do c1.environment.add_env("FRESHRSS_ENV", "production") %}
 {% do c1.environment.add_env("LISTEN", values.network.web_port.port_number) %}


### PR DESCRIPTION
`/api/` works with `OIDC_ENABLE=1` ([FreshRSS docs](https://freshrss.github.io/FreshRSS/en/admins/16_OpenID-Connect.html)), unlike `/i/` which will return HTTP 401

Fixes #1437 

```
2025-07-06 13:38:02.573366+00:00127.0.0.1 - - [06/Jul/2025:15:38:02 +0200] "GET /i/ HTTP/1.1" 401 381 "-" "-"
2025-07-06 13:38:06.590689+00:00127.0.0.1 - - [06/Jul/2025:15:38:06 +0200] "GET /api/ HTTP/1.1" 200 898 "-" "-"
```