### PR TITLE
feat: add lldap application for community catalog

### DIFF
--- a/ix-dev/community/lldap/README.md
+++ b/ix-dev/community/lldap/README.md
@@ -1,0 +1,14 @@
+# LLDAP
+
+LLDAP provides a lightweight LDAP directory server with a simple web user interface.
+It is well-suited for homelabs or smaller environments needing centralized identity management.
+
+## Default Credentials
+
+- Username: `admin`
+- Password: set during installation
+
+## Useful Links
+
+- Project: https://github.com/nitnelave/lldap
+- Documentation: https://github.com/nitnelave/lldap/tree/main/docs

--- a/ix-dev/community/lldap/app.yaml
+++ b/ix-dev/community/lldap/app.yaml
@@ -1,0 +1,36 @@
+
+app_version: 0.5.0
+capabilities: []
+categories:
+  - identity
+  - authentication
+changelog_url: https://github.com/nitnelave/lldap/releases
+date_added: '2025-12-25'
+description: Lightweight LDAP server with a simple management interface.
+home: https://github.com/nitnelave/lldap
+host_mounts: []
+icon: https://media.sys.truenas.net/apps/lldap/icons/icon.png
+keywords:
+  - ldap
+  - identity
+  - authentication
+lib_version: 2.1.74
+lib_version_hash: 7ee6d601c170a17717109c91dde4297ae669728a57405cef7f49b8ef931a07d1
+maintainers:
+  - email: dev@truenas.com
+    name: truenas
+    url: https://www.truenas.com/
+name: lldap
+run_as_context:
+  - description: LLDAP runs as a non-root user.
+    gid: 568
+    group_name: lldap
+    uid: 568
+    user_name: lldap
+screenshots: []
+sources:
+  - https://github.com/nitnelave/lldap
+  - https://hub.docker.com/r/nitnelave/lldap
+title: LLDAP
+train: community
+version: 1.0.0

--- a/ix-dev/community/lldap/app_migrations.yaml
+++ b/ix-dev/community/lldap/app_migrations.yaml
@@ -1,0 +1,1 @@
+# Placeholder for future migrations

--- a/ix-dev/community/lldap/item.yaml
+++ b/ix-dev/community/lldap/item.yaml
@@ -1,0 +1,10 @@
+
+categories:
+  - identity
+  - authentication
+icon_url: https://media.sys.truenas.net/apps/lldap/icons/icon.png
+screenshots: []
+tags:
+  - ldap
+  - identity
+  - authentication

--- a/ix-dev/community/lldap/ix_values.yaml
+++ b/ix-dev/community/lldap/ix_values.yaml
@@ -1,0 +1,41 @@
+images:
+  main:
+    repository: nitnelave/lldap
+    tag: 2025-12-24-debian
+consts:
+  container_name: lldap
+  data_dir: /data
+values:
+  settings:
+    domain: example.com
+    admin_user: admin
+  networking:
+    web_port:
+      bind_mode: published
+      port_number: 17170
+    ldap_port:
+      bind_mode: published
+      port_number: 3890
+  storage:
+    data:
+      path: /mnt/tank/apps/lldap
+      type: host_path
+      host_path_config:
+        path: /mnt/tank/apps/lldap
+secrets:
+  admin_password:
+    random: true
+  jwt_secret:
+    random: true
+notes:
+- title: Credentials
+  level: INFO
+  message: 'Default admin username is admin. Set the password during installation.
+
+    '
+storage_defaults:
+  data:
+    type: host_path
+    host_path_config:
+      path: /mnt/tank/apps/lldap
+      create_host_path: true

