### PR TITLE
fix(LibreChat): Update title from 'Chatwoot' to 'LibreChat'

### DIFF
--- a/ix-dev/community/librechat/app.yaml
+++ b/ix-dev/community/librechat/app.yaml
@@ -48,4 +48,4 @@ sources:
 - https://github.com/LibreChat/LibreChat
 title: LibreChat
 train: community
-version: 1.0.1
+version: 1.0.2


### PR DESCRIPTION
Fix a typo in the metadata
<img width="1089" height="420" alt="image" src="https://github.com/user-attachments/assets/a12a5a6d-d856-4efb-8217-12e4efc36485" />
