### PR TITLE
Add description to MakeMKV License key question

### DIFF
--- a/ix-dev/community/makemkv/app.yaml
+++ b/ix-dev/community/makemkv/app.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/jlesage/docker-makemkv
 title: MakeMKV
 train: community
-version: 1.0.16
+version: 1.0.17

--- a/ix-dev/community/makemkv/questions.yaml
+++ b/ix-dev/community/makemkv/questions.yaml
@@ -55,6 +55,7 @@ questions:
                         required: true
         - variable: makemkv_key
           label: MakeMKV License Key
+          descripion: Optional license key. MakeMKV will default to the current BETA key if left blank.
           schema:
             type: string
             default: ""


### PR DESCRIPTION
This adds a description to the license key question to clarify that it is optional and that the app will default to a usable key if left blank.