### PR TITLE
databasus: allow changing running user of subprocs

### DIFF
--- a/ix-dev/community/databasus/app.yaml
+++ b/ix-dev/community/databasus/app.yaml
@@ -42,4 +42,4 @@ sources:
 - https://hub.docker.com/r/databasus/databasus
 title: Databasus
 train: community
-version: 1.0.3
+version: 1.0.4

--- a/ix-dev/community/databasus/questions.yaml
+++ b/ix-dev/community/databasus/questions.yaml
@@ -1,6 +1,8 @@
 groups:
   - name: Databasus Configuration
     description: Configure Databasus
+  - name: User and Group Configuration
+    description: Configure User and Group for Databasus
   - name: Network Configuration
     description: Configure Network for Databasus
   - name: Storage Configuration
@@ -38,6 +40,29 @@ questions:
                       label: Value
                       schema:
                         type: string
+
+  - variable: run_as
+    label: ""
+    group: User and Group Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: user
+          label: User ID
+          description: The user id that Databasus files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+        - variable: group
+          label: Group ID
+          description: The group id that Databasus files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
 
   - variable: network
     label: ""
@@ -178,7 +203,8 @@ questions:
                                           "null": true
                                       - variable: priority
                                         label: Priority (Optional)
-                                        description: Indicates in which order Compose connects the service's containers to its networks.
+                                        description: Indicates in which order Compose connects the service's containers
+                                          to its networks.
                                         schema:
                                           type: int
                                           "null": true

--- a/ix-dev/community/databasus/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/databasus/templates/test_values/basic-values.yaml
@@ -12,6 +12,10 @@ network:
     bind_mode: published
     port_number: 30405
 
+run_as:
+  user: 568
+  group: 568
+
 ix_volumes:
   data: /opt/tests/mnt/databasus/data
 


### PR DESCRIPTION
Latest update allows setting PUID/PGID to configure user for subprocesses.
Tho container still runs as root