### PR TITLE
node-red: remove deprecated images

### DIFF
--- a/ix-dev/community/node-red/app.yaml
+++ b/ix-dev/community/node-red/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: 4.1.0
+app_version: 4.1.0-18
 capabilities: []
 categories:
 - productivity
@@ -33,4 +33,4 @@ sources:
 - https://github.com/node-red/node-red-docker
 title: Node-RED
 train: community
-version: 1.2.12
+version: 1.3.0

--- a/ix-dev/community/node-red/ix_values.yaml
+++ b/ix-dev/community/node-red/ix_values.yaml
@@ -18,20 +18,6 @@ images:
     repository: nodered/node-red
     tag: 4.1.0-22-minimal
 
-  # TODO: Remove EOL images
-  node_16_image:
-    repository: nodered/node-red
-    tag: 3.1.15-16
-  node_16_minimal_image:
-    repository: nodered/node-red
-    tag: 3.1.15-16-minimal
-  node_14_image:
-    repository: nodered/node-red
-    tag: 3.1.15-14
-  node_14_minimal_image:
-    repository: nodered/node-red
-    tag: 3.1.15-14-minimal
-
 consts:
   node_red_container_name: node-red
   perms_container_name: permissions

--- a/ix-dev/community/node-red/questions.yaml
+++ b/ix-dev/community/node-red/questions.yaml
@@ -47,15 +47,6 @@ questions:
                 description: Node-RED on Node.js 22
               - value: "node_22_minimal_image"
                 description: Node-RED Minimal on Node.js 22
-              # TODO: Remove EOL images
-              - value: "node_16_image"
-                description: Node-RED on Node.js 16 (EOL - Deprecated)
-              - value: "node_16_minimal_image"
-                description: Node-RED Minimal on Node.js 16 (EOL - Deprecated)
-              - value: "node_14_image"
-                description: Node-RED on Node.js 14 (EOL - Deprecated)
-              - value: "node_14_minimal_image"
-                description: Node-RED Minimal on Node.js 14 (EOL - Deprecated)
         - variable: enable_safe_mode
           label: Enable Safe Mode
           description: |

--- a/ix-dev/community/node-red/templates/docker-compose.yaml
+++ b/ix-dev/community/node-red/templates/docker-compose.yaml
@@ -4,11 +4,6 @@
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
 {% set perm_config = {"uid": values.consts.run_user, "gid": values.consts.run_group, "mode": "check"} %}
 
-{% set img = values.node_red.image_selector %}
-{% if img.startswith("node_14") or img.startswith("node_16") %}
-  {% do tpl.notes.add_deprecation("You are using an image with EOL node version. Please update to a newer image, as the current image will be removed in a future release.") %}
-{% endif %}
-
 {% do c1.set_user(values.consts.run_user, values.consts.run_group) %}
 {% do c1.healthcheck.set_custom_test("NODE_OPTIONS=--dns-result-order=ipv4first node /healthcheck.js") %}
 


### PR DESCRIPTION
See #2691

No migration added, as we would like the user to not be able to upgrade until the configuration is updated to use a newer image.

Because there is no migration added, user will get an error that the image selected is not valid. Which should nudge the user to the right direction

---

DO NOT MERGE BEFORE October 3rd