### PR TITLE
Update app version to 10.1.89, CVE-2026-22557, rated 10

### DIFF
--- a/ix-dev/community/unifi-controller/app.yaml
+++ b/ix-dev/community/unifi-controller/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: 10.0.162-mongo8
+app_version: 10.1.89
 capabilities: []
 categories:
 - networking


### PR DESCRIPTION
related link: https://community.ui.com/releases/Security-Advisory-Bulletin-062-062/c29719c0-405e-4d4a-8f26-e343e99f931b

no need for explicit mongo db as this is defualt in upstream