### PR TITLE
Add omni-infra-provider-truenas community app

### DIFF
--- a/ix-dev/community/omni-infra-provider-truenas/README.md
+++ b/ix-dev/community/omni-infra-provider-truenas/README.md
@@ -1,3 +1,3 @@
 Automatically provisions and manages Talos Linux VMs on TrueNAS SCALE through [Sidero Omni](https://omni.siderolabs.com/), turning your NAS into a fully automated Kubernetes platform.
 
-Requires TrueNAS SCALE 25.04+ (Fangtooth). Uses the JSON-RPC 2.0 API via the middleware Unix socket — no API key needed.
+Requires TrueNAS SCALE 25.10+ (Goldeye). Connects to TrueNAS via JSON-RPC 2.0 over WebSocket. An API key is required — create one in **Credentials > Local Users > root > API Keys**.

--- a/ix-dev/community/omni-infra-provider-truenas/README.md
+++ b/ix-dev/community/omni-infra-provider-truenas/README.md
@@ -1,0 +1,3 @@
+Automatically provisions and manages Talos Linux VMs on TrueNAS SCALE through [Sidero Omni](https://omni.siderolabs.com/), turning your NAS into a fully automated Kubernetes platform.
+
+Requires TrueNAS SCALE 25.04+ (Fangtooth). Uses the JSON-RPC 2.0 API via the middleware Unix socket — no API key needed.

--- a/ix-dev/community/omni-infra-provider-truenas/app.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/app.yaml
@@ -1,4 +1,4 @@
-app_version: v0.14.0
+app_version: v0.14.1
 capabilities: []
 categories:
 - networking

--- a/ix-dev/community/omni-infra-provider-truenas/app.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/app.yaml
@@ -1,0 +1,40 @@
+app_version: v0.13.0
+capabilities: []
+categories:
+- networking
+date_added: '2026-04-12'
+description: Automatically provisions and manages Talos Linux VMs on TrueNAS SCALE
+  through Sidero Omni, turning your NAS into a Kubernetes platform.
+home: https://github.com/bearbinary/omni-infra-provider-truenas
+host_mounts:
+- description: TrueNAS middleware Unix socket for zero-auth API access
+  host_path: /var/run/middleware
+icon: https://raw.githubusercontent.com/bearbinary/omni-infra-provider-truenas/main/assets/logo_with_name.png
+keywords:
+- kubernetes
+- omni
+- talos
+- infrastructure
+- sidero
+- vm
+- truenas
+lib_version: 2.3.1
+lib_version_hash: 561017357f22eafbedca2a97f747325cb83149fe1b5f765a2fbda71ab77d96ed
+maintainers:
+- email: zac@bearbinary.com
+  name: bearbinary
+  url: https://github.com/bearbinary
+name: omni-infra-provider-truenas
+run_as_context:
+- description: Container [omni-infra-provider-truenas] runs as non-root user (nobody).
+  gid: 65534
+  group_name: Host group is [nobody]
+  uid: 65534
+  user_name: Host user is [nobody]
+screenshots: []
+sources:
+- https://github.com/bearbinary/omni-infra-provider-truenas
+- https://ghcr.io/bearbinary/omni-infra-provider-truenas
+title: Omni TrueNAS Provider
+train: community
+version: 1.0.0

--- a/ix-dev/community/omni-infra-provider-truenas/app.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/app.yaml
@@ -1,4 +1,4 @@
-app_version: v0.13.0
+app_version: v0.14.0
 capabilities: []
 categories:
 - networking
@@ -6,9 +6,7 @@ date_added: '2026-04-12'
 description: Automatically provisions and manages Talos Linux VMs on TrueNAS SCALE
   through Sidero Omni, turning your NAS into a Kubernetes platform.
 home: https://github.com/bearbinary/omni-infra-provider-truenas
-host_mounts:
-- description: TrueNAS middleware Unix socket for zero-auth API access
-  host_path: /var/run/middleware
+host_mounts: []
 icon: https://raw.githubusercontent.com/bearbinary/omni-infra-provider-truenas/main/assets/logo_with_name.png
 keywords:
 - kubernetes
@@ -18,8 +16,8 @@ keywords:
 - sidero
 - vm
 - truenas
-lib_version: 2.3.1
-lib_version_hash: 561017357f22eafbedca2a97f747325cb83149fe1b5f765a2fbda71ab77d96ed
+lib_version: 2.3.2
+lib_version_hash: b6a043c5dc3d4ba71901b9833713b4352b031f3bf39a1b3908e2cf17f1129d8d
 maintainers:
 - email: zac@bearbinary.com
   name: bearbinary

--- a/ix-dev/community/omni-infra-provider-truenas/ix_values.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/bearbinary/omni-infra-provider-truenas
-    tag: v0.14.0
+    tag: v0.14.1
 
 consts:
   provider_container_name: omni-infra-provider-truenas

--- a/ix-dev/community/omni-infra-provider-truenas/ix_values.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/ix_values.yaml
@@ -1,0 +1,7 @@
+images:
+  image:
+    repository: ghcr.io/bearbinary/omni-infra-provider-truenas
+    tag: v0.13.0
+
+consts:
+  provider_container_name: omni-infra-provider-truenas

--- a/ix-dev/community/omni-infra-provider-truenas/ix_values.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/bearbinary/omni-infra-provider-truenas
-    tag: v0.13.0
+    tag: v0.14.0
 
 consts:
   provider_container_name: omni-infra-provider-truenas

--- a/ix-dev/community/omni-infra-provider-truenas/questions.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/questions.yaml
@@ -1,0 +1,188 @@
+groups:
+  - name: Omni Connection
+    description: Configure the connection to Sidero Omni
+  - name: VM Defaults
+    description: Default settings for provisioned VMs
+  - name: Advanced
+    description: Advanced provider settings
+  - name: Resources Configuration
+    description: Configure Resources for Omni TrueNAS Provider
+
+questions:
+  - variable: omni_provider
+    label: ""
+    group: Omni Connection
+    schema:
+      type: dict
+      attrs:
+        - variable: omni_endpoint
+          label: Omni Endpoint
+          description: |
+            Full URL of your Omni instance (e.g., https://omni.example.com).
+          schema:
+            type: string
+            required: true
+        - variable: omni_service_account_key
+          label: Omni Service Account Key
+          description: |
+            Base64-encoded service account key.</br>
+            Create with: <code>omnictl serviceaccount create --role=InfraProvider infra-provider:truenas</code>
+          schema:
+            type: string
+            required: true
+            private: true
+        - variable: omni_insecure_skip_verify
+          label: Skip Omni TLS Verification
+          description: Disable TLS certificate verification for the Omni endpoint.
+          schema:
+            type: boolean
+            default: false
+        - variable: provider_id
+          label: Provider ID
+          description: |
+            Unique provider identifier registered in Omni.</br>
+            Change only if running multiple providers on different TrueNAS hosts.
+          schema:
+            type: string
+            default: "truenas"
+            required: true
+        - variable: provider_name
+          label: Provider Display Name
+          description: How this provider appears in the Omni UI.
+          schema:
+            type: string
+            default: "TrueNAS"
+        - variable: provider_description
+          label: Provider Description
+          schema:
+            type: string
+            default: "TrueNAS SCALE infrastructure provider"
+        - variable: additional_envs
+          label: Additional Environment Variables
+          description: Configure additional environment variables for the provider.
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: env
+                label: Environment Variable
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: Name
+                      schema:
+                        type: string
+                        required: true
+                    - variable: value
+                      label: Value
+                      schema:
+                        type: string
+
+  - variable: vm_defaults
+    label: ""
+    group: VM Defaults
+    schema:
+      type: dict
+      attrs:
+        - variable: default_pool
+          label: Default ZFS Pool
+          description: |
+            ZFS pool used for VM zvols and cached ISO images.</br>
+            Run <code>zpool list</code> to see available pools.
+          schema:
+            type: string
+            default: "default"
+            required: true
+        - variable: default_network_interface
+          label: Default Network Interface
+          description: |
+            Host network interface for VM NICs.</br>
+            Can be a bridge (br0), VLAN interface (vlan100), or physical interface (enp5s0).</br>
+            Run <code>midclt call vm.device.nic_attach_choices</code> to see available options.
+          schema:
+            type: string
+            default: ""
+        - variable: default_boot_method
+          label: Default Boot Method
+          schema:
+            type: string
+            default: "UEFI"
+            enum:
+              - value: "UEFI"
+                description: UEFI boot (recommended)
+              - value: "BIOS"
+                description: Legacy BIOS boot
+        - variable: graceful_shutdown_timeout
+          label: Graceful Shutdown Timeout (seconds)
+          description: Seconds to wait for ACPI shutdown before force-stop on deprovision.
+          schema:
+            type: int
+            default: 30
+            min: 0
+            max: 300
+
+  - variable: advanced
+    label: ""
+    group: Advanced
+    schema:
+      type: dict
+      attrs:
+        - variable: concurrency
+          label: Concurrency
+          description: Maximum number of parallel provision/deprovision operations.
+          schema:
+            type: int
+            default: 4
+            min: 1
+            max: 16
+        - variable: log_level
+          label: Log Level
+          schema:
+            type: string
+            default: "info"
+            enum:
+              - value: "debug"
+                description: Debug
+              - value: "info"
+                description: Info
+              - value: "warn"
+                description: Warning
+              - value: "error"
+                description: Error
+        - variable: max_error_recoveries
+          label: Max Error Recoveries
+          description: |
+            Max consecutive ERROR state recoveries before auto-replacing a VM.</br>
+            Set to -1 to disable the circuit breaker.
+          schema:
+            type: int
+            default: 5
+            min: -1
+            max: 100
+
+  - variable: resources
+    label: ""
+    group: Resources Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: limits
+          label: Limits
+          schema:
+            type: dict
+            attrs:
+              - variable: cpus
+                label: CPUs
+                description: CPUs limit for the provider container.
+                schema:
+                  type: int
+                  default: 2
+                  required: true
+              - variable: memory
+                label: Memory (in MB)
+                description: Memory limit for the provider container.
+                schema:
+                  type: int
+                  default: 512
+                  required: true

--- a/ix-dev/community/omni-infra-provider-truenas/questions.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/questions.yaml
@@ -1,6 +1,8 @@
 groups:
   - name: Omni Connection
     description: Configure the connection to Sidero Omni
+  - name: TrueNAS Connection
+    description: API credentials for the local TrueNAS middleware
   - name: VM Defaults
     description: Default settings for provisioned VMs
   - name: Advanced
@@ -78,6 +80,37 @@ questions:
                       label: Value
                       schema:
                         type: string
+
+  - variable: truenas
+    label: ""
+    group: TrueNAS Connection
+    schema:
+      type: dict
+      attrs:
+        - variable: host
+          label: TrueNAS Host
+          description: |
+            TrueNAS hostname or IP. Use <code>localhost</code> when running as a TrueNAS app.
+          schema:
+            type: string
+            default: "localhost"
+            required: true
+        - variable: api_key
+          label: TrueNAS API Key
+          description: |
+            Create in the TrueNAS UI: <b>Credentials > Local Users > root > API Keys</b>.
+          schema:
+            type: string
+            required: true
+            private: true
+        - variable: insecure_skip_verify
+          label: Skip TLS Verification
+          description: |
+            Skip TLS certificate verification. Recommended <code>true</code> for localhost
+            connections (TrueNAS uses a self-signed cert by default).
+          schema:
+            type: boolean
+            default: true
 
   - variable: vm_defaults
     label: ""

--- a/ix-dev/community/omni-infra-provider-truenas/templates/docker-compose.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/templates/docker-compose.yaml
@@ -1,0 +1,42 @@
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{% set c1 = tpl.add_container(values.consts.provider_container_name, "image") %}
+
+{% do c1.set_user(65534, 65534) %}
+{% do c1.set_read_only(true) %}
+{% do c1.set_network_mode("host") %}
+{% do c1.healthcheck.disable() %}
+
+{# Omni connection #}
+{% do c1.environment.add_env("OMNI_ENDPOINT", values.omni_provider.omni_endpoint) %}
+{% do c1.environment.add_env("OMNI_SERVICE_ACCOUNT_KEY", values.omni_provider.omni_service_account_key) %}
+{% do c1.environment.add_env("OMNI_INSECURE_SKIP_VERIFY", values.omni_provider.omni_insecure_skip_verify | string | lower) %}
+
+{# Provider identity #}
+{% do c1.environment.add_env("PROVIDER_ID", values.omni_provider.provider_id) %}
+{% do c1.environment.add_env("PROVIDER_NAME", values.omni_provider.provider_name | default("TrueNAS")) %}
+{% do c1.environment.add_env("PROVIDER_DESCRIPTION", values.omni_provider.provider_description | default("TrueNAS SCALE infrastructure provider")) %}
+
+{# VM defaults #}
+{% do c1.environment.add_env("DEFAULT_POOL", values.vm_defaults.default_pool) %}
+{% if values.vm_defaults.default_network_interface %}
+  {% do c1.environment.add_env("DEFAULT_NETWORK_INTERFACE", values.vm_defaults.default_network_interface) %}
+{% endif %}
+{% do c1.environment.add_env("DEFAULT_BOOT_METHOD", values.vm_defaults.default_boot_method | default("UEFI")) %}
+{% do c1.environment.add_env("GRACEFUL_SHUTDOWN_TIMEOUT", values.vm_defaults.graceful_shutdown_timeout | default(30)) %}
+
+{# Advanced #}
+{% do c1.environment.add_env("CONCURRENCY", values.advanced.concurrency | default(4)) %}
+{% do c1.environment.add_env("LOG_LEVEL", values.advanced.log_level | default("info")) %}
+{% do c1.environment.add_env("MAX_ERROR_RECOVERIES", values.advanced.max_error_recoveries | default(5)) %}
+
+{# User-defined extra env vars #}
+{% do c1.environment.add_user_envs(values.omni_provider.additional_envs) %}
+
+{# Mount the TrueNAS middleware Unix socket for zero-auth API access #}
+{% do c1.add_storage("/var/run/middleware", {"type": "host_path", "host_path_config": {"path": "/var/run/middleware", "acl_enable": false}}) %}
+
+{% do tpl.notes.add_info("The provider connects to TrueNAS via the middleware Unix socket (zero-auth). No API key needed.") %}
+{% do tpl.notes.add_info("Configure MachineClasses in Omni to start provisioning VMs.") %}
+
+{{ tpl.render() | tojson }}

--- a/ix-dev/community/omni-infra-provider-truenas/templates/docker-compose.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/templates/docker-compose.yaml
@@ -12,6 +12,11 @@
 {% do c1.environment.add_env("OMNI_SERVICE_ACCOUNT_KEY", values.omni_provider.omni_service_account_key) %}
 {% do c1.environment.add_env("OMNI_INSECURE_SKIP_VERIFY", values.omni_provider.omni_insecure_skip_verify | string | lower) %}
 
+{# TrueNAS connection — WebSocket with API key #}
+{% do c1.environment.add_env("TRUENAS_HOST", values.truenas.host | default("localhost")) %}
+{% do c1.environment.add_env("TRUENAS_API_KEY", values.truenas.api_key) %}
+{% do c1.environment.add_env("TRUENAS_INSECURE_SKIP_VERIFY", values.truenas.insecure_skip_verify | default(true) | string | lower) %}
+
 {# Provider identity #}
 {% do c1.environment.add_env("PROVIDER_ID", values.omni_provider.provider_id) %}
 {% do c1.environment.add_env("PROVIDER_NAME", values.omni_provider.provider_name | default("TrueNAS")) %}
@@ -33,10 +38,7 @@
 {# User-defined extra env vars #}
 {% do c1.environment.add_user_envs(values.omni_provider.additional_envs) %}
 
-{# Mount the TrueNAS middleware Unix socket for zero-auth API access #}
-{% do c1.add_storage("/var/run/middleware", {"type": "host_path", "host_path_config": {"path": "/var/run/middleware", "acl_enable": false}}) %}
-
-{% do tpl.notes.add_info("The provider connects to TrueNAS via the middleware Unix socket (zero-auth). No API key needed.") %}
+{% do tpl.notes.add_info("The provider connects to TrueNAS via JSON-RPC 2.0 over WebSocket. Create an API key at Credentials > Local Users > root > API Keys.") %}
 {% do tpl.notes.add_info("Configure MachineClasses in Omni to start provisioning VMs.") %}
 
 {{ tpl.render() | tojson }}

--- a/ix-dev/community/omni-infra-provider-truenas/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/templates/test_values/basic-values.yaml
@@ -1,0 +1,24 @@
+omni_provider:
+  omni_endpoint: "https://omni.test.example.com"
+  omni_service_account_key: "dGVzdC1rZXktbm90LXJlYWw="
+  omni_insecure_skip_verify: false
+  provider_id: "truenas"
+  provider_name: "TrueNAS"
+  provider_description: "TrueNAS SCALE infrastructure provider"
+  additional_envs: []
+
+vm_defaults:
+  default_pool: "default"
+  default_network_interface: "br0"
+  default_boot_method: "UEFI"
+  graceful_shutdown_timeout: 30
+
+advanced:
+  concurrency: 4
+  log_level: "info"
+  max_error_recoveries: 5
+
+resources:
+  limits:
+    cpus: 2
+    memory: 512

--- a/ix-dev/community/omni-infra-provider-truenas/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/omni-infra-provider-truenas/templates/test_values/basic-values.yaml
@@ -7,6 +7,11 @@ omni_provider:
   provider_description: "TrueNAS SCALE infrastructure provider"
   additional_envs: []
 
+truenas:
+  host: "localhost"
+  api_key: "1-testapikeynotreal"
+  insecure_skip_verify: true
+
 vm_defaults:
   default_pool: "default"
   default_network_interface: "br0"


### PR DESCRIPTION
Hi TrueNAS team — thank you for maintaining this catalog and for being so open to community apps. This is my first submission here, so please let me know if anything in the structure, metadata, or conventions needs adjusting, and I'll happily revise.

## What this app is

**[omni-infra-provider-truenas](https://github.com/bearbinary/omni-infra-provider-truenas)** is a small Go service that bridges [Sidero Omni](https://omni.siderolabs.com/) and TrueNAS SCALE. When a user scales a Kubernetes cluster in Omni, it provisions a Talos Linux VM on TrueNAS (zvol-backed disk, ISO from the Talos Image Factory, bridge/VLAN NIC), and cleans up when machines are removed. Users get Omni-managed Kubernetes directly on their NAS — no separate Proxmox/ESXi host needed.

## Why I think this belongs in the community catalog

- **It pairs naturally with TrueNAS SCALE's existing capabilities.** SCALE 25.04 removed native Kubernetes. A lot of homelabbers and small-lab operators want Kubernetes back on their NAS. This app gives them a supported path to that outcome using Omni + Talos, while keeping TrueNAS itself focused on what it's great at: storage.
- **It uses the TrueNAS 25.04+ JSON-RPC 2.0 API exclusively** — no legacy REST v2.0, no SSH, no shell-outs. All VM/zvol/device operations go through the documented middleware API with an API key. The provider refuses to start if the API is unreachable, so misconfiguration fails fast rather than causing half-provisioned VMs.
- **ZFS-native.** VM disks are zvols, ISOs are SHA-256-deduplicated on a dataset, datasets are tagged with `truenas:managed_by = omni-infra-provider` + a request-ID property so operators can clearly see provider-owned resources in the UI.
- **It runs well as a TrueNAS app.** Host networking, non-root (uid/gid 65534), API key lives in a `secret_question`, and the user points `TRUENAS_HOST=localhost` so the provider talks to the local middleware over WebSocket. No additional host mounts, no privileged mode.
- **Real users are asking for a catalog entry.** I've been fielding install questions from users running it via Docker Compose or Kubernetes manifests, and the repeated ask is "can I just click install on TrueNAS?" This PR is the answer.

## Project details

| | |
|---|---|
| **Repository** | https://github.com/bearbinary/omni-infra-provider-truenas |
| **License** | MIT |
| **Language** | Go 1.26+ |
| **Image** | `ghcr.io/bearbinary/omni-infra-provider-truenas:v0.14.1` (multi-arch: amd64, arm64) |
| **Releases** | Immutable GitHub releases since v0.1.0, CHANGELOG.md curated per version |
| **Tests** | Unit + cassette-replay integration tests in CI; no live TrueNAS required for PR validation |
| **Security** | `betterleaks` secret scanner as pre-push hook and in CI; [SECURITY.md](https://github.com/bearbinary/omni-infra-provider-truenas/blob/main/SECURITY.md) for disclosure |
| **Docs** | Full site at https://bearbinary.github.io/omni-infra-provider-truenas/ — architecture, troubleshooting, sizing, networking, storage guides |

## What's in this PR

All files live under `ix-dev/community/omni-infra-provider-truenas/`:

- **`app.yaml`** — metadata. `train: community`, `categories: [networking]`, `version: 1.0.0`, `app_version: v0.14.1`, runs as uid/gid 65534, maintainer set, `lib_version: 2.3.2` matching other community apps added around the same time.
- **`ix_values.yaml`** — pins the image repo and tag.
- **`questions.yaml`** — groups: Omni Connection, TrueNAS Connection (host / API key as `secret_question` / skip_verify), VM Defaults (pool, network interface, boot method), Advanced (concurrency, log level, error-recovery limit), Resources (CPU/memory limits). Sensible defaults everywhere, required fields clearly marked.
- **`templates/docker-compose.yaml`** — standard compose template using `network_mode: host` (required so the provider can reach the local WebSocket middleware and outbound Omni endpoint), `restart: unless-stopped`, no privileged capabilities.
- **`templates/test_values/basic-values.yaml`** — test values for catalog CI (no secrets, placeholder endpoints).
- **`README.md`** — one-paragraph summary that renders in the catalog UI.

## Requirements I've called out in `questions.yaml`

- **TrueNAS SCALE 25.10+ (Goldeye).** 25.10 removed implicit Unix-socket auth, so an API key is mandatory. The questions group makes this obvious.
- A network bridge (e.g. `br0`) on the host — referenced as `DEFAULT_NETWORK_INTERFACE`.
- A ZFS pool name — referenced as `DEFAULT_POOL`.
- An Omni endpoint and service account key from the user's Omni instance.

## Test plan

- [ ] Install fresh from this branch on a TrueNAS SCALE 25.10 box
- [ ] Container starts; logs show `TrueNAS client connected` with `host=localhost tls_verify=false`
- [ ] Provider registers with Omni and shows up in the Omni infrastructure providers list
- [ ] Creating an Omni MachineRequest provisions a VM on TrueNAS with a zvol-backed disk and boots Talos
- [ ] Deleting the MachineRequest cleans up the VM, CDROM, and zvol
- [ ] Uninstall via the TrueNAS app UI removes the container and its compose state

## Thank you

Happy to make any changes the reviewers want — naming, metadata, categories, default values, anything. I know catalog maintainers are busy and I want to keep this PR easy for you to review. If there's a checklist or style guide I missed, please point me at it and I'll update accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)