### PR TITLE
netbird-server: strip :443 from oauth urls

### DIFF
--- a/ix-dev/community/netbird-server/app.yaml
+++ b/ix-dev/community/netbird-server/app.yaml
@@ -50,4 +50,4 @@ sources:
 - https://hub.docker.com/r/netbirdio/dashboard
 title: NetBird Server
 train: community
-version: 1.0.14
+version: 1.0.15

--- a/ix-dev/community/netbird-server/templates/docker-compose.yaml
+++ b/ix-dev/community/netbird-server/templates/docker-compose.yaml
@@ -25,11 +25,11 @@
   {"server.exposedAddress": netbird_address},
   {"server.store.encryptionKey": values.netbird.store_encryption_key},
   {"server.authSecret": values.netbird.auth_secret},
-  {"server.auth.issuer": "%s/oauth2"|format(netbird_address)},
+  {"server.auth.issuer": "%s/oauth2"|format(netbird_address.removesuffix(":443"))},
   {"server.auth.cliRedirectURIs[0]": "http://localhost:53000/"},
   {"server.auth.signKeyRefreshEnabled": true},
-  {"server.auth.dashboardRedirectURIs[0]": "%s/nb-auth"|format(netbird_address)},
-  {"server.auth.dashboardRedirectURIs[1]": "%s/nb-silent-auth"|format(netbird_address)},
+  {"server.auth.dashboardRedirectURIs[0]": "%s/nb-auth"|format(netbird_address.removesuffix(":443"))},
+  {"server.auth.dashboardRedirectURIs[1]": "%s/nb-silent-auth"|format(netbird_address.removesuffix(":443"))},
 ] %}
 
 {% do cfg.set_user(values.run_as.user, values.run_as.group) %}

--- a/ix-dev/community/netbird-server/templates/docker-compose.yaml
+++ b/ix-dev/community/netbird-server/templates/docker-compose.yaml
@@ -52,7 +52,7 @@
 {% do dashboard.healthcheck.set_test("http", {"port": 80, "path": "/"}) %}
 {% do dashboard.environment.add_env("NETBIRD_MGMT_API_ENDPOINT", netbird_address) %}
 {% do dashboard.environment.add_env("NETBIRD_MGMT_GRPC_API_ENDPOINT", netbird_address) %}
-{% do dashboard.environment.add_env("AUTH_AUTHORITY", "%s/oauth2"|format(netbird_address)) %}
+{% do dashboard.environment.add_env("AUTH_AUTHORITY", "%s/oauth2"|format(netbird_address.removesuffix(":443"))) %}
 {% do dashboard.environment.add_env("AUTH_REDIRECT_URI", "/nb-auth") %}
 {% do dashboard.environment.add_env("AUTH_SILENT_REDIRECT_URI", "/nb-silent-auth") %}
 {% if values.netbird.embedded_idp %}


### PR DESCRIPTION
I figured out why there was a :443 strip function. If you have :443 on the oauth, nb-auth, and silent-auth it breaks the dashboard on first install when trying to generate tokens.

Since :443 is needed for the exposed addresses I just stripped it from those 3 and the oauth env and left it alone for exposed address.

# Pull Request

⚠️⚠️⚠️ **BEFORE CREATING THE PR** ⚠️⚠️⚠️

Please go to the **Preview** tab and select the appropriate template: 

* [🚀 App Addition](?expand=1&template=app_addition.md)