### PR TITLE
Fix: Tracearr - Add max_locks_per_transactionTimescaleDB

### DIFF
--- a/ix-dev/community/tracearr/app.yaml
+++ b/ix-dev/community/tracearr/app.yaml
@@ -48,4 +48,4 @@ sources:
 - https://github.com/connorgallopo/tracearr
 title: Tracearr
 train: community
-version: 1.0.15
+version: 1.0.16

--- a/ix-dev/community/tracearr/templates/docker-compose.yaml
+++ b/ix-dev/community/tracearr/templates/docker-compose.yaml
@@ -11,6 +11,7 @@
   "volume": values.storage.postgres_data,
   "additional_options": {
     "timescaledb.max_tuples_decompressed_per_dml_transaction": 0,
+    "max_locks_per_transaction": 4096,
   },
 } %}
 {% set postgres = tpl.deps.postgres(values.consts.timescale_container_name, values.tracearr.postgres_image_selector, pg_config, perm_container) %}


### PR DESCRIPTION
Fixes history backfill failing with 'out of shared memory' errors on large libraries. This parameter increases the lock table size which is needed when TimescaleDB creates many chunks during backfill operations.

Fixes connorgallopo/Tracearr#268

# Pull Request