### PR TITLE
Add Caddy reverse proxy as community app

### DIFF
--- a/ix-dev/community/caddy/README.md
+++ b/ix-dev/community/caddy/README.md
@@ -1,0 +1,3 @@
+# Caddy
+
+[Caddy](https://caddyserver.com/) is a powerful, extensible platform to serve your sites, services, and apps with automatic HTTPS.

--- a/ix-dev/community/caddy/app.yaml
+++ b/ix-dev/community/caddy/app.yaml
@@ -1,0 +1,42 @@
+"annotations":
+  "min_scale_version": "24.10.2.2"
+"app_version": "2.9.1"
+"capabilities":
+- "description": "Caddy is able to bind to privileged ports."
+  "name": "NET_BIND_SERVICE"
+"categories":
+- "networking"
+"changelog_url": "https://github.com/caddyserver/caddy/releases"
+"date_added": "2026-04-13"
+"description": "Caddy is a powerful, extensible platform to serve your sites, services,\
+  \ and apps with automatic HTTPS."
+"home": "https://caddyserver.com"
+"host_mounts": []
+"icon": "https://media.sys.truenas.net/apps/caddy/icons/icon.svg"
+"keywords":
+- "networking"
+- "reverse-proxy"
+- "https"
+- "tls"
+- "web-server"
+"last_update": "2026-04-13 00:00:00"
+"lib_version": "2.3.1"
+"lib_version_hash": "561017357f22eafbedca2a97f747325cb83149fe1b5f765a2fbda71ab77d96ed"
+"maintainers":
+- "email": "dev@truenas.com"
+  "name": "truenas"
+  "url": "https://www.truenas.com/"
+"name": "caddy"
+"run_as_context":
+- "description": "Container [caddy] runs as non-root user and group."
+  "gid": 568
+  "group_name": "Host group is [apps]"
+  "uid": 568
+  "user_name": "Host user is [apps]"
+"screenshots": []
+"sources":
+- "https://caddyserver.com"
+- "https://github.com/caddyserver/caddy"
+"title": "Caddy"
+"train": "community"
+"version": "1.0.0"

--- a/ix-dev/community/caddy/app.yaml
+++ b/ix-dev/community/caddy/app.yaml
@@ -20,8 +20,8 @@
 - "tls"
 - "web-server"
 "last_update": "2026-04-13 00:00:00"
-"lib_version": "2.3.1"
-"lib_version_hash": "561017357f22eafbedca2a97f747325cb83149fe1b5f765a2fbda71ab77d96ed"
+"lib_version": "2.3.2"
+"lib_version_hash": "b6a043c5dc3d4ba71901b9833713b4352b031f3bf39a1b3908e2cf17f1129d8d"
 "maintainers":
 - "email": "dev@truenas.com"
   "name": "truenas"

--- a/ix-dev/community/caddy/item.yaml
+++ b/ix-dev/community/caddy/item.yaml
@@ -1,0 +1,8 @@
+categories:
+- networking
+icon_url: https://media.sys.truenas.net/apps/caddy/icons/icon.svg
+screenshots: []
+tags:
+- networking
+- reverse-proxy
+- web-server

--- a/ix-dev/community/caddy/ix_values.yaml
+++ b/ix-dev/community/caddy/ix_values.yaml
@@ -1,0 +1,14 @@
+images:
+  image:
+    repository: caddy
+    tag: 2.9.1
+  container_utils_image:
+    repository: ixsystems/container-utils
+    tag: 1.0.2
+
+consts:
+  caddy_container_name: caddy
+  perms_container_name: permissions
+  config_path: /etc/caddy
+  data_path: /data
+  admin_port: 2019

--- a/ix-dev/community/caddy/questions.yaml
+++ b/ix-dev/community/caddy/questions.yaml
@@ -686,12 +686,12 @@ questions:
                 description: CPUs limit for Caddy.
                 schema:
                   type: int
-                  default: 2
+                  default: 1
                   required: true
               - variable: memory
                 label: Memory (in MB)
                 description: Memory limit for Caddy.
                 schema:
                   type: int
-                  default: 4096
+                  default: 1024
                   required: true

--- a/ix-dev/community/caddy/questions.yaml
+++ b/ix-dev/community/caddy/questions.yaml
@@ -1,0 +1,697 @@
+groups:
+  - name: Caddy Configuration
+    description: Configure Caddy
+  - name: User and Group Configuration
+    description: Configure User and Group for Caddy
+  - name: Network Configuration
+    description: Configure Network for Caddy
+  - name: Storage Configuration
+    description: Configure Storage for Caddy
+  - name: Labels Configuration
+    description: Configure Labels for Caddy
+  - name: Resources Configuration
+    description: Configure Resources for Caddy
+
+questions:
+  - variable: TZ
+    group: Caddy Configuration
+    label: Timezone
+    schema:
+      type: string
+      default: Etc/UTC
+      required: true
+      $ref:
+        - definitions/timezone
+
+  - variable: caddy
+    label: ""
+    group: Caddy Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: additional_envs
+          label: Additional Environment Variables
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: env
+                label: Environment Variable
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: Name
+                      schema:
+                        type: string
+                        required: true
+                    - variable: value
+                      label: Value
+                      schema:
+                        type: string
+
+  - variable: run_as
+    label: ""
+    group: User and Group Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: user
+          label: User ID
+          description: The user id that Caddy files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+        - variable: group
+          label: Group ID
+          description: The group id that Caddy files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+
+  - variable: network
+    label: ""
+    group: Network Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: http_port
+          label: HTTP Port
+          description: The port for HTTP traffic
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 80
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if: [["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
+        - variable: https_port
+          label: HTTPS Port
+          description: The port for HTTPS traffic
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 443
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if: [["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
+        - variable: admin_port
+          label: Admin API Port
+          description: The port for Caddy's admin API (used for health checks and configuration)
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: ""
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 2019
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if: [["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
+        - variable: networks
+          label: Networks
+          description: The docker networks to join
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: network
+                label: Network
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: Name
+                      description: |
+                        The name of the network to join.</br>
+                        The network must already exist.
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: containers
+                      label: Containers
+                      description: The containers to add to this network.
+                      schema:
+                        type: list
+                        items:
+                          - variable: container
+                            label: Container
+                            schema:
+                              type: dict
+                              attrs:
+                                - variable: name
+                                  label: Container Name
+                                  schema:
+                                    type: string
+                                    required: true
+                                    enum:
+                                      - value: caddy
+                                        description: caddy
+                                - variable: config
+                                  label: Container Network Configuration
+                                  schema:
+                                    type: dict
+                                    attrs:
+                                      - variable: aliases
+                                        label: Aliases (Optional)
+                                        description: The network aliases to use for this container on this network.
+                                        schema:
+                                          type: list
+                                          default: []
+                                          items:
+                                            - variable: alias
+                                              label: Alias
+                                              schema:
+                                                type: string
+                                      - variable: interface_name
+                                        label: Interface Name (Optional)
+                                        description: The network interface name to use for this network
+                                        schema:
+                                          type: string
+                                      - variable: mac_address
+                                        label: MAC Address (Optional)
+                                        description: The MAC address to use for this network interface.
+                                        schema:
+                                          type: string
+                                      - variable: ipv4_address
+                                        label: IPv4 Address (Optional)
+                                        description: The IPv4 address to use for this network interface.
+                                        schema:
+                                          type: string
+                                      - variable: ipv6_address
+                                        label: IPv6 Address (Optional)
+                                        description: The IPv6 address to use for this network interface.
+                                        schema:
+                                          type: string
+                                      - variable: gw_priority
+                                        label: Gateway Priority (Optional)
+                                        description: Indicates the priority of the gateway for this network interface.
+                                        schema:
+                                          type: int
+                                          "null": true
+                                      - variable: priority
+                                        label: Priority (Optional)
+                                        description: Indicates in which order Compose connects the service's containers to its networks.
+                                        schema:
+                                          type: int
+                                          "null": true
+
+  - variable: storage
+    label: ""
+    group: Storage Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: config
+          label: Caddy Config Storage
+          description: |
+            The path to store Caddy configuration files (Caddyfile).</br>
+            Place your Caddyfile in this directory.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "config"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+
+        - variable: data
+          label: Caddy Data Storage
+          description: |
+            The path to store Caddy data (TLS certificates, etc.).</br>
+            This should be persistent to avoid re-issuing certificates.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "data"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+
+        - variable: additional_storage
+          label: Additional Storage
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: storageEntry
+                label: Storage Entry
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: type
+                      label: Type
+                      description: |
+                        ixVolume: Is dataset created automatically by the system.</br>
+                        Host Path: Is a path that already exists on the system.</br>
+                        SMB Share: Is a SMB share that is mounted to as a volume.</br>
+                        NFS Share: Is a NFS share that is mounted to as a volume.
+                      schema:
+                        type: string
+                        required: true
+                        default: "ix_volume"
+                        enum:
+                          - value: "host_path"
+                            description: Host Path (Path that already exists on the system)
+                          - value: "ix_volume"
+                            description: ixVolume (Dataset created automatically by the system)
+                          - value: "cifs"
+                            description: SMB/CIFS Share (Mounts a volume to a SMB share)
+                          - value: "nfs"
+                            description: NFS Share (Mounts a volume to a NFS share)
+                    - variable: read_only
+                      label: Read Only
+                      description: Mount the volume as read only.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: mount_path
+                      label: Mount Path
+                      description: The path inside the container to mount the storage.
+                      schema:
+                        type: path
+                        required: true
+                    - variable: host_path_config
+                      label: Host Path Configuration
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "host_path"]]
+                        attrs:
+                          - variable: acl_enable
+                            label: Enable ACL
+                            description: Enable ACL for the storage.
+                            schema:
+                              type: boolean
+                              default: false
+                          - variable: acl
+                            label: ACL Configuration
+                            schema:
+                              type: dict
+                              show_if: [["acl_enable", "=", true]]
+                              attrs: []
+                              $ref:
+                                - "normalize/acl"
+                          - variable: path
+                            label: Host Path
+                            description: The host path to use for storage.
+                            schema:
+                              type: hostpath
+                              show_if: [["acl_enable", "=", false]]
+                              required: true
+                    - variable: ix_volume_config
+                      label: ixVolume Configuration
+                      description: The configuration for the ixVolume dataset.
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "ix_volume"]]
+                        $ref:
+                          - "normalize/ix_volume"
+                        attrs:
+                          - variable: acl_enable
+                            label: Enable ACL
+                            description: Enable ACL for the storage.
+                            schema:
+                              type: boolean
+                              default: false
+                          - variable: dataset_name
+                            label: Dataset Name
+                            description: The name of the dataset to use for storage.
+                            schema:
+                              type: string
+                              required: true
+                              default: "storage_entry"
+                          - variable: acl_entries
+                            label: ACL Configuration
+                            schema:
+                              type: dict
+                              show_if: [["acl_enable", "=", true]]
+                              attrs: []
+                              $ref:
+                                - "normalize/acl"
+                    - variable: cifs_config
+                      label: SMB Configuration
+                      description: The configuration for the SMB dataset.
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "cifs"]]
+                        attrs:
+                          - variable: server
+                            label: Server
+                            description: The server to mount the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                          - variable: path
+                            label: Path
+                            description: The path to mount the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                          - variable: username
+                            label: Username
+                            description: The username to use for the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                          - variable: password
+                            label: Password
+                            description: The password to use for the SMB share.
+                            schema:
+                              type: string
+                              required: true
+                              private: true
+                          - variable: domain
+                            label: Domain
+                            description: The domain to use for the SMB share.
+                            schema:
+                              type: string
+                    - variable: nfs_config
+                      label: NFS Configuration
+                      description: The configuration for the NFS dataset.
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "nfs"]]
+                        attrs:
+                          - variable: server
+                            label: Server
+                            description: The server to mount the NFS share.
+                            schema:
+                              type: string
+                              required: true
+                          - variable: path
+                            label: Path
+                            description: The path to mount the NFS share.
+                            schema:
+                              type: string
+                              required: true
+
+  - variable: labels
+    label: ""
+    group: Labels Configuration
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: label
+          label: Label
+          schema:
+            type: dict
+            attrs:
+              - variable: key
+                label: Key
+                schema:
+                  type: string
+                  required: true
+              - variable: value
+                label: Value
+                schema:
+                  type: string
+                  required: true
+              - variable: containers
+                label: Containers
+                description: Containers where the label should be applied
+                schema:
+                  type: list
+                  items:
+                    - variable: container
+                      label: Container
+                      schema:
+                        type: string
+                        required: true
+                        enum:
+                          - value: caddy
+                            description: caddy
+
+  - variable: resources
+    label: ""
+    group: Resources Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: limits
+          label: Limits
+          schema:
+            type: dict
+            attrs:
+              - variable: cpus
+                label: CPUs
+                description: CPUs limit for Caddy.
+                schema:
+                  type: int
+                  default: 2
+                  required: true
+              - variable: memory
+                label: Memory (in MB)
+                description: Memory limit for Caddy.
+                schema:
+                  type: int
+                  default: 4096
+                  required: true

