### PR TITLE
byparr: switch to back to /docs

### DIFF
--- a/ix-dev/community/byparr/app.yaml
+++ b/ix-dev/community/byparr/app.yaml
@@ -29,4 +29,4 @@ sources:
 - https://github.com/ThePhaseless/Byparr
 title: Byparr
 train: community
-version: 1.0.16
+version: 1.0.17

--- a/ix-dev/community/byparr/templates/docker-compose.yaml
+++ b/ix-dev/community/byparr/templates/docker-compose.yaml
@@ -4,7 +4,7 @@
 
 {% do c1.set_shm_size_mb(2048) %}
 {% do c1.environment.add_env("PORT", values.network.web_port.port_number) %}
-{% do c1.healthcheck.set_test("curl", {"port":values.network.web_port.port_number, "path": "/health"}) %}
+{% do c1.healthcheck.set_test("curl", {"port":values.network.web_port.port_number, "path": "/docs"}) %}
 
 {% do c1.environment.add_user_envs(values.byparr.additional_envs) %}
 {% do c1.add_port(values.network.web_port) %}


### PR DESCRIPTION
`/health` endpoint, validates if google is up. https://github.com/ThePhaseless/Byparr/blob/50e0c3bff3b0a27610ffd91dd2c5f7fb404c2d99/src/endpoints.py#L35-L40

Not all users can access google, but surely they can access their app.