### PR TITLE
Modify Docker tag for apps/community/fireshare

### DIFF
--- a/ix-dev/community/fireshare/ix_values.yaml
+++ b/ix-dev/community/fireshare/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: shaneisrael/fireshare
-    tag: 1.4.0
+    tag: latest
 
 consts:
   fireshare_container_name: fireshare


### PR DESCRIPTION


# Pull Request

1.4.0 is a broken build. The apps catalog should always target latest instead of a specific version to avoid the Truenas catalog item getting stuck on a broken build.


(There was no template available for this type of change).