### PR TITLE
dockhand: set home

### DIFF
--- a/ix-dev/community/dockhand/app.yaml
+++ b/ix-dev/community/dockhand/app.yaml
@@ -32,4 +32,4 @@ sources:
 - https://hub.docker.com/r/fnsys/dockhand
 title: Dockhand
 train: community
-version: 1.1.5
+version: 1.1.6

--- a/ix-dev/community/dockhand/templates/docker-compose.yaml
+++ b/ix-dev/community/dockhand/templates/docker-compose.yaml
@@ -7,6 +7,7 @@
 {% do c1.set_user(values.run_as.user, values.run_as.group) %}
 {% do c1.healthcheck.set_test("curl", {"port": values.network.web_port.port_number, "path": "/api/health"}) %}
 
+{% do c1.environment.add_env("HOME", "/tmp") %}
 {% do c1.environment.add_env("PORT", values.network.web_port.port_number) %}
 {# Note that the DATA_DIR (container path) must be the SAME path as the host path #}
 {% set data_host_path = tpl.funcs.get_host_path(values.storage.data) %}


### PR DESCRIPTION
Closes #4588

Dockhand sometimes does operations like build a docker image, which by default it uses the `$HOME/...` to store build cache, but that doesn't work if the running UID is different than the default.

This sets `$HOME` to `/tmp`. As it is only used for temp operations, data are still stored in another dir 