### PR TITLE
Small tweaks to Gramps Web config

### DIFF
--- a/ix-dev/community/gramps-web/questions.yaml
+++ b/ix-dev/community/gramps-web/questions.yaml
@@ -48,7 +48,6 @@ questions:
           description: |
             The secret app key for Gramps Web.</br>
             Must be at least 32 characters long.</br>
-            If not provided, a random key will be used.</br>
           schema:
             type: string
             min_length: 32

--- a/ix-dev/community/gramps-web/questions.yaml
+++ b/ix-dev/community/gramps-web/questions.yaml
@@ -36,22 +36,22 @@ questions:
             required: true
             private: true
         - variable: disable_telemetry
-          label: Disable Telemetry
+          label: Disable anonymous Telemetry
           description: |
-            Disable telemetry for Gramps Web.</br>
-            This will prevent Gramps Web from sending any telemetry data to the Gramps project.
+            Disable anonymous telemetry for Gramps Web.</br>
+            This will prevent Gramps Web from sending anonymous statistics data to the Gramps project.
           schema:
             type: boolean
             default: false
         - variable: app_key
           label: App Key
           description: |
-            The app key for Gramps Web.</br>
-            Must be exactly 32 characters long.</br>
+            The secret app key for Gramps Web.</br>
+            Must be at least 32 characters long.</br>
+            If not provided, a random key will be used.</br>
           schema:
             type: string
             min_length: 32
-            max_length: 32
             default: ""
             required: true
             private: true

--- a/trains/community/gramps-web/app_versions.json
+++ b/trains/community/gramps-web/app_versions.json
@@ -129,7 +129,6 @@
                                 "schema": {
                                     "type": "string",
                                     "min_length": 32,
-                                    "max_length": 32,
                                     "default": "",
                                     "required": true,
                                     "private": true


### PR DESCRIPTION
Hi,

I'm the maintainer of [Gramps Web](https://www.grampsweb.org/) and just installed TrueNAS. I love it so far and love even more that I found a Gramps Web community app.

Trying it out, I noticed two things in the setup that I am changing in this PR:

- The secret key is forced to be 32 characters in length. There is no reason to limit it to 32 characters, and in fact I need a longer value to migrate my deployment to TrueNAS. (Note: this is a normal Flaks secret key.) Consequently, I removed the upper limit, but left the lower limit at 32, to reduce the likelihood of users using something insecure.
- I find it very strange that the `DISABLE_TELEMETRY` option is the *only* configuration option that is exposed via the UI, while many much more important config options (like e-mail settings etc. - see [the full list](https://www.grampsweb.org/install_setup/configuration/)) can only be set via environment variables. It is explained [here](https://www.grampsweb.org/install_setup/telemetry/) that this telemetry is extremely limited and is needed by the Gramps Web project to estimate usage of free map tiles, among other things. Thus, there should be very little reason for users to disable it. Nevertheless, I left it as it is to not create the impression I am trying to force something on users. But I *did* change the wording adding "anonymous" to make it clear that this app is not spying on you even when you don't check the box.

I might add a contribution exposing more settings via UI later.