### PR TITLE
feat(kasm): add update instructions to notes

### DIFF
--- a/ix-dev/community/kasm-workspaces/app.yaml
+++ b/ix-dev/community/kasm-workspaces/app.yaml
@@ -58,4 +58,4 @@ sources:
 - https://github.com/linuxserver/docker-kasm
 title: Kasm Workspaces
 train: community
-version: 1.0.10
+version: 1.0.11

--- a/ix-dev/community/kasm-workspaces/ix_values.yaml
+++ b/ix-dev/community/kasm-workspaces/ix_values.yaml
@@ -10,3 +10,6 @@ consts:
     Default users:
     - admin@kasm.local
     - user@kasm.local
+
+    Update notice: Updating the app itself is not enough to update Kasm,
+    please visit the Setup page in order to finish the update process.


### PR DESCRIPTION
Kasm doesn't update automatically and the update has to be manually installed via the setup page after successful container update.