### PR TITLE
Added Support for Forgejo Runner Configuration

### DIFF
--- a/trains/community/forgejo-runner/1.1.5/templates/macros/entrypoint.sh
+++ b/trains/community/forgejo-runner/1.1.5/templates/macros/entrypoint.sh
@@ -17,7 +17,13 @@ else
 fi
 echo "\n\n"
 
+if [ ! -f /data/config.yaml ]; then
+  echo "Generating default config"
+  forgejo-runner generate-config > /data/config.yaml
+fi
+
 echo "Starting the runner"
-forgejo-runner daemon
+forgejo-runner daemon --config /data/config.yaml
+
 exit 0
 {% endmacro %}


### PR DESCRIPTION
Updated the entrypoint script for the Forgejo runner to support configuration.

Added logic to check for the existence of `/data/config.yaml` and automatically generate a default configuration using `forgejo-runner generate-config` if the file is missing.