### PR TITLE
unifi: expose L2 service discovery port

### DIFF
--- a/ix-dev/community/unifi-controller/app.yaml
+++ b/ix-dev/community/unifi-controller/app.yaml
@@ -33,4 +33,4 @@ sources:
 - https://hub.docker.com/r/goofball222/unifi
 title: Unifi Controller
 train: community
-version: 1.4.17
+version: 1.4.18

--- a/ix-dev/community/unifi-controller/questions.yaml
+++ b/ix-dev/community/unifi-controller/questions.yaml
@@ -342,6 +342,54 @@ questions:
                         required: true
                         $ref:
                           - definitions/node_bind_ip
+        - variable: service_discovery_port
+          label: Service Discovery Port
+          description: The port for service discovery.
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: ""
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 1900
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if: [["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: discovery_port
           label: Discovery Port
           description: The port for Unifi Controller Discovery

--- a/ix-dev/community/unifi-controller/templates/docker-compose.yaml
+++ b/ix-dev/community/unifi-controller/templates/docker-compose.yaml
@@ -16,6 +16,7 @@
 {% do c1.environment.add_env("DB_MONGO_LOCAL", true) %}
 {% do c1.environment.add_env("RUN_CHOWN", false) %}
 {% do c1.environment.add_env("RUNAS_UID0", false) %}
+{% do c1.environment.add_env("UNIFI_SERVICE_DISCOVERY_PORT", values.network.service_discovery_port.port_number) %}
 {% do c1.environment.add_env("UNIFI_STUN_PORT", values.network.stun_port.port_number) %}
 {% do c1.environment.add_env("UNIFI_HTTP_PORT", values.network.web_http_port.port_number) %}
 {% do c1.environment.add_env("UNIFI_HTTPS_PORT", values.network.web_https_port.port_number) %}
@@ -26,6 +27,7 @@
 
 {% if not values.network.host_network %}
   {% do c1.add_port(values.network.discovery_port, {"container_port": 10001, "protocol": "udp"}) %}
+  {% do c1.add_port(values.network.service_discovery_port, {"protocol": "udp"}) %}
   {% do c1.add_port(values.network.stun_port, {"protocol": "udp"}) %}
   {% do c1.add_port(values.network.web_https_port) %}
   {% do c1.add_port(values.network.portal_https_port) %}

--- a/ix-dev/community/unifi-controller/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/unifi-controller/templates/test_values/basic-values.yaml
@@ -30,6 +30,9 @@ network:
   stun_port:
     bind_mode: published
     port_number: 3478
+  service_discovery_port:
+    bind_mode: published
+    port_number: 1900
   certificate_id: null
 
 ix_volumes:

--- a/ix-dev/community/unifi-controller/templates/test_values/https-values.yaml
+++ b/ix-dev/community/unifi-controller/templates/test_values/https-values.yaml
@@ -30,6 +30,9 @@ network:
   stun_port:
     bind_mode: published
     port_number: 3478
+  service_discovery_port:
+    bind_mode: published
+    port_number: 1900
   certificate_id: "2"
 
 ix_volumes:


### PR DESCRIPTION
Add option to expose UDP traffic on port 1900 allowing for L2 discovery of the UniFi Controller.