### PR TITLE
Stirling PDF - Rename environment variable for security settings

### DIFF
--- a/ix-dev/community/stirling-pdf/templates/docker-compose.yaml
+++ b/ix-dev/community/stirling-pdf/templates/docker-compose.yaml
@@ -5,7 +5,7 @@
 {% do c1.healthcheck.set_test("curl", {"port": values.consts.internal_web_port, "path": "/api/v1/info/status"}) %}
 
 {% do c1.environment.add_env("LANGS", values.stirling.langs|join(",")) %}
-{% do c1.environment.add_env("DOCKER_ENABLE_SECURITY", values.stirling.enable_security) %}
+{% do c1.environment.add_env("SECURITY_ENABLELOGIN", values.stirling.enable_security) %}
 {% do c1.environment.add_user_envs(values.stirling.additional_envs) %}
 
 {% if not values.network.host_network %}


### PR DESCRIPTION
- The previous value - although shown in the error message when trying to connect from the desktop app - seems to be outdated, and has no effect
- Docs now mention the new value, and that actually enables the login for the app: https://docs.stirlingpdf.com/Installation/Docker%20Install

I'm not sure if this is the only change needed, but I thought doing this as a PR would help you more than a simple issue. Feel free to close if it's not helpful!