### PR TITLE
add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-ix-dev/*/*/templates/library/base_* linguist-generated=true
+ix-dev/*/*/templates/library/base_*/** linguist-generated=true


### PR DESCRIPTION
Marks all library files as generated, this should hide them from the PR diffs.

Hopefully PRs with lots of those files updated, will be "loadable" in github.