### PR TITLE
nextcloud: fix robots

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -81,4 +81,4 @@ sources:
 - https://github.com/nextcloud/docker
 title: Nextcloud
 train: stable
-version: 2.1.32
+version: 2.1.33

--- a/ix-dev/stable/nextcloud/templates/macros/nc.jinja.conf
+++ b/ix-dev/stable/nextcloud/templates/macros/nc.jinja.conf
@@ -44,12 +44,6 @@ http {
     client_max_body_size {{ values.nextcloud.php_upload_limit }}G;
     add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload" always;
 
-    location = /robots.txt {
-      allow all;
-      log_not_found off;
-      access_log off;
-    }
-
     location ^~ /.well-known {
         # The rules in this block are an adaptation of the rules
         # in `.htaccess` that concern `/.well-known`.


### PR DESCRIPTION
nginx is used as a rev proxy here, so it does not have access to the robots file.
Let the nextcloud container handle the request.
