### PR TITLE
[App Fix] Continuwuity 1.0.2

### DIFF
--- a/ix-dev/community/continuwuity/app.yaml
+++ b/ix-dev/community/continuwuity/app.yaml
@@ -33,4 +33,4 @@ sources:
 - https://forgejo.ellis.link/continuwuation/continuwuity
 title: Continuwuity
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/continuwuity/questions.yaml
+++ b/ix-dev/community/continuwuity/questions.yaml
@@ -74,6 +74,7 @@ questions:
                 label: Server
                 schema:
                   type: string
+                  required: true
         - variable: additional_envs
           label: Additional Environment Variables
           schema:

--- a/ix-dev/community/continuwuity/questions.yaml
+++ b/ix-dev/community/continuwuity/questions.yaml
@@ -54,6 +54,7 @@ questions:
             show_if: [["allow_registration", "=", true]]
             default: ""
             required: true
+            private: true
         - variable: allow_federation
           label: Enable Federation
           description: Allow your Continuwuity instance to federate<br>

--- a/ix-dev/community/continuwuity/questions.yaml
+++ b/ix-dev/community/continuwuity/questions.yaml
@@ -72,7 +72,7 @@ questions:
               - variable: server
                 label: Server
                 schema:
-                  type: uri
+                  type: string
         - variable: additional_envs
           label: Additional Environment Variables
           schema:

--- a/ix-dev/community/continuwuity/templates/docker-compose.yaml
+++ b/ix-dev/community/continuwuity/templates/docker-compose.yaml
@@ -13,17 +13,21 @@
 {% do c1.environment.add_env("CONTINUWUITY_DATABASE_PATH", values.consts.database_path) %}
 {% do c1.environment.add_env("CONTINUWUITY_SERVER_NAME", values.continuwuity.server_name) %}
 {% do c1.environment.add_env("CONTINUWUITY_ALLOW_REGISTRATION", values.continuwuity.allow_registration) %}
-{% do c1.environment.add_env("CONTINUWUITY_REGISTRATION_TOKEN", values.continuwuity.registration_token) %}
-
-{% set trusted_servers = namespace(x=[]) %}
-{% for srv in values.continuwuity.trusted_servers %}
-  {% set parsed = tpl.funcs.url_to_dict(srv) %}
-  {% set host = "%s:%d"|format(parsed.host, parsed.port) if parsed.port else parsed.host %}
-  {% do trusted_servers.x.append(host) %}
-{% endfor %}
-
 {% do c1.environment.add_env("CONTINUWUITY_ALLOW_FEDERATION", values.continuwuity.allow_federation) %}
-{% do c1.environment.add_env("CONTINUWUITY_TRUSTED_SERVERS", trusted_servers.x|tojson) %}
+{% if values.continuwuity.allow_registration %}
+  {% do c1.environment.add_env("CONTINUWUITY_REGISTRATION_TOKEN", values.continuwuity.registration_token) %}
+{% endif %}
+
+{% if values.continuwuity.allow_federation and values.continuwuity.trusted_servers %}
+  {% set trusted_servers = namespace(x=[]) %}
+  {% for srv in values.continuwuity.trusted_servers %}
+    {% set parsed = tpl.funcs.url_to_dict(srv) %}
+    {% set host = "%s:%d"|format(parsed.host, parsed.port) if parsed.port else parsed.host %}
+    {% do trusted_servers.x.append(host) %}
+  {% endfor %}
+
+  {% do c1.environment.add_env("CONTINUWUITY_TRUSTED_SERVERS", trusted_servers.x|tojson) %}
+{% endif %}
 
 {% do c1.environment.add_user_envs(values.continuwuity.additional_envs) %}
 

--- a/ix-dev/community/continuwuity/templates/docker-compose.yaml
+++ b/ix-dev/community/continuwuity/templates/docker-compose.yaml
@@ -13,21 +13,17 @@
 {% do c1.environment.add_env("CONTINUWUITY_DATABASE_PATH", values.consts.database_path) %}
 {% do c1.environment.add_env("CONTINUWUITY_SERVER_NAME", values.continuwuity.server_name) %}
 {% do c1.environment.add_env("CONTINUWUITY_ALLOW_REGISTRATION", values.continuwuity.allow_registration) %}
-{% if values.continuwuity.allow_registration %}
 {% do c1.environment.add_env("CONTINUWUITY_REGISTRATION_TOKEN", values.continuwuity.registration_token) %}
-{% endif %}
-{% set trusted_servers = [] %}
-{% if values.continuwuity.allow_federation %}
-  {% for srv in values.continuwuity.trusted_servers %}
-    {% set clean_server = srv.server | replace("https://", "") | replace("http://", "") | replace("/", "") %}
-    {% if clean_server %}
-      {% do trusted_servers.append(clean_server) %}
-    {% endif %}
-  {% endfor %}
-{% endif %}
+
+{% set trusted_servers = namespace(x=[]) %}
+{% for srv in values.continuwuity.trusted_servers %}
+  {% set parsed = tpl.funcs.url_to_dict(srv) %}
+  {% set host = "%s:%d"|format(parsed.host, parsed.port) if parsed.port else parsed.host %}
+  {% do trusted_servers.x.append(host) %}
+{% endfor %}
 
 {% do c1.environment.add_env("CONTINUWUITY_ALLOW_FEDERATION", values.continuwuity.allow_federation) %}
-{% do c1.environment.add_env("CONTINUWUITY_TRUSTED_SERVERS", trusted_servers|tojson) %}
+{% do c1.environment.add_env("CONTINUWUITY_TRUSTED_SERVERS", trusted_servers.x|tojson) %}
 
 {% do c1.environment.add_user_envs(values.continuwuity.additional_envs) %}
 

