### PR TITLE
Adding Redis and WebUI Secret Key to OpenWebUI

### DIFF
--- a/ix-dev/community/open-webui/app.yaml
+++ b/ix-dev/community/open-webui/app.yaml
@@ -30,10 +30,15 @@ run_as_context:
   group_name: open-webui
   uid: 568
   user_name: open-webui
+- description: Redis runs as any non-root user.
+  gid: 568
+  group_name: redis
+  uid: 568
+  user_name: redis
 screenshots:
 - https://media.sys.truenas.net/apps/open-webui/screenshots/screenshot1.png
 sources:
 - https://github.com/open-webui/open-webui
 title: Open WebUI
 train: community
-version: 1.1.18
+version: 1.1.19

--- a/ix-dev/community/open-webui/ix_values.yaml
+++ b/ix-dev/community/open-webui/ix_values.yaml
@@ -8,7 +8,11 @@ images:
   cuda_image:
     repository: ghcr.io/open-webui/open-webui
     tag: 0.6.26-cuda
+  redis_image:
+    repository: valkey/valkey
+    tag: 8.1.3
 
 consts:
   open_webui_container_name: open-webui
+  redis_container_name: redis
   perms_container_name: permissions

--- a/ix-dev/community/open-webui/questions.yaml
+++ b/ix-dev/community/open-webui/questions.yaml
@@ -69,6 +69,13 @@ questions:
             default: ""
             private: true
             required: true
+        - variable: webui_secret_key
+          label: WebUI Secret Key
+          schema:
+            type: string
+            default: ""
+            private: true
+            required: true
         - variable: additional_envs
           label: Additional Environment Variables
           schema:

--- a/ix-dev/community/open-webui/questions.yaml
+++ b/ix-dev/community/open-webui/questions.yaml
@@ -62,6 +62,13 @@ questions:
             show_if: [["image_selector", "=", "image"]]
             private: true
             default: ""
+        - variable: redis_password
+          label: Redis Password
+          schema:
+            type: string
+            default: ""
+            private: true
+            required: true
         - variable: additional_envs
           label: Additional Environment Variables
           schema:
@@ -496,6 +503,8 @@ questions:
                         enum:
                           - value: open-webui
                             description: open-webui
+                          - value: redis
+                            description: redis
   - variable: resources
     label: ""
     group: Resources Configuration

--- a/ix-dev/community/open-webui/templates/docker-compose.yaml
+++ b/ix-dev/community/open-webui/templates/docker-compose.yaml
@@ -14,6 +14,7 @@
 {% do c1.environment.add_env("HOST", "0.0.0.0") %}
 {% do c1.environment.add_env("PORT", values.network.web_port.port_number) %}
 {% do c1.environment.add_env("REDIS_URL", redis.get_url("redis")) %}
+{% do c1.environment.add_env("WEBUI_SECRET_KEY", values.open_webui.webui_secret_key) %}
 {% if values.open_webui.openai_api_key %}{% do c1.environment.add_env("OPENAI_API_KEY", values.open_webui.openai_api_key) %}{% endif %}
 {% if values.open_webui.ollama_base_url %}{% do c1.environment.add_env("OLLAMA_BASE_URL", values.open_webui.ollama_base_url) %}{% endif %}
 

--- a/ix-dev/community/open-webui/templates/docker-compose.yaml
+++ b/ix-dev/community/open-webui/templates/docker-compose.yaml
@@ -4,12 +4,16 @@
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
 {% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
 
+{% set redis_config = {"password": values.open_webui.redis_password, "volume": tpl.funcs.temp_config("redis_data")} %}
+{% set redis = tpl.deps.redis(values.consts.redis_container_name, "redis_image", redis_config, perm_container) %}
+
 {% do c1.set_user(values.run_as.user, values.run_as.group) %}
 {% do c1.add_group(0) %}
 {% do c1.healthcheck.set_test("curl", {"port": values.network.web_port.port_number, "path": "/health"}) %}
 {% do c1.add_extra_host("host.docker.internal", "host-gateway") %}
 {% do c1.environment.add_env("HOST", "0.0.0.0") %}
 {% do c1.environment.add_env("PORT", values.network.web_port.port_number) %}
+{% do c1.environment.add_env("REDIS_URL", redis.get_url("redis")) %}
 {% if values.open_webui.openai_api_key %}{% do c1.environment.add_env("OPENAI_API_KEY", values.open_webui.openai_api_key) %}{% endif %}
 {% if values.open_webui.ollama_base_url %}{% do c1.environment.add_env("OLLAMA_BASE_URL", values.open_webui.ollama_base_url) %}{% endif %}
 

--- a/ix-dev/community/open-webui/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/open-webui/templates/test_values/basic-values.yaml
@@ -1,5 +1,6 @@
 open_webui:
   image_selector: ollama_image
+  redis_password: test
   additional_envs: []
 
 network:

--- a/ix-dev/community/open-webui/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/open-webui/templates/test_values/basic-values.yaml
@@ -1,6 +1,7 @@
 open_webui:
   image_selector: ollama_image
   redis_password: test
+  webui_secret_key: t0p-s3cr3t
   additional_envs: []
 
 network:


### PR DESCRIPTION
Hey,

with this PR i want to add
1. Redis Caching to OpenWebUI:
https://docs.openwebui.com/getting-started/env-configuration#redis

2. the Env. variable "WEBUI_SECRET_KEY" as an input variable. This variable overrides the randomly generated string used for JSON Web Token. In result the user can restore a login-session after OpenWebUI is restarted.
https://docs.openwebui.com/getting-started/env-configuration#webui_secret_key

I have also seen, that there is an Env. var to disable the update check in the app itself. I think this would make sense in this installation too, as updates only get pushed by this repo and not automatically upstream. I didn't implemented in this PR, as i don't know if this is deliberate.
https://docs.openwebui.com/getting-started/env-configuration#enable_version_update_check

Kind regards