### PR TITLE
radarr: add WebUI SSL options

### DIFF
--- a/ix-dev/community/radarr/questions.yaml
+++ b/ix-dev/community/radarr/questions.yaml
@@ -131,6 +131,26 @@ questions:
                         required: true
                         $ref:
                           - definitions/node_bind_ip
+              - variable: ssl_enable
+                label: Enable SSL
+                description: Enable SSL for the WebUI.
+                schema:
+                  type: boolean
+                  default: false
+              - variable: ssl_cert_path
+                label: SSL Certificate Path
+                description: Path to the PKCS \#12 file.
+                schema:
+                  type: path
+                  show_if: [["ssl_enable", "=", true]]
+                  required: true
+              - variable: ssl_cert_password
+                label: SSL Certificate Password
+                description: Password of the PKCS \#12 file.
+                schema:
+                  type: string
+                  show_if: [["ssl_enable", "=", true]]
+                  private: true
         - variable: host_network
           label: Host Network
           description: |

--- a/ix-dev/community/radarr/templates/docker-compose.yaml
+++ b/ix-dev/community/radarr/templates/docker-compose.yaml
@@ -5,8 +5,19 @@
 {% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
 
 {% do c1.set_user(values.run_as.user, values.run_as.group) %}
-{% do c1.healthcheck.set_test("curl", {"port": values.network.web_port.port_number, "path": "/ping"}) %}
-{% do c1.environment.add_env("RADARR__SERVER__PORT", values.network.web_port.port_number) %}
+
+{% set scheme = "https" if values.network.web_port.ssl_enable else "http" %}
+{% do c1.healthcheck.set_test("curl", {"port": values.network.web_port.port_number, "path": "/ping", "scheme": scheme}) %}
+
+{% if values.network.web_port.ssl_enable %}
+  {% do c1.environment.add_env("RADARR__SERVER__ENABLESSL", "True") %}
+  {% do c1.environment.add_env("RADARR__SERVER__SSLPORT", values.network.web_port.port_number) %}
+  {% do c1.environment.add_env("RADARR__SERVER__SSLCERTPATH", values.network.web_port.ssl_cert_path) %}
+  {% do c1.environment.add_env("RADARR__SERVER__SSLCERTPASSWORD", values.network.web_port.ssl_cert_password) %}
+{% else %}
+  {% do c1.environment.add_env("RADARR__SERVER__PORT", values.network.web_port.port_number) %}
+{% endif %}
+
 {% do c1.environment.add_env("RADARR__APP__INSTANCENAME", values.radarr.instance_name) %}
 {% do c1.environment.add_user_envs(values.radarr.additional_envs) %}
 
@@ -25,6 +36,6 @@
   {% do c1.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
 {% endif %}
 
-{% do tpl.portals.add(values.network.web_port) %}
+{% do tpl.portals.add(values.network.web_port, {"scheme": scheme}) %}
 
 {{ tpl.render() | tojson }}


### PR DESCRIPTION
Hello

Can you consider integrating this change please?

This allows to configure the Radarr WebUI as HTTPS.

N.B: The PKCS 12 file is not provisioned automatically. The user must provide it separately, e.g. via a host mount.