### PR TITLE
passbolt: make key readable

### DIFF
--- a/ix-dev/community/passbolt/app.yaml
+++ b/ix-dev/community/passbolt/app.yaml
@@ -41,4 +41,4 @@ sources:
 - https://www.passbolt.com
 title: Passbolt
 train: community
-version: 1.2.35
+version: 1.2.36

--- a/ix-dev/community/passbolt/templates/docker-compose.yaml
+++ b/ix-dev/community/passbolt/templates/docker-compose.yaml
@@ -36,7 +36,7 @@
 {% endif %}
 
 {% if values.passbolt.image_selector == "pro_image" %}
-  {% do c1.configs.add("subscription_key", values.passbolt.subscription_key, "/etc/passbolt/subscription_key.txt", "0440") %}
+  {% do c1.configs.add("subscription_key", values.passbolt.subscription_key, "/etc/passbolt/subscription_key.txt", "0444") %}
 {% endif %}
 
 {% do c1.add_port(values.network.web_port, {"container_port": internal_port}) %}


### PR DESCRIPTION
Docker creates the file as root, so we need OTHERS (in this case the www-data user within the container) to be able to read this file
Closes #4342