### PR TITLE
Fix Dashy config save - use fixed UID 1000 matching upstream image

### DIFF
--- a/ix-dev/community/dashy/app.yaml
+++ b/ix-dev/community/dashy/app.yaml
@@ -20,11 +20,11 @@ maintainers:
   url: https://www.truenas.com/
 name: dashy
 run_as_context:
-- description: Container [dashy] can run as any non-root user and group.
-  gid: 568
-  group_name: Host group is [apps]
-  uid: 568
-  user_name: Host user is [apps]
+- description: Container [dashy] runs as non-root user and group.
+  gid: 1000
+  group_name: Host group is [unknown (1000)]
+  uid: 1000
+  user_name: Host user is [unknown (1000)]
 screenshots:
 - https://media.sys.truenas.net/apps/dashy/screenshots/screenshot1.gif
 - https://media.sys.truenas.net/apps/dashy/screenshots/screenshot2.gif
@@ -33,4 +33,4 @@ sources:
 - https://github.com/lissy93/dashy
 title: Dashy
 train: community
-version: 2.0.2
+version: 2.0.3

--- a/ix-dev/community/dashy/app_migrations.yaml
+++ b/ix-dev/community/dashy/app_migrations.yaml
@@ -4,3 +4,8 @@ migrations:
     max_version: 1.1.10
   target:
     min_version: 1.2.0
+- file: remove_run_as_migration
+  from:
+    max_version: 2.0.2
+  target:
+    min_version: 2.0.3

--- a/ix-dev/community/dashy/ix_values.yaml
+++ b/ix-dev/community/dashy/ix_values.yaml
@@ -10,6 +10,8 @@ consts:
   dashy_container_name: dashy
   init_container_name: init
   perms_container_name: permissions
+  user_id: 1000
+  group_id: 1000
   ssl_key_path: /cert/tls.key
   ssl_cert_path: /cert/tls.crt
   dashy_config_path: /app/user-data

--- a/ix-dev/community/dashy/migrations/remove_run_as_migration
+++ b/ix-dev/community/dashy/migrations/remove_run_as_migration
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import yaml
+
+
+def migrate(values):
+    values.pop("run_as", None)
+    return values
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        exit(1)
+
+    if os.path.exists(sys.argv[1]):
+        with open(sys.argv[1], "r") as f:
+            print(yaml.dump(migrate(yaml.safe_load(f.read()))))

--- a/ix-dev/community/dashy/questions.yaml
+++ b/ix-dev/community/dashy/questions.yaml
@@ -1,8 +1,6 @@
 groups:
   - name: Dashy Configuration
     description: Configure Dashy
-  - name: User and Group Configuration
-    description: Configure User and Group for Dashy
   - name: Network Configuration
     description: Configure Network for Dashy
   - name: Storage Configuration
@@ -39,29 +37,6 @@ questions:
                       label: Value
                       schema:
                         type: string
-  - variable: run_as
-    label: ""
-    group: User and Group Configuration
-    schema:
-      type: dict
-      attrs:
-        - variable: user
-          label: User ID
-          description: The user id that Dashy files will be owned by.
-          schema:
-            type: int
-            min: 568
-            default: 568
-            required: true
-        - variable: group
-          label: Group ID
-          description: The group id that Dashy files will be owned by.
-          schema:
-            type: int
-            min: 568
-            default: 568
-            required: true
-
   - variable: network
     label: ""
     group: Network Configuration

--- a/ix-dev/community/dashy/templates/docker-compose.yaml
+++ b/ix-dev/community/dashy/templates/docker-compose.yaml
@@ -2,17 +2,17 @@
 {% set tpl = ix_lib.base.render.Render(values) %}
 
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
-{% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
+{% set perms_config = {"uid": values.consts.user_id, "gid": values.consts.group_id, "mode": "check"} %}
 
 {% set config = tpl.add_container(values.consts.init_container_name, "image") %}
 
 {% do config.setup_as_helper() %}
-{% do config.set_user(values.run_as.user, values.run_as.group) %}
+{% do config.set_user(values.consts.user_id, values.consts.group_id) %}
 {% do config.configs.add("init.sh", init(values), "/init.sh", "0755") %}
 {% do config.set_entrypoint(["/init.sh"]) %}
 
 {% set c1 = tpl.add_container(values.consts.dashy_container_name, "image") %}
-{% do c1.set_user(values.run_as.user, values.run_as.group) %}
+{% do c1.set_user(values.consts.user_id, values.consts.group_id) %}
 
 {% do c1.healthcheck.set_custom_test(["CMD", "node", "/app/services/healthcheck.js"]) %}
 {% do c1.depends.add_dependency(values.consts.init_container_name, "service_completed_successfully") %}

--- a/ix-dev/community/dashy/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/dashy/templates/test_values/basic-values.yaml
@@ -13,10 +13,6 @@ network:
     bind_mode: published
     port_number: 8080
 
-run_as:
-  user: 568
-  group: 568
-
 ix_volumes:
   config: /opt/tests/mnt/config
 

--- a/ix-dev/community/dashy/templates/test_values/https-values.yaml
+++ b/ix-dev/community/dashy/templates/test_values/https-values.yaml
@@ -13,10 +13,6 @@ network:
     bind_mode: published
     port_number: 9080
 
-run_as:
-  user: 568
-  group: 568
-
 ix_volumes:
   config: /opt/tests/mnt/config
 


### PR DESCRIPTION
## Summary

Fixes #4911

Dashy v4.x changed its container to run as `node` (UID 1000, GID 1000), but the TrueNAS app was forcing UID 568 via `set_user()`. This caused permission mismatches — Dashy couldn't write config files or create backups on the mounted volume.

**Changes:**
- Use fixed UID 1000/GID 1000 in `ix_values.yaml` consts (matching upstream image's `node` user)
- Update `docker-compose.yaml` to use `values.consts.user_id/group_id` instead of `values.run_as.user/group`
- Update `app.yaml` `run_as_context` to document UID 1000/GID 1000
- Remove `run_as` section from `questions.yaml` (UID is no longer user-configurable)
- Add `remove_run_as_migration` for existing installations
- Bump version to 2.0.3

**Why UID 1000:** Dashy's upstream image (`lissy93/dashy:4.0.3`) is based on `node:22-alpine` with `USER node` (UID 1000/GID 1000). The image has no support for `USER_UID`/`USER_GID` env vars, so the container must run as UID 1000 to match internal file ownership. This follows the same pattern used by drawio, node-red, briefkasten, and other fixed-UID apps in the catalog.

## Test plan

- [ ] Install Dashy from this branch
- [ ] Verify the container runs as UID 1000/GID 1000
- [ ] Verify Dashy can save configuration through the UI
- [ ] Verify config backups are created successfully
- [ ] Verify existing installations migrate correctly (run_as removed from stored config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)