--- a/ix-dev/community/caddy/templates/docker-compose.yaml
+++ b/ix-dev/community/caddy/templates/docker-compose.yaml
@@ -1,0 +1,39 @@
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{% set c1 = tpl.add_container(values.consts.caddy_container_name, "image") %}
+{% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
+{% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
+
+{% do c1.set_user(values.run_as.user, values.run_as.group) %}
+{% do c1.add_caps(["NET_BIND_SERVICE"]) %}
+{% do c1.environment.add_user_envs(values.caddy.additional_envs) %}
+{% do c1.healthcheck.set_custom_test([
+  "CMD", "wget",
+  "--no-verbose",
+  "--tries=1",
+  "--spider",
+  "http://localhost:%d/config/" | format(values.consts.admin_port),
+]) %}
+
+{% do c1.add_port(values.network.http_port) %}
+{% do c1.add_port(values.network.https_port) %}
+{% do c1.add_port(values.network.admin_port) %}
+
+{% do c1.add_storage(values.consts.config_path, values.storage.config) %}
+{% do perm_container.add_or_skip_action("config", values.storage.config, perms_config) %}
+{% do c1.add_storage(values.consts.data_path, values.storage.data) %}
+{% do perm_container.add_or_skip_action("data", values.storage.data, perms_config) %}
+
+{% for store in values.storage.additional_storage %}
+  {% do c1.add_storage(store.mount_path, store) %}
+  {% do perm_container.add_or_skip_action(store.mount_path, store, perms_config) %}
+{% endfor %}
+
+{% if perm_container.has_actions() %}
+  {% do perm_container.activate() %}
+  {% do c1.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
+{% endif %}
+
+{% do tpl.portals.add(values.network.http_port) %}
+
+{{ tpl.render() | tojson }}

--- a/ix-dev/community/caddy/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/caddy/templates/test_values/basic-values.yaml
@@ -1,7 +1,7 @@
 resources:
   limits:
-    cpus: 2.0
-    memory: 4096
+    cpus: 1.0
+    memory: 1024
 
 caddy:
   additional_envs: []

--- a/ix-dev/community/caddy/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/caddy/templates/test_values/basic-values.yaml
@@ -1,0 +1,40 @@
+resources:
+  limits:
+    cpus: 2.0
+    memory: 4096
+
+caddy:
+  additional_envs: []
+
+network:
+  host_network: false
+  http_port:
+    bind_mode: published
+    port_number: 80
+  https_port:
+    bind_mode: published
+    port_number: 443
+  admin_port:
+    bind_mode: ""
+    port_number: 2019
+
+run_as:
+  user: 568
+  group: 568
+
+ix_volumes:
+  config: /opt/tests/mnt/caddy/config
+  data: /opt/tests/mnt/caddy/data
+
+storage:
+  config:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: config
+      create_host_path: true
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: data
+      create_host_path: true
+  additional_storage: []


### PR DESCRIPTION
## Summary

- Adds [Caddy](https://caddyserver.com/) as a new community application
- Caddy is a powerful, extensible platform to serve sites, services, and apps with **automatic HTTPS**
- Single-container app using the official `caddy:2.9.1` Docker image

## App Details

- **Ports**: HTTP (80), HTTPS (443), Admin API (2019, unexposed by default)
- **Storage**: Config volume (`/etc/caddy` for Caddyfile), Data volume (`/data` for TLS certificates)
- **Capabilities**: `NET_BIND_SERVICE` for binding privileged ports
- **Runs as**: non-root user (uid/gid 568, apps user)
- **Health check**: Caddy admin API endpoint

## Why Caddy?

Caddy fills a gap in the community catalog — there is `nginx-proxy-manager` and `traefik`, but no Caddy option. Caddy is popular for its:
- Automatic HTTPS with Let's Encrypt / ZeroSSL out of the box
- Simple Caddyfile configuration syntax
- Built-in reverse proxy with load balancing
- Zero-downtime config reloads

A [feature request](https://forums.truenas.com/t/closed-new-app-catalogue-request-caddy-reverse-proxy/47490) was previously filed on the TrueNAS forums.

## Test plan

- [ ] Verify app installs and starts successfully on TrueNAS SCALE
- [ ] Verify health check passes via admin API
- [ ] Verify HTTP/HTTPS ports are accessible
- [ ] Verify Caddyfile is read from config storage mount
- [ ] Verify TLS certificates persist in data storage across restarts
- [ ] CI test values pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)