### PR TITLE
octoprint: Fix mjpg-streamer arguments not being written into environment variables

### DIFF
--- a/ix-dev/community/octoprint/templates/docker-compose.yaml
+++ b/ix-dev/community/octoprint/templates/docker-compose.yaml
@@ -7,7 +7,7 @@
 {% do c1.environment.add_env("ENABLE_MJPG_STREAMER", values.octoprint.video_enable) %}
 {% if values.octoprint.video_enable %}
   {% do c1.environment.add_env("CAMERA_DEV", values.octoprint.video_device) %}
-  {% do c1.environment.add_env("MJPG_STREAMER_INPUT", values.octoprint.video_resolution) %}
+  {% do c1.environment.add_env("MJPG_STREAMER_INPUT", values.octoprint.mjpg_streamer_input) %}
 {% endif %}
 {% do c1.environment.add_user_envs(values.octoprint.additional_envs) %}
 

--- a/ix-dev/community/octoprint/templates/test_values/mjpg-streamer.yaml
+++ b/ix-dev/community/octoprint/templates/test_values/mjpg-streamer.yaml
@@ -1,0 +1,31 @@
+resources:
+  limits:
+    cpus: 2.0
+    memory: 4096
+
+TZ: Etc/UTC
+
+octoprint:
+  devices: 
+    - host_device: "/dev/random"
+      container_device: "/dev/video0"
+  video_enable: true
+  video_device: "/dev/video0"
+  mjpg_streamer_input: "-y -n -r 1920x1080"
+
+network:
+  host_network: false
+  web_port:
+    bind_mode: published
+    port_number: 34567
+
+ix_volumes:
+  octoprint-data: /opt/tests/mnt/octoprint-data
+
+storage:
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: octoprint-data
+      create_host_path: true
+  additional_storage: []


### PR DESCRIPTION
This PR fixes the mjpg-streamer argument variable (`values.octoprint.mjpg_streamer_input`) not being written into the environment variable (`MJPG_STREAMER_INPUT`). 

I've also added a test file (`mjpg-streamer.yaml`) that can be used to test the mjpg related settings. I've used `/dev/random` as the device on the host side for the test file so that the test container doesn't fail to start, even when no camera is attached to the host device.

This is my first PR for this project, let me know if further changes are required or if I need to provide more information.