### PR TITLE
opencloud: allow starting extra services

### DIFF
--- a/ix-dev/community/opencloud/app.yaml
+++ b/ix-dev/community/opencloud/app.yaml
@@ -37,4 +37,4 @@ sources:
 - https://hub.docker.com/r/opencloudeu/opencloud-rolling
 title: OpenCloud
 train: community
-version: 1.0.13
+version: 1.0.14

--- a/ix-dev/community/opencloud/questions.yaml
+++ b/ix-dev/community/opencloud/questions.yaml
@@ -56,6 +56,20 @@ questions:
                 schema:
                   type: boolean
                   default: true
+        - variable: extra_services
+          label: Extra Services
+          description: |
+            A list of additional services to start in the same OpenCloud process.</br>
+            For example `collaboration`. Additional config may be required depending on the service.
+          schema:
+            type: list
+            items:
+              - variable: service
+                label: Service
+                schema:
+                  type: string
+                  default: ""
+                  required: true
         - variable: smtp
           label: SMTP
           schema:

--- a/ix-dev/community/opencloud/templates/docker-compose.yaml
+++ b/ix-dev/community/opencloud/templates/docker-compose.yaml
@@ -95,7 +95,11 @@
   {% endif %}
 {% endif %}
 
-{% do c1.environment.add_env("OC_ADD_RUN_SERVICES", extra_services.x | join(",")) %}
+{% if values.opencloud.additional_services %}
+  {% do extra_services.x.extend(values.opencloud.additional_services) %}
+{% endif %}
+
+{% do c1.environment.add_env("OC_ADD_RUN_SERVICES", extra_services.x | unique | list | join(",")) %}
 {% do c1.environment.add_env("IDM_ADMIN_PASSWORD", "admin") %}
 {% do c1.environment.add_user_envs(values.opencloud.additional_envs) %}
 

--- a/ix-dev/community/opencloud/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/opencloud/templates/test_values/basic-values.yaml
@@ -8,6 +8,7 @@ opencloud:
   insecure_access: true
   full_text_search:
     enabled: true
+  extra_services: []
   smtp:
     enabled: false
     sender: null

--- a/ix-dev/community/opencloud/templates/test_values/https-values.yaml
+++ b/ix-dev/community/opencloud/templates/test_values/https-values.yaml
@@ -8,6 +8,7 @@ opencloud:
   insecure_access: true
   full_text_search:
     enabled: true
+  extra_services: []
   smtp:
     enabled: false
     sender: null


### PR DESCRIPTION
Allow starting extra services by the opencloud process, so users can configure things like Collaboration.
While it would be nice to automatically set it up, OpenCloud requires a `csp.yaml` file, that is used across many integrations.
So we cant have full control over it. Also its structure is hard to modify with tools like `yq`. Its mostly lists so you can't merge or remove/re-add values in case of a change (ie collabora url changed). It will leave duplicates behind.

---

Related #3466