### PR TITLE
feat(community): update Toparr to 2.0.0

### DIFF
--- a/ix-dev/community/toparr/app.yaml
+++ b/ix-dev/community/toparr/app.yaml
@@ -1,4 +1,4 @@
-app_version: 1.2.0
+app_version: 2.0.0
 capabilities:
 - description: Toparr is able to bypass read/execute permission checks
   name: DAC_READ_SEARCH
@@ -46,4 +46,4 @@ sources:
 - https://ghcr.io/ajthom90/toparr
 title: Toparr
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/toparr/ix_values.yaml
+++ b/ix-dev/community/toparr/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/ajthom90/toparr
-    tag: 1.2.0
+    tag: 2.0.0
 
 consts:
   toparr_container_name: toparr


### PR DESCRIPTION
## Summary
- Update Toparr Intel GPU Monitor from 1.2.0 to 2.0.0
- Bumps container image tag to `ghcr.io/ajthom90/toparr:2.0.0`
- Increments app version from 1.0.2 to 1.0.3

## Test plan
- [ ] CI renders docker-compose template successfully with test values
- [ ] Container image `ghcr.io/ajthom90/toparr:2.0.0` exists and is pullable
- [ ] App installs and starts correctly on TrueNAS SCALE

🤖 Generated with [Claude Code](https://claude.com/claude-code)