### PR TITLE
LocalAI: Replace missing image tag to fix app deployment

### DIFF
--- a/ix-dev/community/localai/ix_values.yaml
+++ b/ix-dev/community/localai/ix_values.yaml
@@ -1,22 +1,22 @@
 images:
   image:
     repository: quay.io/go-skynet/local-ai
-    tag: v3.6.0
+    tag: v3.7.0
   cuda11_image:
     repository: quay.io/go-skynet/local-ai
-    tag: v3.6.0-gpu-nvidia-cuda-11
+    tag: v3.7.0-gpu-nvidia-cuda-11
   cuda12_image:
     repository: quay.io/go-skynet/local-ai
-    tag: v3.6.0-gpu-nvidia-cuda-12
+    tag: v3.7.0-gpu-nvidia-cuda-12
   rocm_image:
     repository: quay.io/go-skynet/local-ai
-    tag: v3.6.0-gpu-hipblas
+    tag: v3.7.0-gpu-hipblas
   intel_image:
     repository: quay.io/go-skynet/local-ai
-    tag: v3.6.0-gpu-intel
+    tag: v3.7.0-gpu-intel
   vulkan_image:
     repository: quay.io/go-skynet/local-ai
-    tag: v3.6.0-vulkan
+    tag: v3.7.0-vulkan
 
 consts:
   localai_container_name: localai


### PR DESCRIPTION
Currently we cannot deploy LocalAI on TrueNAS., this is due to the ix values pointing to an image tag (v3.6.0) which do not seem to exist on Quay.io.

```sh
❯ curl -s "https://quay.io/api/v1/repository/go-skynet/local-ai/tag/?limit=1000" | jq '.tags[].name' | grep -i '3.6'
```

The version series 3.7 however seems to exist which this PR updates the ix values to:

```sh
❯ curl -s "https://quay.io/api/v1/repository/go-skynet/local-ai/tag/?limit=1000" | jq '.tags[].name' | grep -i '3.7'
"v3.7.0-aio-cpu"
"v3.7.0"
"v3.7.0-aio-gpu-intel"
"v3.7.0-gpu-intel"
"v3.7.0-aio-gpu-nvidia-cuda-12"
"v3.7.0-gpu-nvidia-cuda-12"
"v3.7.0-aio-gpu-nvidia-cuda-11"
"v3.7.0-gpu-nvidia-cuda-11"
"v3.7.0-aio-gpu-hipblas"
"v3.7.0-gpu-hipblas"
"v3.7.0-aio-gpu-vulkan"
"v3.7.0-gpu-vulkan"
"v3.7.0-nvidia-l4t-arm64"
```

For more context, see the conversation I started on the [initial LocalAI PR here](https://github.com/truenas/apps/pull/3493#issuecomment-3476280357).