### PR TITLE
Arti: always resolve host.docker.internal to ipv4 in setup

### DIFF
--- a/ix-dev/community/arti/app.yaml
+++ b/ix-dev/community/arti/app.yaml
@@ -31,4 +31,4 @@ sources:
 - https://github.com/MAGICGrants/arti-docker
 title: Arti
 train: community
-version: 1.1.26
+version: 1.1.27

--- a/ix-dev/community/arti/templates/macros/setup.py.jinja
+++ b/ix-dev/community/arti/templates/macros/setup.py.jinja
@@ -10,7 +10,7 @@ config_file_path = '/arti/arti.toml'
 Path(config_file_path).touch(exist_ok=True)
 os.chmod(config_file_path, 0o664)
 
-docker_host_ip = os.popen("getent hosts host.docker.internal").read().split()[0]
+docker_host_ip = os.popen("getent ahostsv4 host.docker.internal").read().split()[0]
 arti_config = toml.load(config_file_path)
 arti_config['onion_services'] = {}
 


### PR DESCRIPTION
This addresses crash on startup when using ipv6.