### PR TITLE
Update source URL for ViTransfer in app_versions.json

### DIFF
--- a/trains/community/vitransfer/app_versions.json
+++ b/trains/community/vitransfer/app_versions.json
@@ -1261,7 +1261,7 @@
             ],
             "screenshots": [],
             "sources": [
-                "https://github.com/crypt010/vitransfer"
+                "https://github.com/MansiVisuals/ViTransfer"
             ],
             "title": "ViTransfer",
             "train": "community",


### PR DESCRIPTION
Using the correct https://github.com/MansiVisuals/ViTransfer instead of https://github.com/crypt010/vitransfer. 
crypt010 is only for the docker images on docker.io