--- a/ix-dev/community/continuwuity/templates/docker-compose.yaml
+++ b/ix-dev/community/continuwuity/templates/docker-compose.yaml
@@ -14,8 +14,18 @@
 {% do c1.environment.add_env("CONTINUWUITY_SERVER_NAME", values.continuwuity.server_name) %}
 {% do c1.environment.add_env("CONTINUWUITY_ALLOW_REGISTRATION", values.continuwuity.allow_registration) %}
 {% do c1.environment.add_env("CONTINUWUITY_REGISTRATION_TOKEN", values.continuwuity.registration_token) %}
+{% set trusted_servers = [] %}
+{% if values.continuwuity.allow_federation %}
+  {% for srv in values.continuwuity.trusted_servers %}
+    {% set clean_server = srv.server | replace("https://", "") | replace("http://", "") | replace("/", "") %}
+    {% if clean_server %}
+      {% do trusted_servers.append(clean_server) %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
 {% do c1.environment.add_env("CONTINUWUITY_ALLOW_FEDERATION", values.continuwuity.allow_federation) %}
-{% do c1.environment.add_env("CONTINUWUITY_TRUSTED_SERVERS", values.continuwuity.trusted_servers|tojson) %}
+{% do c1.environment.add_env("CONTINUWUITY_TRUSTED_SERVERS", trusted_servers|tojson) %}
 
 {% do c1.environment.add_user_envs(values.continuwuity.additional_envs) %}
 

--- a/ix-dev/community/continuwuity/templates/docker-compose.yaml
+++ b/ix-dev/community/continuwuity/templates/docker-compose.yaml
@@ -21,7 +21,7 @@
 {% if values.continuwuity.allow_federation and values.continuwuity.trusted_servers %}
   {% set trusted_servers = namespace(x=[]) %}
   {% for srv in values.continuwuity.trusted_servers %}
-    {% set parsed = tpl.funcs.url_to_dict(srv, v6_brackets=true)) %}
+    {% set parsed = tpl.funcs.url_to_dict(srv, v6_brackets=true) %}
     {% set host = "%s:%d"|format(parsed.host, parsed.port) if parsed.port else parsed.host %}
     {% do trusted_servers.x.append(host) %}
   {% endfor %}

--- a/ix-dev/community/continuwuity/templates/docker-compose.yaml
+++ b/ix-dev/community/continuwuity/templates/docker-compose.yaml
@@ -13,7 +13,9 @@
 {% do c1.environment.add_env("CONTINUWUITY_DATABASE_PATH", values.consts.database_path) %}
 {% do c1.environment.add_env("CONTINUWUITY_SERVER_NAME", values.continuwuity.server_name) %}
 {% do c1.environment.add_env("CONTINUWUITY_ALLOW_REGISTRATION", values.continuwuity.allow_registration) %}
+{% if values.continuwuity.allow_registration %}
 {% do c1.environment.add_env("CONTINUWUITY_REGISTRATION_TOKEN", values.continuwuity.registration_token) %}
+{% endif %}
 {% set trusted_servers = [] %}
 {% if values.continuwuity.allow_federation %}
   {% for srv in values.continuwuity.trusted_servers %}

--- a/ix-dev/community/continuwuity/templates/docker-compose.yaml
+++ b/ix-dev/community/continuwuity/templates/docker-compose.yaml
@@ -21,7 +21,7 @@
 {% if values.continuwuity.allow_federation and values.continuwuity.trusted_servers %}
   {% set trusted_servers = namespace(x=[]) %}
   {% for srv in values.continuwuity.trusted_servers %}
-    {% set parsed = tpl.funcs.url_to_dict(srv) %}
+    {% set parsed = tpl.funcs.url_to_dict(srv, v6_brackets=true)) %}
     {% set host = "%s:%d"|format(parsed.host, parsed.port) if parsed.port else parsed.host %}
     {% do trusted_servers.x.append(host) %}
   {% endfor %}

--- a/ix-dev/community/continuwuity/templates/test_values/no-federation-values.yaml
+++ b/ix-dev/community/continuwuity/templates/test_values/no-federation-values.yaml
@@ -1,0 +1,33 @@
+resources:
+  limits:
+    cpus: 2.0
+    memory: 4096
+
+continuwuity:
+  server_name: example.com
+  allow_registration: true
+  allow_federation: false
+  registration_token: ""
+  trusted_servers: []
+  additional_envs: []
+
+network:
+  web_port:
+    bind_mode: published
+    port_number: 8080
+  host_network: false
+
+run_as:
+  user: 568
+  group: 568
+
+ix_volumes:
+  data: /opt/tests/mnt/continuwuity/data
+
+storage:
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: data
+      create_host_path: true
+  additional_storage: []

--- a/ix-dev/community/continuwuity/templates/test_values/no-federation-values.yaml
+++ b/ix-dev/community/continuwuity/templates/test_values/no-federation-values.yaml
@@ -5,7 +5,7 @@ resources:
 
 continuwuity:
   server_name: example.com
-  allow_registration: true
+  allow_registration: false
   allow_federation: false
   registration_token: ""
   trusted_servers: []


### PR DESCRIPTION
Round 2, electric boolagoo! This PR should solve a bug with continwuity preventing one from starting an instance. Its quite hacky so I welcome some feedback, but I essentially just need to be able to ensure that if no trusted_servers are passed, an empty string is not passed to the app. This causes a crash. I validated this fix on my own instance of truenas (manual changes... dangerous I know).

Is there a better way to do this? Am I properly ensuring people just enter domains and dont need the protocol (http/https)?

Feedback is appreciated. I'm a bit out of my depth with this lol