### PR TITLE
add host network option for nginx-proxy-manager

### DIFF
--- a/ix-dev/community/nginx-proxy-manager/app.yaml
+++ b/ix-dev/community/nginx-proxy-manager/app.yaml
@@ -46,4 +46,4 @@ sources:
 - https://hub.docker.com/r/jc21/nginx-proxy-manager
 title: Nginx Proxy Manager
 train: community
-version: 1.2.26
+version: 1.3.0

--- a/ix-dev/community/nginx-proxy-manager/ix_values.yaml
+++ b/ix-dev/community/nginx-proxy-manager/ix_values.yaml
@@ -5,6 +5,7 @@ images:
 consts:
   npm_container_name: npm
   data_path: /data
+  internal_web_port: 81
   notes_body: |
     ## Default Username and Password
 

--- a/ix-dev/community/nginx-proxy-manager/questions.yaml
+++ b/ix-dev/community/nginx-proxy-manager/questions.yaml
@@ -78,11 +78,20 @@ questions:
     schema:
       type: dict
       attrs:
+        - variable: host_network
+          label: Host Network
+          description: |
+            Binds the container to the host network. </br>
+            <font color="red">Warning:</font> It's recommended to keep this disabled, unless you know what you are doing. This will cause conflicts if the host is already using ports 80, 443, or 81 (e.g., TrueNAS Web UI).</br>
+          schema:
+            type: boolean
+            default: false
         - variable: web_port
           label: WebUI Port
           description: The port for Nginx Proxy Manager WebUI
           schema:
             type: dict
+            show_if: [["host_network", "=", false]]
             attrs:
               - variable: bind_mode
                 label: Port Bind Mode
@@ -132,6 +141,7 @@ questions:
           description: The port for Nginx Proxy Manager HTTP
           schema:
             type: dict
+            show_if: [["host_network", "=", false]]
             attrs:
               - variable: bind_mode
                 label: Port Bind Mode
@@ -181,6 +191,7 @@ questions:
           description: The port for Nginx Proxy Manager HTTPS
           schema:
             type: dict
+            show_if: [["host_network", "=", false]]
             attrs:
               - variable: bind_mode
                 label: Port Bind Mode
@@ -230,6 +241,7 @@ questions:
           label: Additional Ports
           schema:
             type: list
+            show_if: [["host_network", "=", false]]
             items:
               - variable: port
                 label: Port

--- a/ix-dev/community/nginx-proxy-manager/templates/docker-compose.yaml
+++ b/ix-dev/community/nginx-proxy-manager/templates/docker-compose.yaml
@@ -11,10 +11,9 @@
 {% do c1.environment.add_user_envs(values.npm.additional_envs) %}
 
 {% if not values.network.host_network %}
-  {% do c1.add_port(values.network.web_port, {"container_port": 81}) %}
+  {% do c1.add_port(values.network.web_port, {"container_port": values.consts.internal_web_port}) %}
   {% do c1.add_port(values.network.https_port, {"container_port": 443}) %}
   {% do c1.add_port(values.network.http_port, {"container_port": 80}) %}
-
   {% for port in values.network.additional_ports %}
     {% do c1.add_port(port) %}
   {% endfor %}
@@ -26,7 +25,7 @@
   {% do c1.add_storage(store.mount_path, store) %}
 {% endfor %}
 
-{% do tpl.portals.add(values.network.web_port) %}
+{% do tpl.portals.add(values.network.web_port, {"port": values.consts.internal_web_port if values.network.host_network else None}) %}
 {% do tpl.notes.set_body(values.consts.notes_body) %}
 
 {{ tpl.render() | tojson }}

--- a/ix-dev/community/nginx-proxy-manager/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/nginx-proxy-manager/templates/test_values/basic-values.yaml
@@ -17,6 +17,7 @@ network:
     bind_mode: published
     port_number: 8443
   additional_ports: []
+  host_network: false
 
 run_as:
   user: 568


### PR DESCRIPTION
# App Enhancement

- [x] I have opened an [[Enhancement]: Nginx Proxy Manager - host network #4149
](https://github.com/truenas/apps/issues/4149) to discuss this app addition before submitting this pull request.

# AI

- [x] Part or All of this PR was generated by an LLM.

## App Information

- **Upstream**: https://github.com/NginxProxyManager/nginx-proxy-manager
- **App Version**: 2.13.6

## Enhancement
Allow app to use host network

## Testing

Tested locally with:

- [x] basic-values.yaml

All tests passed successfully.


## Special Notes

- First-time setup instructions: [if applicable]
- Any other important information

## Checklist

- [x] App runs successfully locally
- [x] Only modified files under /ix-dev/ or /library/
- [x] README.md included
- [x] Multiple test scenarios tested
- [x] questions.yaml has clear descriptions and follows structure of existing apps
- [x] All automated CI checks pass
