### PR TITLE
Adds PEP 723 compliant inline metadata

### DIFF
--- a/.github/scripts/ci.py
+++ b/.github/scripts/ci.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pyyaml",
+# ]
+# ///
+
 import subprocess
 import argparse
 import pathlib

--- a/.github/scripts/generate_metadata.py
+++ b/.github/scripts/generate_metadata.py
@@ -6,6 +6,13 @@ This script analyzes Docker Compose configurations for TrueNAS apps and updates
 their metadata with capability requirements extracted from rendered templates.
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pyyaml",
+# ]
+# ///
+
 import os
 import re
 import sys

--- a/.github/scripts/port_validation.py
+++ b/.github/scripts/port_validation.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python3
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pyyaml",
+# ]
+# ///
+
 import sys
 import yaml
 


### PR DESCRIPTION
This is a convenience PR to add PEP-723 metadata to the scripts so that they can be directly invoked with the proper dependencies using a tool such as `uv run`, without needing to directly manage the python dependencies.  Since they're based upon comment syntax, tools which do not implement this (or direct invocation of the script) remain unaffected.

Reference:
https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata
https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies

I listed the Python version constraint as Python>=3.11 since that's what is on the current TrueNAS Scale stable release but I noticed a couple of things have been bumped to 3.13 -- let me know if I should make that change here in advance of an upcoming release.
