### PR TITLE
Update I2P version and URLs to use i2p.net

### DIFF
--- a/ix-dev/community/i2p/app.yaml
+++ b/ix-dev/community/i2p/app.yaml
@@ -1,4 +1,4 @@
-app_version: i2p-2.11.0-4
+app_version: i2p-2.10.0-5
 capabilities: []
 categories:
 - networking

--- a/ix-dev/community/i2p/ix_values.yaml
+++ b/ix-dev/community/i2p/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: geti2p/i2p
-    tag: i2p-2.11.0-4
+    tag: i2p-2.10.0-5
 
 consts:
   i2p_container_name: i2p


### PR DESCRIPTION
Bump version to I2P-2.11.0-4 and updating urls from geti2p.net to i2p.net.