### PR TITLE
Add HTTPS support to immich app

### DIFF
--- a/ix-dev/community/immich/app.yaml
+++ b/ix-dev/community/immich/app.yaml
@@ -1,7 +1,17 @@
 annotations:
   min_scale_version: 24.10.2.2
 app_version: v2.5.6
-capabilities: []
+capabilities:
+- description: Nginx is able to change file ownership arbitrarily
+  name: CHOWN
+- description: Nginx is able to bypass file permission checks
+  name: DAC_OVERRIDE
+- description: Nginx is able to bypass permission checks for file operations
+  name: FOWNER
+- description: Nginx is able to change group ID of processes
+  name: SETGID
+- description: Nginx is able to change user ID of processes
+  name: SETUID
 categories:
 - media
 changelog_url: https://github.com/immich-app/immich/releases
@@ -23,6 +33,11 @@ maintainers:
 name: immich
 run_as_context:
 - description: Container [machine-learning] runs as root user and group.
+  gid: 0
+  group_name: Host group is [root]
+  uid: 0
+  user_name: Host user is [root]
+- description: Container [nginx] runs as root user and group.
   gid: 0
   group_name: Host group is [root]
   uid: 0

--- a/ix-dev/community/immich/ix_values.yaml
+++ b/ix-dev/community/immich/ix_values.yaml
@@ -17,6 +17,9 @@ images:
   ml_openvino_image:
     repository: ghcr.io/immich-app/immich-machine-learning
     tag: v2.5.6-openvino
+  nginx_image:
+    repository: nginx
+    tag: 1.29.6
   vectorchord_15_image:
     repository: ghcr.io/immich-app/postgres
     tag: 15-vectorchord0.5.3
@@ -33,11 +36,15 @@ images:
 consts:
   server_container_name: server
   ml_container_name: machine-learning
+  nginx_container_name: nginx
   pgvecto_container_name: pgvecto
   redis_container_name: redis
   perms_container_name: permissions
+  internal_immich_web_port: 2283
   ml_port: 32002
   ml_cache_path: /mlcache
+  nginx_ssl_cert_path: /etc/certs/server.crt
+  nginx_ssl_key_path: /etc/certs/server.key
   db_user: immich
   db_name: immich
   base_path: /data

--- a/ix-dev/community/immich/questions.yaml
+++ b/ix-dev/community/immich/questions.yaml
@@ -321,6 +321,14 @@ questions:
                         required: true
                         $ref:
                           - definitions/node_bind_ip
+        - variable: certificate_id
+          label: Certificate
+          description: The certificate for Immich Web Port
+          schema:
+            type: int
+            "null": true
+            $ref:
+              - "definitions/certificate"
         - variable: networks
           label: Networks
           description: The docker networks to join
@@ -363,6 +371,8 @@ questions:
                                         description: server
                                       - value: machine-learning
                                         description: machine-learning
+                                      - value: nginx
+                                        description: nginx
                                       - value: pgvecto
                                         description: pgvecto
                                       - value: redis
@@ -858,6 +868,8 @@ questions:
                             description: server
                           - value: machine-learning
                             description: machine-learning
+                          - value: nginx
+                            description: nginx
                           - value: pgvecto
                             description: pgvecto
                           - value: redis

--- a/ix-dev/community/immich/templates/docker-compose.yaml
+++ b/ix-dev/community/immich/templates/docker-compose.yaml
@@ -1,3 +1,4 @@
+{% from "macros/nginx.conf.jinja" import nginx_conf %}
 {% set tpl = ix_lib.base.render.Render(values) %}
 
 {% set immich_net = tpl.networks.create_internal("immich-net") %}
@@ -23,6 +24,7 @@
 {% do redis.container.add_network(immich_net) %}
 
 {% set ml_container = namespace(x=None) %}
+{% set nginx = namespace(x=None) %}
 
 {% set server_container = tpl.add_container(values.consts.server_container_name, "image") %}
 {% do server_container.add_network(immich_net) %}
