### PR TITLE
stdapi-ai: add changelog URL

### DIFF
--- a/ix-dev/community/stdapi-ai/app.yaml
+++ b/ix-dev/community/stdapi-ai/app.yaml
@@ -2,7 +2,7 @@ app_version: 1.8.0
 capabilities: []
 categories:
 - ai
-changelog_url: https://stdapi.ai/roadmap/
+changelog_url: https://stdapi.ai/roadmap/#release-history
 date_added: '2026-03-24'
 description: OpenAI and Anthropic compatible API gateway for AWS Bedrock. Access 80+
   models including Claude, Nova, Deepseek, Mistral, and Minimax with enterprise compliance


### PR DESCRIPTION
Bump stdapi-ai to version 1.8.0 and add changelog URL.