### PR TITLE
Add pyproject.toml with testing dependencies for convenience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "truenas-apps"
+version = "0.1.0"
+description = "TrueNAS Apps Catalog"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[project.optional-dependencies]
+test = [
+    "pyyaml",
+    "psutil",
+    "pytest",
+    "pytest-cov",
+    "bcrypt",
+    "pydantic",
+]
+
+[tool.setuptools]
+packages = []
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
All the Python packages mentioned in CONTRIBUTIONS.md are declared in the `[project.optional-dependencies]` section under a `test` group.

To install the test dependencies, you can now run:

```sh
pip install -e ".[test]"
```

The advantage of using `pyproject.toml` with optional dependencies is that:

- It keeps your testing dependencies separate from any future runtime dependencies
- It's the modern Python standard ([PEP 621](https://peps.python.org/pep-0621/))
- It makes dependency management cleaner and more maintainable
- Other developers can easily install all testing dependencies with a single command

NOTE:  Since this repository isn't actually a Python package to be installed (it's just a repository that needs dependencies), we tell setuptools not to discover any package in `[tool.setuptools]`.