### PR TITLE
FileFlows change to latest

### DIFF
--- a/ix-dev/community/fileflows/ix_values.yaml
+++ b/ix-dev/community/fileflows/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: revenz/fileflows
-    tag: "25.09"
+    tag: "latest"
 
 consts:
   fileflows_container_name: fileflows


### PR DESCRIPTION
Changed FileFlows to use latest tag, using a fix tag will eventually break and users will be confused why FileFlows stops working.