@@ -43,13 +45,31 @@
   {% do perm_container.add_or_skip_action(store.mount_path, store, perms_config) %}
 {% endfor %}
 
-{% do server_container.add_port(values.network.web_port) %}
+{% if values.network.certificate_id %}
+  {% set nginx.x = tpl.add_container(values.consts.nginx_container_name, "nginx_image") %}
+  {% do nginx.x.add_network(immich_net) %}
+  {% do nginx.x.depends.add_dependency(values.consts.server_container_name, "service_healthy") %}
+  {% do nginx.x.add_caps(["CHOWN", "FOWNER", "DAC_OVERRIDE", "SETGID", "SETUID"]) %}
+  {% do nginx.x.healthcheck.set_test("curl", {"port": values.network.web_port.port_number, "path": "/robots.txt", "scheme": "https"}) %}
+  {% do nginx.x.add_port(values.network.web_port) %}
+
+  {% set cert = values.ix_certificates[values.network.certificate_id] %}
+  {% do nginx.x.configs.add("private", cert.privatekey, values.consts.nginx_ssl_key_path) %}
+  {% do nginx.x.configs.add("public", cert.certificate, values.consts.nginx_ssl_cert_path) %}
+
+  {% do nginx.x.configs.add("nginx.conf", nginx_conf(values), "/etc/nginx/nginx.conf") %}
+
+  {% do nginx.x.add_storage("/var/cache/nginx", {"type": "anonymous"}) %}
+  {% do nginx.x.add_storage("/var/run", {"type": "anonymous"}) %}
+{% else %}
+  {% do server_container.add_port(values.network.web_port, {"container_port": values.consts.internal_immich_web_port}) %}
+{% endif %}
 {% do server_container.add_port(values.network.api_metrics_port) %}
 {% do server_container.add_port(values.network.microservices_metrics_port) %}
 
 {% do server_container.environment.add_env("NODE_ENV", "production") %}
 {% do server_container.environment.add_env("IMMICH_LOG_LEVEL", values.immich.log_level) %}
-{% do server_container.environment.add_env("IMMICH_PORT", values.network.web_port.port_number) %}
+{% do server_container.environment.add_env("IMMICH_PORT", values.consts.internal_immich_web_port) %}
 {% do server_container.environment.add_env("IMMICH_API_METRICS_PORT", values.network.api_metrics_port.port_number) %}
 {% do server_container.environment.add_env("IMMICH_MICROSERVICES_METRICS_PORT", values.network.microservices_metrics_port.port_number) %}
 {% do server_container.environment.add_env("DB_USERNAME", values.consts.db_user) %}
@@ -97,6 +117,7 @@
   {% endif %}
 {% endif %}
 
-{% do tpl.portals.add(values.network.web_port) %}
+{% set proto = "https" if values.network.certificate_id else "http" %}
+{% do tpl.portals.add(values.network.web_port, {"scheme": proto}) %}
 
 {{ tpl.render() | tojson }}

