### PR TITLE
jellyfin: add optional DLNA/SSDP (UDP 1900) port mapping

### DIFF
--- a/trains/community/jellyfin/1.2.21/questions.yaml
+++ b/trains/community/jellyfin/1.2.21/questions.yaml
@@ -231,6 +231,66 @@ questions:
                         required: true
                         $ref:
                           - definitions/node_bind_ip
+        - variable: dlna_ssdp
+          label: DLNA/SSDP Port (UDP 1900)
+          description: |
+            Optional. Only enable if you installed the Jellyfin DLNA plugin.</br>
+            Warning: UDP/1900 is a standard SSDP port and may conflict with other UPnP/DLNA services on the host.
+          schema:
+            type: dict
+            show_if: [["host_network", "=", false]]
+            attrs:
+              - variable: enabled
+                label: Enable DLNA/SSDP
+                schema:
+                  type: boolean
+                  default: false
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  show_if: [["enabled", "=", true]]
+                  default: ""
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  show_if:
+                    [["enabled", "=", true], ["bind_mode", "=", "published"]]
+                  default: 1900
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if:
+                    [["enabled", "=", true], ["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: host_network
           label: Host Network
           description: |

--- a/trains/community/jellyfin/1.2.21/templates/docker-compose.yaml
+++ b/trains/community/jellyfin/1.2.21/templates/docker-compose.yaml
@@ -16,6 +16,9 @@
   {% do c1.add_port(values.network.web_port, {"container_port": values.consts.internal_web_port}) %}
   {% do c1.add_port(values.network.https_port, {"container_port": values.consts.internal_https_port}) %}
   {% do c1.add_port(values.network.discovery_port, {"container_port": 7359, "protocol": "udp"}) %}
+  {% if values.network.dlna_ssdp.enabled %}
+    {% do c1.add_port(values.network.dlna_ssdp, {"container_port": 1900, "protocol": "udp"}) %}
+  {% endif %}
 {% endif %}
 
 {% do c1.add_storage("/config", values.storage.config) %}


### PR DESCRIPTION
**Description**
This PR adds an optional port configuration for Jellyfin DLNA/SSDP discovery (UDP/1900). Jellyfin DLNA is provided via a plugin and is not enabled for all installations; additionally, UDP/1900 is a well-known SSDP port that can conflict with other services. Therefore, the port mapping is opt-in via the UI.

**Motivation / Problem**
	•	Jellyfin DLNA discovery uses SSDP on UDP/1900.
	•	The current app exposes HTTP/HTTPS and Jellyfin’s UDP discovery port, but not SSDP/1900.
	•	Publishing UDP/1900 by default can cause conflicts on systems already running other UPnP/DLNA/SSDP services.

**What changed**

1. questions.yaml

- Added a new network.dlna_ssdp section under “Network Configuration”.
- Includes an Enable DLNA/SSDP boolean (default false).
- When enabled, provides the same bind_mode / port_number / host_ips UX pattern as existing ports.
- The section is hidden when host_network=true, consistent with other port configs.

2. templates/docker-compose.yaml

- Added a conditional port mapping:
- When network.dlna_ssdp.enabled is true and host_network is false, the template publishes container port 1900/udp using the configured bind settings.

UI/UX behavior (Tested successfuly on TrueNAS-25.04.2.1)

- A new “DLNA/SSDP Port (UDP 1900)” section appears under Network Configuration when Host Network is disabled.

- Mapping is disabled by default; users must explicitly enable it to publish UDP/1900.

Backward compatibility

- Defaults remain unchanged; existing installs are unaffected because:

- network.dlna_ssdp.enabled defaults to false

- No additional port is published unless the user opts in