### PR TITLE
openclaw: bump resources for the config container

### DIFF
--- a/ix-dev/community/openclaw/app.yaml
+++ b/ix-dev/community/openclaw/app.yaml
@@ -30,4 +30,4 @@ sources:
 - https://github.com/openclaw/openclaw
 title: OpenClaw
 train: community
-version: 1.0.14
+version: 1.0.15

--- a/ix-dev/community/openclaw/app.yaml
+++ b/ix-dev/community/openclaw/app.yaml
@@ -30,4 +30,4 @@ sources:
 - https://github.com/openclaw/openclaw
 title: OpenClaw
 train: community
-version: 1.0.13
+version: 1.0.14

--- a/ix-dev/community/openclaw/templates/docker-compose.yaml
+++ b/ix-dev/community/openclaw/templates/docker-compose.yaml
@@ -21,7 +21,7 @@
   {% endfor %}
 {% endfor %}
 
-{% do config.setup_as_helper(disable_network=false) %}
+{% do config.setup_as_helper(disable_network=false, profile="medium") %}
 {% do config.set_entrypoint(["/entrypoint.sh"]) %}
 {% do config.set_tty(true) %}
 


### PR DESCRIPTION
Bumps up the resources for the config container to 1G memory (from 512M).
It _should_ be plenty enough.
Tho a CLI reaching to 512M is _too much_, but hey.

Closes #4795