--- a/ix-dev/community/immich/templates/macros/nginx.conf.jinja
+++ b/ix-dev/community/immich/templates/macros/nginx.conf.jinja
@@ -1,0 +1,62 @@
+{% macro nginx_conf(values) -%}
+{%- set nginx_host = "%s:%d" | format(values.consts.nginx_container_name, values.network.web_port.port_number) %}
+{%- set nginx_url = "https://%s" | format(nginx_host) %}
+events {
+  worker_connections  1024;
+}
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+  # Types to enable gzip compression on
+  gzip_types
+    text/plain text/css text/js text/xml
+    text/javascript application/javascript
+    application/x-javascript application/json
+    application/xml application/rss+xml
+    image/svg+xml;
+  sendfile        on;
+  client_max_body_size 50000m;
+  keepalive_timeout  65;
+  # Disable tokens for security (#23684)
+  server_tokens off;
+  gzip  on;
+  client_body_temp_path /var/tmp/firmware;
+  server {
+    server_name            "{{ nginx_host }}";
+    listen                 0.0.0.0:{{ values.network.web_port.port_number }} default_server ssl http2;
+    ssl_certificate        "{{ values.consts.nginx_ssl_cert_path }}";
+    ssl_certificate_key    "{{ values.consts.nginx_ssl_key_path }}";
+    ssl_session_timeout    120m;
+    ssl_session_cache      shared:ssl:16m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA:EDH+aRSA:EECDH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!SHA1:!SHA256:!SHA384;
+    add_header Strict-Transport-Security max-age=31536000;
+    # disable buffering uploads to prevent OOM on reverse proxy server and make uploads twice as fast (no pause)
+    proxy_request_buffering off;
+    # increase body buffer to avoid limiting upload speed
+    client_body_buffer_size 1024k;
+    location = /robots.txt {
+      add_header Content-Type text/plain;
+      proxy_set_header Referer "{{ nginx_url }}";
+      return 200 "User-agent: *\nDisallow: /loleaflet/*\n";
+    }
+    # static files
+    location / {
+      proxy_pass http://{{ values.consts.server_container_name }}:{{ values.consts.internal_immich_web_port }};
+      proxy_set_header   Host              $host;
+      proxy_set_header   X-Real-IP         $remote_addr;
+      proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Proto $scheme;
+      proxy_set_header   Referer           "{{ nginx_url }}";
+      proxy_set_header   Upgrade           $http_upgrade;
+      proxy_set_header   Connection        "upgrade";
+      proxy_http_version 1.1;
+      proxy_redirect     off;
+      proxy_read_timeout 600s;
+      proxy_send_timeout 600s;
+      send_timeout       600s;
+    }
+  }
+}
+{%- endmacro %}

--- a/ix-dev/community/immich/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/immich/templates/test_values/basic-values.yaml
@@ -24,6 +24,7 @@ network:
   microservices_metrics_port:
     bind_mode: published
     port_number: 8085
+  certificate_id:
 
 run_as:
   user: 568