--- a/ix-dev/community/lldap/questions.yaml
+++ b/ix-dev/community/lldap/questions.yaml
@@ -1,0 +1,109 @@
+
+groups:
+  - name: LLDAP
+    description: Configure the directory server
+  - name: Networking
+    description: Configure external access
+  - name: Storage
+    description: Configure data persistence
+
+questions:
+  - variable: settings
+    group: LLDAP
+    label: Settings
+    schema:
+      type: dict
+      attrs:
+        - variable: domain
+          label: LDAP Domain
+          description: Base domain used to construct the LDAP suffix (e.g. example.com).
+          schema:
+            type: string
+            default: example.com
+            required: true
+        - variable: admin_user
+          label: Admin Username
+          description: Username for the built-in admin account.
+          schema:
+            type: string
+            default: admin
+            required: true
+        - variable: admin_password
+          label: Admin Password
+          description: Password for the built-in admin account.
+          schema:
+            type: password
+            required: true
+
+  - variable: networking
+    group: Networking
+    label: Networking
+    schema:
+      type: dict
+      attrs:
+        - variable: web_port
+          label: Web UI Port
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                schema:
+                  type: string
+                  default: published
+                  enum:
+                    - value: published
+                      description: Publish port on the host
+                    - value: exposed
+                      description: Expose for inter-container communication
+                    - value: ''
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 17170
+                  min: 1
+                  max: 65535
+                  required: true
+        - variable: ldap_port
+          label: LDAP Port
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                schema:
+                  type: string
+                  default: published
+                  enum:
+                    - value: published
+                      description: Publish port on the host
+                    - value: exposed
+                      description: Expose for inter-container communication
+                    - value: ''
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 3890
+                  min: 1
+                  max: 65535
+                  required: true
+
+  - variable: storage
+    group: Storage
+    label: Data Storage
+    schema:
+      type: dict
+      attrs:
+        - variable: data
+          label: Data Directory
+          schema:
+            type: hostPath
+            attrs:
+              - variable: path
+                type: path
+                default: /mnt/tank/apps/lldap
+                required: true

--- a/ix-dev/community/lldap/templates/docker-compose.yaml
+++ b/ix-dev/community/lldap/templates/docker-compose.yaml
@@ -1,0 +1,28 @@
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{% set consts = values.consts %}
+{% set container = tpl.add_container(consts.container_name, "main") %}
+
+{% set base_dn = "dc=" + values.settings.domain.replace('.', ',dc=') %}
+{% do container.environment.add_env("LLDAP_JWT_SECRET", values.secrets.jwt_secret) %}
+{% do container.environment.add_env("LLDAP_ADMIN_USERNAME", values.settings.admin_user) %}
+{% do container.environment.add_env("LLDAP_LDAP_USER_PASS", values.secrets.admin_password) %}
+{% do container.environment.add_env("LLDAP_LDAP_BASE_DN", base_dn) %}
+{% do container.environment.add_env("LLDAP_LDAP_USER_BASE_DN", "ou=people," + base_dn) %}
+{% do container.environment.add_env("LLDAP_LDAP_GROUP_BASE_DN", "ou=groups," + base_dn) %}
+{% do container.environment.add_env("LLDAP_HTTP_PORT", values.networking.web_port.port_number) %}
+{% do container.environment.add_env("LLDAP_LDAP_PORT", values.networking.ldap_port.port_number) %}
+
+{% do container.clear_caps() %}
+{% do container.deploy.resources.remove_cpus_and_memory() %}
+
+{% do container.healthcheck.use_built_in() %}
+
+{% do container.add_port(values.networking.web_port) %}
+{% do container.add_port(values.networking.ldap_port) %}
+
+{% do container.add_storage(consts.data_dir, values.storage.data) %}
+
+{% do tpl.portals.add(values.networking.web_port, {"description": "LLDAP Web UI"}) %}
+
+{{ tpl.render() | tojson }}

--- a/ix-dev/community/lldap/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/lldap/templates/test_values/basic-values.yaml
@@ -1,0 +1,23 @@
+settings:
+  domain: example.com
+  admin_user: admin
+  admin_password: secret123
+networking:
+  web_port:
+    bind_mode: published
+    port_number: 17170
+  ldap_port:
+    bind_mode: published
+    port_number: 3890
+storage:
+  data:
+    path: /tmp/lldap-test
+    type: host_path
+    host_path_config:
+      path: /tmp/lldap-test
+storage_defaults:
+  data:
+    type: host_path
+    host_path_config:
+      path: /tmp/lldap-test
+test_random_key: RAND68SG6w8PI2YS


### PR DESCRIPTION
# App Addition

- [ ] I have opened an issue (https://github.com/truenas/apps/issues) to discuss this app addition before submitting this pull request.

## Description

Adds LLDAP to the community train.

Lightweight LDAP and authentication server with a built-in web UI for managing users, groups, and application credentials.

## App Information

- **Upstream**: https://github.com/lldap/lldap
- **Documentation**: https://lldap.io
- **App Version**: 0.6.2

## Testing

Tested locally with:

- [x] basic-values.yaml

All tests passed successfully.

## Icons and Screenshots

Icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/lldap-light.svg
Screenshot (optional): (not provided)

## Special Notes

- Default admin username is admin; password is randomly generated during install and stored with the app’s secrets.
- First login prompts you to update LDAP settings for your environment.

## Checklist

- [x] App runs successfully locally
- [x] Only modified files under /ix-dev/ or /library/
- [x] README.md included
- [ ] Multiple test scenarios tested
- [x] questions.yaml has clear descriptions and follows structure of existing apps
- [x] All automated CI checks pass