### PR TITLE
fix(ci): free up some disk space

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,9 +23,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android || :
           # ~5GB
           sudo rm -rf /opt/hostedtoolcache/CodeQL || :
-      - name: Pre Pull Docker Image
-        run: |
-          docker pull ghcr.io/truenas/apps_validation:latest
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -39,6 +37,9 @@ jobs:
           restore-keys: |
             renovate-
 
+      - name: Pre Pull Docker Image
+        run: |
+          docker pull ghcr.io/truenas/apps_validation:latest
       - name: Fix Cache Permissions
         run: |
           set -x


### PR DESCRIPTION
We started hitting some errors due to low space in the github runner.
This will remove some unused tools that are not really needed in our case.
Also pre-pulls the docker image, as its a large one, before the actual work is started and fail early if the space is not enough