--- a/ix-dev/community/immich/templates/test_values/https-values.yaml
+++ b/ix-dev/community/immich/templates/test_values/https-values.yaml
@@ -1,0 +1,136 @@
+resources:
+  limits:
+    cpus: 2.0
+    memory: 4096
+
+immich:
+  postgres_image_selector: vectorchord_18_image
+  enable_ml: true
+  ml_image_selector: ml_image
+  log_level: log
+  hugging_face_endpoint: ""
+  db_password: immich
+  redis_password: immich
+  db_storage_type: SSD
+  additional_envs: []
+
+network:
+  web_port:
+    bind_mode: published
+    port_number: 8080
+  api_metrics_port:
+    bind_mode: published
+    port_number: 8084
+  microservices_metrics_port:
+    bind_mode: published
+    port_number: 8085
+  certificate_id: "2"
+
+run_as:
+  user: 568
+  group: 568
+
+ix_volumes:
+  postgres-data: /opt/tests/mnt/immich/postgres-data
+  data: /opt/tests/mnt/immich/data
+
+storage:
+  postgres_data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: postgres-data
+      create_host_path: true
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: data
+      create_host_path: true
+  ml_cache:
+    type: temporary
+  additional_storage: []
+
+ix_certificates:
+  "2":
+    certificate: |
+      -----BEGIN CERTIFICATE-----
+      MIIEdjCCA16gAwIBAgIDYFMYMA0GCSqGSIb3DQEBCwUAMGwxDDAKBgNVBAMMA2Fz
+      ZDELMAkGA1UEBhMCVVMxDTALBgNVBAgMBGFzZGYxCzAJBgNVBAcMAmFmMQ0wCwYD
+      VQQKDARhc2RmMQwwCgYDVQQLDANhc2QxFjAUBgkqhkiG9w0BCQEWB2FAYS5jb20w
+      HhcNMjEwODMwMjMyMzU0WhcNMjMxMjAzMjMyMzU0WjBuMQswCQYDVQQDDAJhZDEL
+      MAkGA1UEBhMCVVMxDTALBgNVBAgMBGFzZGYxDTALBgNVBAcMBGFzZGYxDTALBgNV
+      BAoMBGFkc2YxDTALBgNVBAsMBGFzZGYxFjAUBgkqhkiG9w0BCQEWB2FAYS5jb20w
+      ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7+1xOHRQyOnQTHFcrdasX
+      Zl0gzutVlA890a1wiQpdD5dOtCLo7+eqVYjqVKo9W8RUIArXWmBu/AbkH7oVFWC1
+      P973W1+ArF5sA70f7BZgqRKJTIisuIFIlRETgfnP2pfQmHRZtGaIJRZI4vQCdYgW
+      2g0KOvvNcZJCVq1OrhKiNiY1bWCp66DGg0ic6OEkZFHTm745zUNQaf2dNgsxKU0H
+      PGjVLJI//yrRFAOSBUqgD4c50krnMF7fU/Fqh+UyOu8t6Y/HsySh3urB+Zie331t
+      AzV6QV39KKxRflNx/yuWrtIEslGTm+xHKoCYJEk/nZ3mX8Y5hG6wWAb7A/FuDVg3
+      AgMBAAGjggEdMIIBGTAnBgNVHREEIDAehwTAqAADhwTAqAAFhwTAqAC2hwTAqACB
+      hwTAqACSMB0GA1UdDgQWBBQ4G2ff4tgZl4vmo4xCfqmJhdqShzAMBgNVHRMBAf8E
+      AjAAMIGYBgNVHSMEgZAwgY2AFLlYf9L99nxJDcpCM/LT3V5hQ/a3oXCkbjBsMQww
+      CgYDVQQDDANhc2QxCzAJBgNVBAYTAlVTMQ0wCwYDVQQIDARhc2RmMQswCQYDVQQH
+      DAJhZjENMAsGA1UECgwEYXNkZjEMMAoGA1UECwwDYXNkMRYwFAYJKoZIhvcNAQkB
+      FgdhQGEuY29tggNgUxcwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwEwDgYDVR0PAQH/
+      BAQDAgWgMA0GCSqGSIb3DQEBCwUAA4IBAQA6FpOInEHB5iVk3FP67GybJ29vHZTD
+      KQHbQgmg8s4L7qIsA1HQ+DMCbdylpA11x+t/eL/n48BvGw2FNXpN6uykhLHJjbKR
+      h8yITa2KeD3LjLYhScwIigXmTVYSP3km6s8jRL6UKT9zttnIHyXVpBDya6Q4WTMx
+      fmfC6O7t1PjQ5ZyVtzizIUP8ah9n4TKdXU4A3QIM6WsJXpHb+vqp1WDWJ7mKFtgj
+      x5TKv3wcPnktx0zMPfLb5BTSE9rc9djcBG0eIAsPT4FgiatCUChe7VhuMnqskxEz
+      MymJLoq8+mzucRwFkOkR2EIt1x+Irl2mJVMeBow63rVZfUQBD8h++LqB
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      MIIEhDCCA2ygAwIBAgIDYFMXMA0GCSqGSIb3DQEBCwUAMGwxDDAKBgNVBAMMA2Fz
+      ZDELMAkGA1UEBhMCVVMxDTALBgNVBAgMBGFzZGYxCzAJBgNVBAcMAmFmMQ0wCwYD
+      VQQKDARhc2RmMQwwCgYDVQQLDANhc2QxFjAUBgkqhkiG9w0BCQEWB2FAYS5jb20w
+      HhcNMjEwODMwMjMyMDQ1WhcNMzEwODI4MjMyMDQ1WjBsMQwwCgYDVQQDDANhc2Qx
+      CzAJBgNVBAYTAlVTMQ0wCwYDVQQIDARhc2RmMQswCQYDVQQHDAJhZjENMAsGA1UE
+      CgwEYXNkZjEMMAoGA1UECwwDYXNkMRYwFAYJKoZIhvcNAQkBFgdhQGEuY29tMIIB
+      IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq//c0hEEr83CS1pMgsHX50jt
+      2MqIbcf63UUNJTiYpUUvUQSFJFc7m/dr+RTZvu97eDCnD5K2qkHHvTPaPZwY+Djf
+      iy7N641Sz6u/y3Yo3xxs1Aermsfedh48vusJpjbkT2XS44VjbkrpKcWDNVpp3Evd
+      M7oJotXeUsZ+imiyVCfr4YhoY5gbGh/r+KN9Wf9YKoUyfLLZGwdZkhtX2zIbidsL
+      Thqi9YTaUHttGinjiBBum234u/CfvKXsfG3yP2gvBGnlvZnM9ktv+lVffYNqlf7H
+      VmB1bKKk84HtzuW5X76SGAgOG8eHX4x5ZLI1WQUuoQOVRl1I0UCjBtbz8XhwvQID
+      AQABo4IBLTCCASkwLQYDVR0RBCYwJIcEwKgABYcEwKgAA4cEwKgAkocEwKgAtYcE
+      wKgAgYcEwKgAtjAdBgNVHQ4EFgQUuVh/0v32fEkNykIz8tPdXmFD9rcwDwYDVR0T
+      AQH/BAUwAwEB/zCBmAYDVR0jBIGQMIGNgBS5WH/S/fZ8SQ3KQjPy091eYUP2t6Fw
+      pG4wbDEMMAoGA1UEAwwDYXNkMQswCQYDVQQGEwJVUzENMAsGA1UECAwEYXNkZjEL
+      MAkGA1UEBwwCYWYxDTALBgNVBAoMBGFzZGYxDDAKBgNVBAsMA2FzZDEWMBQGCSqG
+      SIb3DQEJARYHYUBhLmNvbYIDYFMXMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF
+      BQcDAjAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQELBQADggEBAKEocOmVuWlr
+      zegtKYMe8NhHIkFY9oVn5ym6RHNOJpPH4QF8XYC3Z5+iC5yGh4P/jVe/4I4SF6Ql
+      PtofU0jNq5vzapt/y+m008eXqPQFmoUOvu+JavoRVcRx2LIP5AgBA1mF56CSREsX
+      TkuJAA9IUQ8EjnmAoAeKINuPaKxGDuU8BGCMqr/qd564MKNf9XYL+Fb2rlkA0O2d
+      2No34DQLgqSmST/LAvPM7Cbp6knYgnKmGr1nETCXasg1cueHLnWWTvps2HiPp2D/
+      +Fq0uqcZLu4Mdo0CPs4e5sHRyldEnRSKh0DVLprq9zr/GMipmPLJUsT5Jed3sj0w
+      M7Y3vwxshpo=
+      -----END CERTIFICATE-----
+    privatekey: |
+      -----BEGIN PRIVATE KEY-----
+      MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC7+1xOHRQyOnQT
+      HFcrdasXZl0gzutVlA890a1wiQpdD5dOtCLo7+eqVYjqVKo9W8RUIArXWmBu/Abk
+      H7oVFWC1P973W1+ArF5sA70f7BZgqRKJTIisuIFIlRETgfnP2pfQmHRZtGaIJRZI
+      4vQCdYgW2g0KOvvNcZJCVq1OrhKiNiY1bWCp66DGg0ic6OEkZFHTm745zUNQaf2d
+      NgsxKU0HPGjVLJI//yrRFAOSBUqgD4c50krnMF7fU/Fqh+UyOu8t6Y/HsySh3urB
+      +Zie331tAzV6QV39KKxRflNx/yuWrtIEslGTm+xHKoCYJEk/nZ3mX8Y5hG6wWAb7
+      A/FuDVg3AgMBAAECggEAapt30rj9DitGTtxAt13pJMEhyYxvvD3WkvmJwguF/Bbu
+      eW0Ba1c668fMeRCA54FWi1sMqusPS4HUqqUvk+tmyAOsAF4qgD/A4MMSC7uJSVI5
+      N/JWhJWyhCY94/FPakiO1nbPbVw41bcqtzU2qvparpME2CtxSCbDiqm7aaag3Kqe
+      EF0fGSUdZ+TYl9JM05+eIyiX+UY19Fg0OjTHMn8nGpxcNTfDBdQ68TKvdo/dtIKL
+      PLKzJUNNdM8odC4CvQtfGMqaslwZwXkiOl5VJcW21ncj/Y0ngEMKeD/i65ZoqGdR
+      0FKCQYEAGtM2FvJcZQ92Wsw7yj2bK2MSegVUyLK32QKBgQDe8syVCepPzRsfjfxA
+      6TZlWcGuTZLhwIx97Ktw3VcQ1f4rLoEYlv0xC2VWBORpzIsJo4I/OLmgp8a+Ga8z
+      FkVRnq90dV3t4NP9uJlHgcODHnOardC2UUka4olBSCG6zmK4Jxi34lOxhGRkshOo
+      L4IBeOIB5g+ZrEEXkzfYJHESRQKBgQDX2YhFhGIrT8BAnC5BbXbhm8h6Bhjz8DYL
+      d+qhVJjef7L/aJxViU0hX9Ba2O8CLK3FZeREFE3hJPiJ4TZSlN4evxs5p+bbNDcA
+      0mhRI/o3X4ac6IxdRebyYnCOB/Cu94/MzppcZcotlCekKNike7eorCcX4Qavm7Pu
+      MUuQ+ifmSwKBgEnchoqZzlbBzMqXb4rRuIO7SL9GU/MWp3TQg7vQmJerTZlgvsQ2
+      wYsOC3SECmhCq4117iCj2luvOdihCboTFsQDnn0mpQe6BIF6Ns3J38wAuqv0CcFd
+      DKsrge1uyD3rQilgSoAhKzkUc24o0PpXQurZ8YZPgbuXpbj5vPaOnCdBAoGACYc7
+      wb3XS4wos3FxhUfcwJbM4b4VKeeHqzfu7pI6cU/3ydiHVitKcVe2bdw3qMPqI9Wc
+      nvi6e17Tbdq4OCsEJx1OiVwFD9YdO3cOTc6lw/3+hjypvZBRYo+/4jUthbu96E+S
+      dtOzehGZMmDvN0uSzupSi3ZOgkAAUFpyuIKickMCgYAId0PCRjonO2thn/R0rZ7P
+      //L852uyzYhXKw5/fjFGhQ6LbaLgIRFaCZ0L2809u0HFnNvJjHv4AKP6j+vFQYYY
+      qQ+66XnfsA9G/bu4MDS9AX83iahD9IdLXQAy8I19prAbpVumKegPbMnNYNB/TYEc
+      3G15AKCXo7jjOUtHY01DCQ==
+      -----END PRIVATE KEY-----

--- a/ix-dev/community/immich/templates/test_values/root-values.yaml
+++ b/ix-dev/community/immich/templates/test_values/root-values.yaml
@@ -23,6 +23,7 @@ network:
   microservices_metrics_port:
     bind_mode: published
     port_number: 8085
+  certificate_id:
 
 run_as:
   user: 0


### PR DESCRIPTION
This PR makes it possible to run immich with HTTPS for the web_port.

I've been using collabora office for a while and noticed how it is setup there, so I thought I would add the same nginx layer for immich too.

This also changes the internal immich web_port to always be the default 2283 (mentioned in the immich docs).

If there are any further improvements I can add to this PR I will gladly change it.

Cheers, lumarel