### PR TITLE
fix(librechat): correct undefined variable in additional storage loop

### DIFF
--- a/ix-dev/community/librechat/app.yaml
+++ b/ix-dev/community/librechat/app.yaml
@@ -48,4 +48,4 @@ sources:
 - https://github.com/LibreChat/LibreChat
 title: LibreChat
 train: community
-version: 1.0.8
+version: 1.0.9

--- a/ix-dev/community/librechat/templates/docker-compose.yaml
+++ b/ix-dev/community/librechat/templates/docker-compose.yaml
@@ -62,7 +62,7 @@
 {% for store in values.storage.additional_storage %}
   {% do c1.add_storage(store.mount_path, store) %}
   {% do rag.add_storage(store.mount_path, store) %}
-  {% do perm_container.add_or_skip_action(store.mount_path, store, perm_config) %}
+  {% do perm_container.add_or_skip_action(store.mount_path, store, perms_config) %}
 {% endfor %}
 
 {% do rag.set_user(values.run_as.user, values.run_as.group) %}


### PR DESCRIPTION
Fixes undefined variable error when processing additional_storage mounts:
- Corrected variable name from 'perm_config' to 'perms_config'
- Ensures permissions container properly processes custom mounts
- Prevents Jinja2 template rendering failures

Error fixed:
jinja2.exceptions.UndefinedError: 'perm_config' is undefined

Bumped chart version to 1.0.9