### PR TITLE
immich: replace in-place pg_upgrade with dump/restore for PG15->18

### DIFF
--- a/ix-dev/community/immich/app.yaml
+++ b/ix-dev/community/immich/app.yaml
@@ -48,4 +48,4 @@ sources:
 - https://github.com/immich-app/immich
 title: Immich
 train: community
-version: 1.14.17
+version: 1.15.0

--- a/ix-dev/community/immich/deprecations.yaml
+++ b/ix-dev/community/immich/deprecations.yaml
@@ -1,12 +1,18 @@
 - scope: "partial"
 
-  deprecated_date: "2025-12-01"
-  removal_date: "2026-03-01"
-  reason: "Drop support for Postgres 15"
+  deprecated_date: "2026-05-09"
+  removal_date: "2026-08-09"
+  reason: "In-place pg_upgrade replaced with dump/restore for PG15 → PG18"
 
   partial_details:
-    feature: "Postgres 15"
-    description: "Postgres 15 is no longer supported"
+    feature: "In-place pg_upgrade for Postgres 15"
+    description: |
+      The previous in-place pg_upgrade flow can no longer upgrade existing
+      Postgres 15 clusters because the upstream upgrade image no longer
+      ships PG15 binaries. This release replaces it with an automated
+      dump/restore flow. The legacy data directory is preserved on disk
+      after a successful upgrade for manual verification.
     steps:
-      - "Edit the application and select Postgres 18 in the image selector"
-      - "Save the application"
+      - "Take a recursive ZFS snapshot of your Immich datasets via the TrueNAS UI before updating"
+      - "Update the application — the dump/restore runs automatically on first compose-up"
+      - "Verify your library is intact, then remove /var/lib/postgresql/_legacy_pg15_* under your postgres_data dataset to reclaim space"

--- a/ix-dev/community/immich/ix_values.yaml
+++ b/ix-dev/community/immich/ix_values.yaml
@@ -37,7 +37,7 @@ consts:
   ml_container_name: machine-learning
   pgvecto_container_name: pgvecto
   pg_precheck_container_name: pgvecto-precheck
-  pg_dump_container_name: pgvecto-dump
+  pg_dump_container_name_prefix: pgvecto-dump
   pg_restore_container_name: pgvecto-restore
   redis_container_name: redis
   perms_container_name: permissions
@@ -47,3 +47,10 @@ consts:
   db_name: immich
   base_path: /data
   target_pg_major: 18
+  # Old Postgres major versions we know how to dump from on the way to
+  # `target_pg_major`. Each entry must have a corresponding `vectorchord_<v>_image`
+  # in `images:` above. To support future PG bumps, bump `target_pg_major` and
+  # append the previous major here; one dump init container will be rendered
+  # per entry and only the one whose on-disk version matches actually does work.
+  dump_source_versions:
+    - 15

--- a/ix-dev/community/immich/ix_values.yaml
+++ b/ix-dev/community/immich/ix_values.yaml
@@ -20,17 +20,25 @@ images:
   vectorchord_18_image:
     repository: ghcr.io/immich-app/postgres
     tag: 18-vectorchord0.5.3
+  # Used only by the dump-phase init container during PG15 → PG18 upgrades.
+  # Pinned to the last vchord-PG15 build that ships both `vchord` and the legacy
+  # `vectors` (pgvecto.rs) extension so `pg_dump` succeeds against either schema.
+  # If this tag is garbage-collected upstream, fall back to
+  # `ixsystems/postgres-upgrade:1.1.11` which still has `postgresql-15` apt-installed.
+  vectorchord_15_image:
+    repository: ghcr.io/immich-app/postgres
+    tag: 15-vectorchord0.4.3-pgvectors0.2.0
   redis_image:
     repository: valkey/valkey
     tag: 9.0.4
-  postgres_upgrade_image:
-    repository: ixsystems/postgres-upgrade
-    tag: 1.2.7
 
 consts:
   server_container_name: server
   ml_container_name: machine-learning
   pgvecto_container_name: pgvecto
+  pg_precheck_container_name: pgvecto-precheck
+  pg_dump_container_name: pgvecto-dump
+  pg_restore_container_name: pgvecto-restore
   redis_container_name: redis
   perms_container_name: permissions
   ml_port: 32002
@@ -38,3 +46,4 @@ consts:
   db_user: immich
   db_name: immich
   base_path: /data
+  target_pg_major: 18

--- a/ix-dev/community/immich/migrations/set_default_vectorchord_image
+++ b/ix-dev/community/immich/migrations/set_default_vectorchord_image
@@ -7,7 +7,7 @@ import yaml
 
 def migrate(values):
     if not values["immich"].get("postgres_image_selector"):
-        values["immich"]["postgres_image_selector"] = "vectorchord_15_image"
+        values["immich"]["postgres_image_selector"] = "vectorchord_18_image"
     return values
 
 

--- a/ix-dev/community/immich/templates/docker-compose.yaml
+++ b/ix-dev/community/immich/templates/docker-compose.yaml
@@ -1,19 +1,90 @@
+{% from "macros/pg-upgrade.sh" import precheck, dump_script, restore_script %}
+
 {% set tpl = ix_lib.base.render.Render(values) %}
 
 {% set immich_net = tpl.networks.create_internal("immich-net") %}
 
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
 {% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
+{% set pg_perms_config = {"uid": 999, "gid": 999, "mode": "check"} %}
 
-{% set pg_config = {
-  "user": values.consts.db_user,
-  "password": values.immich.db_password,
-  "database": values.consts.db_name,
-  "volume": values.storage.postgres_data,
-} %}
-{% set postgres = tpl.deps.postgres(values.consts.pgvecto_container_name, values.immich.postgres_image_selector, pg_config, perm_container) %}
-{% do postgres.container.environment.add_env("DB_STORAGE_TYPE", values.immich.db_storage_type) %}
-{% do postgres.container.add_network(immich_net) %}
+{# ---------------------------------------------------------------------------
+   Postgres major-version upgrade pipeline
+   ---------------------------------------------------------------------------
+   The legacy in-place pg_upgrade flow (via `tpl.deps.postgres()` auto-attached
+   `postgres-upgrade` sidecar) cannot upgrade PG15→PG18 in 2.6.x catalog
+   versions because the upstream upgrade image dropped the PG15 binaries.
+   See #4628, #4645, #4648, #4667, #4695 (and #3882, #3949 for context).
+
+   Replacement: a chain of init containers that, on first compose-up after a
+   PG major change, run `pg_dump` from a temporary PG15 container against the
+   existing data dir, move the legacy data dir aside, let the new PG18
+   container init a fresh cluster, then `pg_restore` the dump. All steps are
+   idempotent (marker files in `_upgrade_workdir/`); on fresh installs and
+   already-target installs they exit 0 cheaply.
+
+   Why the postgres container is built manually instead of via
+   `tpl.deps.postgres()`: the helper unconditionally attaches an
+   `_upgrade` sidecar that calls into the broken upstream `/upgrade.sh`. We
+   bypass it here rather than introduce a library kwarg in this PR; the
+   library-side opt-out is a candidate follow-up.
+#}
+
+{# Precheck: validates on-disk PG version, .immich marker, disk space and ownership.
+   Runs against the postgres_data and data volumes only; no network needed. #}
+{% set pg_precheck = tpl.add_container(values.consts.pg_precheck_container_name, "vectorchord_18_image") %}
+{% do pg_precheck.set_user(0, 0) %}
+{% do pg_precheck.setup_as_helper(profile="low") %}
+{% do pg_precheck.set_entrypoint(["/bin/bash", "/upgrade-precheck.sh"]) %}
+{% do pg_precheck.environment.add_env("TARGET_VERSION", values.consts.target_pg_major) %}
+{% do pg_precheck.add_storage("/var/lib/postgresql", values.storage.postgres_data) %}
+{% do pg_precheck.add_storage("/data", values.storage.data) %}
+{% do pg_precheck.configs.add("immich-pg-upgrade-precheck.sh", precheck(values), "/upgrade-precheck.sh", "0755") %}
+
+{# Dump: starts a temporary PG15 server against the legacy data dir and pg_dumps the database.
+   Image is the vectorchord-15 build (same extension surface as the legacy cluster) so
+   `pg_dump` succeeds even when the legacy `vectors` extension is still loaded. #}
+{% set pg_dump = tpl.add_container(values.consts.pg_dump_container_name, "vectorchord_15_image") %}
+{% do pg_dump.set_user(999, 999) %}
+{% do pg_dump.setup_as_helper(profile="low") %}
+{% do pg_dump.set_entrypoint(["/bin/bash", "/upgrade-dump.sh"]) %}
+{% do pg_dump.add_storage("/var/lib/postgresql", values.storage.postgres_data) %}
+{% do pg_dump.environment.add_env("POSTGRES_PASSWORD", values.immich.db_password) %}
+{% do pg_dump.configs.add("immich-pg-upgrade-dump.sh", dump_script(values), "/upgrade-dump.sh", "0755") %}
+{% do pg_dump.depends.add_dependency(values.consts.pg_precheck_container_name, "service_completed_successfully") %}
+
+{# Main Postgres 18 container. Built manually (not via `tpl.deps.postgres()`) to avoid
+   the upstream `_upgrade` sidecar. Mirrors the lib's defaults (uid 999, shm 256MB,
+   stop grace 60s, postgres healthcheck) so the rendered output is equivalent for
+   non-upgrade purposes. #}
+{% set postgres = tpl.add_container(values.consts.pgvecto_container_name, "vectorchord_18_image") %}
+{% do postgres.set_user(999, 999) %}
+{% do postgres.set_shm_size_mb(256) %}
+{% do postgres.set_grace_period(60) %}
+{% do postgres.remove_devices() %}
+{% do postgres.add_network(immich_net) %}
+{% do postgres.healthcheck.set_test("postgres", {"user": values.consts.db_user, "db": values.consts.db_name, "port": 5432}) %}
+{% do postgres.add_storage("/var/lib/postgresql", values.storage.postgres_data) %}
+{% do postgres.environment.add_env("POSTGRES_USER", values.consts.db_user) %}
+{% do postgres.environment.add_env("POSTGRES_PASSWORD", values.immich.db_password) %}
+{% do postgres.environment.add_env("POSTGRES_DB", values.consts.db_name) %}
+{% do postgres.environment.add_env("PGPORT", 5432) %}
+{% do postgres.environment.add_env("PGDATA", "/var/lib/postgresql/%s/docker"|format(values.consts.target_pg_major)) %}
+{% do postgres.environment.add_env("DB_STORAGE_TYPE", values.immich.db_storage_type) %}
+{% do postgres.depends.add_dependency(values.consts.pg_dump_container_name, "service_completed_successfully") %}
+{% do perm_container.add_or_skip_action("pgvecto_postgres_data", values.storage.postgres_data, pg_perms_config) %}
+
+{# Restore: runs after PG18 is healthy. Idempotent — exits 0 if no dump is present
+   (fresh install) or restore.complete is already set. #}
+{% set pg_restore = tpl.add_container(values.consts.pg_restore_container_name, "vectorchord_18_image") %}
+{% do pg_restore.set_user(999, 999) %}
+{% do pg_restore.setup_as_helper(profile="low", disable_network=False) %}
+{% do pg_restore.set_entrypoint(["/bin/bash", "/upgrade-restore.sh"]) %}
+{% do pg_restore.add_network(immich_net) %}
+{% do pg_restore.add_storage("/var/lib/postgresql", values.storage.postgres_data) %}
+{% do pg_restore.environment.add_env("POSTGRES_PASSWORD", values.immich.db_password) %}
+{% do pg_restore.configs.add("immich-pg-upgrade-restore.sh", restore_script(values), "/upgrade-restore.sh", "0755") %}
+{% do pg_restore.depends.add_dependency(values.consts.pgvecto_container_name, "service_healthy") %}
 
 {% set redis_config = {
   "password": values.immich.redis_password,
@@ -29,6 +100,7 @@
 {% do server_container.set_user(values.run_as.user, values.run_as.group) %}
 {% do server_container.healthcheck.set_custom_test(["CMD", "immich-healthcheck"]) %}
 {% do server_container.depends.add_dependency(values.consts.pgvecto_container_name, "service_healthy") %}
+{% do server_container.depends.add_dependency(values.consts.pg_restore_container_name, "service_completed_successfully") %}
 {% do server_container.depends.add_dependency(values.consts.redis_container_name, "service_healthy") %}
 
 {% set cli_temp_storage = tpl.funcs.temp_config("cli-temp-storage") %}
@@ -89,13 +161,24 @@
 
 {% if perm_container.has_actions() %}
   {% do perm_container.activate() %}
-  {% do postgres.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
+  {% do pg_precheck.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
   {% do redis.container.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
   {% do server_container.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
   {% if values.immich.enable_ml %}
     {% do ml_container.x.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
   {% endif %}
 {% endif %}
+
+{# Notes-card guidance: surfaces in the TrueNAS UI before/during the upgrade, since runtime
+   errors only land in container logs. Always rendered (cheap; the user might also be on a
+   fresh install where no upgrade is needed and these notes are still informative). #}
+{% do tpl.notes.add_warning(
+  "Postgres major-version upgrades for Immich now use a dump/restore flow instead of in-place pg_upgrade. "
+  "Before upgrading, take a recursive ZFS snapshot of the Immich datasets via the TrueNAS UI "
+  "(Datasets → your Immich dataset → Add Snapshot, recursive). The legacy data directory will be "
+  "preserved on disk under /var/lib/postgresql/_legacy_pg<old_version>_<timestamp> after a successful "
+  "upgrade so you can verify and remove it manually."
+) %}
 
 {% do tpl.portals.add(values.network.web_port) %}
 

--- a/ix-dev/community/immich/templates/docker-compose.yaml
+++ b/ix-dev/community/immich/templates/docker-compose.yaml
@@ -41,17 +41,27 @@
 {% do pg_precheck.add_storage("/data", values.storage.data) %}
 {% do pg_precheck.configs.add("immich-pg-upgrade-precheck.sh", precheck(values), "/upgrade-precheck.sh", "0755") %}
 
-{# Dump: starts a temporary PG15 server against the legacy data dir and pg_dumps the database.
-   Image is the vectorchord-15 build (same extension surface as the legacy cluster) so
-   `pg_dump` succeeds even when the legacy `vectors` extension is still loaded. #}
-{% set pg_dump = tpl.add_container(values.consts.pg_dump_container_name, "vectorchord_15_image") %}
-{% do pg_dump.set_user(999, 999) %}
-{% do pg_dump.setup_as_helper(profile="low") %}
-{% do pg_dump.set_entrypoint(["/bin/bash", "/upgrade-dump.sh"]) %}
-{% do pg_dump.add_storage("/var/lib/postgresql", values.storage.postgres_data) %}
-{% do pg_dump.environment.add_env("POSTGRES_PASSWORD", values.immich.db_password) %}
-{% do pg_dump.configs.add("immich-pg-upgrade-dump.sh", dump_script(values), "/upgrade-dump.sh", "0755") %}
-{% do pg_dump.depends.add_dependency(values.consts.pg_precheck_container_name, "service_completed_successfully") %}
+{# Dump: one init container per supported old PG major (`consts.dump_source_versions`).
+   Each runs the same script with `OLD_VERSION` set to its own major; only the container
+   whose `OLD_VERSION` matches the on-disk PG_VERSION does any work. Containers are chained
+   sequentially (rather than in parallel) so they don't race on the shared volume.
+   Adding a new old version in the future is just registering a `vectorchord_<v>_image`
+   above and appending `<v>` to `dump_source_versions`. #}
+{% set last_dump_name = namespace(x=values.consts.pg_precheck_container_name) %}
+{% for v in values.consts.dump_source_versions %}
+  {% set dump_name = "%s-%s"|format(values.consts.pg_dump_container_name_prefix, v) %}
+  {% set pg_dump = tpl.add_container(dump_name, "vectorchord_%s_image"|format(v)) %}
+  {% do pg_dump.set_user(999, 999) %}
+  {% do pg_dump.setup_as_helper(profile="low") %}
+  {% do pg_dump.set_entrypoint(["/bin/bash", "/upgrade-dump.sh"]) %}
+  {% do pg_dump.add_storage("/var/lib/postgresql", values.storage.postgres_data) %}
+  {% do pg_dump.environment.add_env("OLD_VERSION", v) %}
+  {% do pg_dump.environment.add_env("TARGET_VERSION", values.consts.target_pg_major) %}
+  {% do pg_dump.environment.add_env("POSTGRES_PASSWORD", values.immich.db_password) %}
+  {% do pg_dump.configs.add("immich-pg-upgrade-dump.sh", dump_script(values), "/upgrade-dump.sh", "0755") %}
+  {% do pg_dump.depends.add_dependency(last_dump_name.x, "service_completed_successfully") %}
+  {% set last_dump_name.x = dump_name %}
+{% endfor %}
 
 {# Main Postgres 18 container. Built manually (not via `tpl.deps.postgres()`) to avoid
    the upstream `_upgrade` sidecar. Mirrors the lib's defaults (uid 999, shm 256MB,
@@ -71,7 +81,9 @@
 {% do postgres.environment.add_env("PGPORT", 5432) %}
 {% do postgres.environment.add_env("PGDATA", "/var/lib/postgresql/%s/docker"|format(values.consts.target_pg_major)) %}
 {% do postgres.environment.add_env("DB_STORAGE_TYPE", values.immich.db_storage_type) %}
-{% do postgres.depends.add_dependency(values.consts.pg_dump_container_name, "service_completed_successfully") %}
+{# Depends on whichever container is last in the precheck → dump-* chain. With no
+   dump_source_versions configured, that is the precheck container directly. #}
+{% do postgres.depends.add_dependency(last_dump_name.x, "service_completed_successfully") %}
 {% do perm_container.add_or_skip_action("pgvecto_postgres_data", values.storage.postgres_data, pg_perms_config) %}
 
 {# Restore: runs after PG18 is healthy. Idempotent — exits 0 if no dump is present

--- a/ix-dev/community/immich/templates/macros/pg-upgrade.sh
+++ b/ix-dev/community/immich/templates/macros/pg-upgrade.sh
@@ -1,0 +1,215 @@
+{% macro precheck(values) %}
+#!/usr/bin/env bash
+# Pre-upgrade safety checks. Runs before the dump container.
+# Exits 0 if safe to proceed (including no-op fresh-install / same-version cases).
+# Exits non-zero with a message if the cluster on disk is in a state we cannot upgrade.
+set -euo pipefail
+
+base=/var/lib/postgresql
+target="{{ values.consts.target_pg_major }}"
+
+# Detect on-disk PG version, if any.
+on_disk=""
+for v in 18 17 16 15 14 13; do
+  if [ -f "${base}/${v}/docker/PG_VERSION" ]; then
+    on_disk="${v}"
+    break
+  fi
+done
+
+if [ -z "${on_disk}" ]; then
+  echo "Precheck: no existing Postgres cluster on disk (fresh install or empty volume). OK."
+  exit 0
+fi
+
+if [ "${on_disk}" = "${target}" ]; then
+  echo "Precheck: on-disk Postgres version (${on_disk}) matches target (${target}). No upgrade needed."
+  exit 0
+fi
+
+if [ "${on_disk}" -gt "${target}" ]; then
+  echo "Precheck FAILED: on-disk Postgres version is ${on_disk}, target is ${target}." >&2
+  echo "Downgrades are not supported. Restore from backup or roll back the application version." >&2
+  exit 2
+fi
+
+# Marker file check: refuse to dump+restore if the data volume does not look like an Immich install.
+if [ ! -e /data/.immich ]; then
+  echo "Precheck FAILED: /data/.immich marker file is missing." >&2
+  echo "Either this volume does not contain an Immich install, or the marker was removed." >&2
+  echo "Refusing to run an automated upgrade against unrecognised data." >&2
+  exit 2
+fi
+
+# Disk-space check: dump+restore needs at least 2x the size of the source cluster on the same dataset.
+src=$(du -sb "${base}/${on_disk}/docker" | awk '{print $1}')
+avail=$(df -B1 --output=avail "${base}" | tail -1)
+need=$(( src * 2 ))
+if [ "${need}" -gt "${avail}" ]; then
+  src_gib=$(( src / 1024 / 1024 / 1024 ))
+  avail_gib=$(( avail / 1024 / 1024 / 1024 ))
+  need_gib=$(( need / 1024 / 1024 / 1024 ))
+  echo "Precheck FAILED: insufficient free space for dump+restore." >&2
+  echo "Source cluster size: ${src_gib} GiB; need at least ${need_gib} GiB free; available: ${avail_gib} GiB." >&2
+  echo "Free up space on the postgres_data dataset and retry." >&2
+  exit 2
+fi
+
+# Ownership check: the postgres dirs must be owned by the in-container postgres user (999:999).
+own=$(stat -c '%u:%g' "${base}/${on_disk}/docker")
+if [ "${own}" != "999:999" ]; then
+  echo "Precheck FAILED: ${base}/${on_disk}/docker is owned by ${own}; expected 999:999 (netdata)." >&2
+  echo "Fix ownership on the host (chown -R 999:999 …/pgData) and retry." >&2
+  exit 2
+fi
+
+src_gib=$(( src / 1024 / 1024 / 1024 ))
+avail_gib=$(( avail / 1024 / 1024 / 1024 ))
+echo "Precheck OK: PG${on_disk} → PG${target}; src=${src_gib} GiB, free=${avail_gib} GiB."
+{% endmacro %}
+
+
+{% macro dump_script(values) %}
+#!/usr/bin/env bash
+# Runs in a temporary PG15 container alongside the legacy data dir.
+# Starts the old server on a private socket, dumps the database, then moves the
+# legacy data dir aside so the main PG18 container initialises a fresh cluster.
+# Idempotent: if a completed dump already exists this exits 0 immediately.
+set -euo pipefail
+
+base=/var/lib/postgresql
+work="${base}/_upgrade_workdir"
+mkdir -p "${work}"
+chmod 0700 "${work}"
+
+# Idempotency: if we already produced a complete dump and moved the old dir aside, nothing to do.
+if [ -f "${work}/dump.complete" ]; then
+  echo "Dump: marker present at ${work}/dump.complete — skipping."
+  exit 0
+fi
+
+# Detect on-disk version. If only the target dir exists, this is a fresh install or an
+# already-upgraded cluster — nothing to do.
+on_disk=""
+for v in 17 16 15 14 13; do
+  if [ -f "${base}/${v}/docker/PG_VERSION" ]; then
+    on_disk="${v}"
+    break
+  fi
+done
+if [ -z "${on_disk}" ]; then
+  echo "Dump: no pre-target Postgres cluster on disk; nothing to dump."
+  exit 0
+fi
+
+old_dir="${base}/${on_disk}/docker"
+sock=/tmp/pg-dump-sock
+mkdir -p "${sock}"
+chown 999:999 "${sock}"
+chmod 0700 "${sock}"
+
+# pg_hba in an Immich-initialised cluster may require a password even on the local
+# socket; export PGPASSWORD so psql/pg_dump can authenticate either way.
+export PGPASSWORD="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+
+# Start the old PG with no TCP listener; only a private unix socket.
+PGDATA="${old_dir}" pg_ctl -D "${old_dir}" \
+  -o "-c listen_addresses='' -c unix_socket_directories=${sock} -c unix_socket_permissions=0700" \
+  -w -t 60 start
+
+trap 'PGDATA="${old_dir}" pg_ctl -D "${old_dir}" -m fast stop || true' EXIT
+
+# Sanitise legacy state that breaks downstream restore on PG18.
+# - The legacy pgvecto.rs `vectors` extension/schema is unavailable in the new image (#3882).
+# - The reserved-prefix GUC `vchordrq.prewarm_dim` produces warnings on PG18 (#4667).
+psql -h "${sock}" -U "{{ values.consts.db_user }}" -d "{{ values.consts.db_name }}" \
+  -v ON_ERROR_STOP=1 \
+  -c "DROP EXTENSION IF EXISTS vectors CASCADE;" \
+  -c "DROP SCHEMA IF EXISTS vectors CASCADE;" \
+  -c "ALTER DATABASE \"{{ values.consts.db_name }}\" RESET vchordrq.prewarm_dim;"
+
+# Custom-format dump of the application database. Streams to disk; doesn't buffer in memory.
+pg_dump -h "${sock}" -U "{{ values.consts.db_user }}" -d "{{ values.consts.db_name }}" \
+  -Fc -f "${work}/dump.partial"
+
+mv "${work}/dump.partial" "${work}/dump.dat"
+chmod 0600 "${work}/dump.dat"
+
+# Stop cleanly so the data dir can be moved.
+PGDATA="${old_dir}" pg_ctl -D "${old_dir}" -m fast stop
+trap - EXIT
+
+# Mark the dump complete BEFORE moving the legacy data dir aside. Order matters: if the
+# subsequent `mv` fails (or the container is killed between the two steps) we must err on
+# the side of "dump exists; trust the dump" rather than "dump never completed; re-dump from
+# the legacy dir" — because once we're past this point a re-dump may no longer be possible
+# (the source could be gone or the new PG18 cluster could already have started initdb).
+touch "${work}/dump.complete"
+
+# Move the legacy data dir to a non-numeric sibling so the main PG18 container's entrypoint
+# initialises a fresh cluster at /var/lib/postgresql/{{ values.consts.target_pg_major }}/docker.
+# A non-numeric prefix also avoids any future re-introduction of the upstream upgrade.sh
+# from misidentifying it as a candidate cluster (it walks ${base}/*/docker).
+ts=$(date +%s)
+mv "${base}/${on_disk}" "${base}/_legacy_pg${on_disk}_${ts}"
+
+size=$(du -h "${work}/dump.dat" | awk '{print $1}')
+echo "Dump complete: ${work}/dump.dat (${size}); legacy data moved to ${base}/_legacy_pg${on_disk}_${ts}."
+{% endmacro %}
+
+
+{% macro restore_script(values) %}
+#!/usr/bin/env bash
+# Runs after the main PG18 container is healthy. Restores the dump produced by the
+# dump container (if any), then runs post-restore sanitisation.
+# Idempotent: if no dump is present, or restore already completed, exits 0.
+set -euo pipefail
+
+base=/var/lib/postgresql
+work="${base}/_upgrade_workdir"
+
+if [ ! -f "${work}/dump.complete" ]; then
+  echo "Restore: no dump present (fresh install or no upgrade needed). Nothing to restore."
+  exit 0
+fi
+if [ -f "${work}/restore.complete" ]; then
+  echo "Restore: marker present at ${work}/restore.complete — already restored."
+  exit 0
+fi
+if [ ! -f "${work}/dump.dat" ]; then
+  echo "Restore FAILED: dump.complete marker present but ${work}/dump.dat is missing." >&2
+  echo "Either the dump file was removed or restore already moved it aside without writing restore.complete." >&2
+  echo "Inspect ${work} and ${base}/_legacy_pg* manually." >&2
+  exit 2
+fi
+
+host="{{ values.consts.pgvecto_container_name }}"
+db="{{ values.consts.db_name }}"
+user="{{ values.consts.db_user }}"
+
+export PGPASSWORD="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+
+# pg_restore --clean --if-exists drops and recreates each object so we don't conflict with
+# the empty schema that initdb / docker-entrypoint leaves behind.
+pg_restore -h "${host}" -U "${user}" -d "${db}" \
+  --clean --if-exists --no-owner --no-acl \
+  --exit-on-error \
+  "${work}/dump.dat"
+
+# Clear reserved-prefix GUC that some installs carry over (#4667). Idempotent.
+psql -h "${host}" -U "${user}" -d "${db}" -v ON_ERROR_STOP=1 \
+  -c "ALTER DATABASE \"${db}\" RESET vchordrq.prewarm_dim;"
+
+# Sanity check: at least one immich row visible. Table is `asset` (singular) on Immich.
+# Quoting the count separately so we don't trip ON_ERROR_STOP on an empty new install.
+count=$(psql -h "${host}" -U "${user}" -d "${db}" -At -v ON_ERROR_STOP=1 \
+  -c "SELECT count(*) FROM asset;")
+echo "Restore: post-restore asset row count = ${count}."
+
+# Mark restore complete and rename the dump so a subsequent compose-up does not retrigger.
+ts=$(date +%s)
+mv "${work}/dump.dat" "${work}/dump.restored.${ts}.dat"
+touch "${work}/restore.complete"
+echo "Restore complete. Dump archived as ${work}/dump.restored.${ts}.dat."
+echo "Legacy PG data dir is preserved at /var/lib/postgresql/_legacy_pg* — remove manually once you have verified Immich is working."
+{% endmacro %}

--- a/ix-dev/community/immich/templates/macros/pg-upgrade.sh
+++ b/ix-dev/community/immich/templates/macros/pg-upgrade.sh
@@ -1,12 +1,14 @@
 {% macro precheck(values) %}
 #!/usr/bin/env bash
-# Pre-upgrade safety checks. Runs before the dump container.
+# Pre-upgrade safety checks. Runs before any dump containers.
 # Exits 0 if safe to proceed (including no-op fresh-install / same-version cases).
 # Exits non-zero with a message if the cluster on disk is in a state we cannot upgrade.
 set -euo pipefail
 
 base=/var/lib/postgresql
 target="{{ values.consts.target_pg_major }}"
+# Space-separated list of old majors we have a dump path for.
+supported_old_versions="{% for v in values.consts.dump_source_versions %}{{ v }} {% endfor %}"
 
 # Detect on-disk PG version, if any.
 on_disk=""
@@ -30,6 +32,21 @@ fi
 if [ "${on_disk}" -gt "${target}" ]; then
   echo "Precheck FAILED: on-disk Postgres version is ${on_disk}, target is ${target}." >&2
   echo "Downgrades are not supported. Restore from backup or roll back the application version." >&2
+  exit 2
+fi
+
+# Refuse if we have no dump path for the on-disk version.
+match=0
+for v in ${supported_old_versions}; do
+  if [ "${v}" = "${on_disk}" ]; then
+    match=1
+    break
+  fi
+done
+if [ "${match}" -ne 1 ]; then
+  echo "Precheck FAILED: no automated upgrade path from PG${on_disk} to PG${target}." >&2
+  echo "Supported source versions: ${supported_old_versions}" >&2
+  echo "Restore from backup, or upgrade in stages via an Immich version that bridges to a supported source." >&2
   exit 2
 fi
 
@@ -71,38 +88,36 @@ echo "Precheck OK: PG${on_disk} → PG${target}; src=${src_gib} GiB, free=${avai
 
 {% macro dump_script(values) %}
 #!/usr/bin/env bash
-# Runs in a temporary PG15 container alongside the legacy data dir.
-# Starts the old server on a private socket, dumps the database, then moves the
-# legacy data dir aside so the main PG18 container initialises a fresh cluster.
-# Idempotent: if a completed dump already exists this exits 0 immediately.
+# Runs inside a temporary PG${OLD_VERSION} container alongside the legacy data dir.
+# Only the dump container whose `OLD_VERSION` matches what's on disk does any work;
+# the others exit 0 cleanly. The first to run a successful dump writes the marker
+# `_upgrade_workdir/dump.complete`, which subsequent containers in the chain honour.
 set -euo pipefail
 
 base=/var/lib/postgresql
 work="${base}/_upgrade_workdir"
+old="${OLD_VERSION:?OLD_VERSION must be set}"
+target="${TARGET_VERSION:?TARGET_VERSION must be set}"
+
 mkdir -p "${work}"
 chmod 0700 "${work}"
 
-# Idempotency: if we already produced a complete dump and moved the old dir aside, nothing to do.
 if [ -f "${work}/dump.complete" ]; then
-  echo "Dump: marker present at ${work}/dump.complete — skipping."
+  echo "Dump-${old}: marker present at ${work}/dump.complete — skipping."
   exit 0
 fi
 
-# Detect on-disk version. If only the target dir exists, this is a fresh install or an
-# already-upgraded cluster — nothing to do.
-on_disk=""
-for v in 17 16 15 14 13; do
-  if [ -f "${base}/${v}/docker/PG_VERSION" ]; then
-    on_disk="${v}"
-    break
-  fi
-done
-if [ -z "${on_disk}" ]; then
-  echo "Dump: no pre-target Postgres cluster on disk; nothing to dump."
+if [ "${old}" = "${target}" ]; then
+  echo "Dump-${old}: skipping — old equals target." >&2
   exit 0
 fi
 
-old_dir="${base}/${on_disk}/docker"
+if [ ! -f "${base}/${old}/docker/PG_VERSION" ]; then
+  echo "Dump-${old}: no PG${old} cluster on disk; skipping."
+  exit 0
+fi
+
+old_dir="${base}/${old}/docker"
 sock=/tmp/pg-dump-sock
 mkdir -p "${sock}"
 chown 999:999 "${sock}"
@@ -119,9 +134,9 @@ PGDATA="${old_dir}" pg_ctl -D "${old_dir}" \
 
 trap 'PGDATA="${old_dir}" pg_ctl -D "${old_dir}" -m fast stop || true' EXIT
 
-# Sanitise legacy state that breaks downstream restore on PG18.
+# Sanitise legacy state that breaks downstream restore on PG${target}.
 # - The legacy pgvecto.rs `vectors` extension/schema is unavailable in the new image (#3882).
-# - The reserved-prefix GUC `vchordrq.prewarm_dim` produces warnings on PG18 (#4667).
+# - The reserved-prefix GUC `vchordrq.prewarm_dim` produces warnings on the new server (#4667).
 psql -h "${sock}" -U "{{ values.consts.db_user }}" -d "{{ values.consts.db_name }}" \
   -v ON_ERROR_STOP=1 \
   -c "DROP EXTENSION IF EXISTS vectors CASCADE;" \
@@ -139,29 +154,30 @@ chmod 0600 "${work}/dump.dat"
 PGDATA="${old_dir}" pg_ctl -D "${old_dir}" -m fast stop
 trap - EXIT
 
-# Mark the dump complete BEFORE moving the legacy data dir aside. Order matters: if the
-# subsequent `mv` fails (or the container is killed between the two steps) we must err on
-# the side of "dump exists; trust the dump" rather than "dump never completed; re-dump from
-# the legacy dir" — because once we're past this point a re-dump may no longer be possible
-# (the source could be gone or the new PG18 cluster could already have started initdb).
+# Mark the dump complete BEFORE moving the legacy data dir aside. Order matters: if
+# the subsequent `mv` fails (or the container is killed between the two steps) we err
+# on the side of "dump exists; trust the dump" rather than "dump never completed; re-dump
+# from the legacy dir" — because once we're past this point a re-dump may no longer be
+# possible (the source could be gone or the new PG cluster could already have started initdb).
 touch "${work}/dump.complete"
 
-# Move the legacy data dir to a non-numeric sibling so the main PG18 container's entrypoint
-# initialises a fresh cluster at /var/lib/postgresql/{{ values.consts.target_pg_major }}/docker.
-# A non-numeric prefix also avoids any future re-introduction of the upstream upgrade.sh
-# from misidentifying it as a candidate cluster (it walks ${base}/*/docker).
+# Move the legacy data dir to a non-numeric sibling so the main PG container's entrypoint
+# initialises a fresh cluster at /var/lib/postgresql/${target}/docker. A non-numeric prefix
+# also avoids any future re-introduction of the upstream upgrade.sh from misidentifying it
+# as a candidate cluster (it walks ${base}/*/docker).
 ts=$(date +%s)
-mv "${base}/${on_disk}" "${base}/_legacy_pg${on_disk}_${ts}"
+mv "${base}/${old}" "${base}/_legacy_pg${old}_${ts}"
 
 size=$(du -h "${work}/dump.dat" | awk '{print $1}')
-echo "Dump complete: ${work}/dump.dat (${size}); legacy data moved to ${base}/_legacy_pg${on_disk}_${ts}."
+echo "Dump-${old} complete: ${work}/dump.dat (${size}); legacy data moved to ${base}/_legacy_pg${old}_${ts}."
 {% endmacro %}
 
 
 {% macro restore_script(values) %}
 #!/usr/bin/env bash
-# Runs after the main PG18 container is healthy. Restores the dump produced by the
-# dump container (if any), then runs post-restore sanitisation.
+# Runs after the main Postgres container is healthy. Restores the dump produced by
+# whichever dump container matched the on-disk version (if any), then runs
+# post-restore sanitisation.
 # Idempotent: if no dump is present, or restore already completed, exits 0.
 set -euo pipefail
 
@@ -201,7 +217,7 @@ psql -h "${host}" -U "${user}" -d "${db}" -v ON_ERROR_STOP=1 \
   -c "ALTER DATABASE \"${db}\" RESET vchordrq.prewarm_dim;"
 
 # Sanity check: at least one immich row visible. Table is `asset` (singular) on Immich.
-# Quoting the count separately so we don't trip ON_ERROR_STOP on an empty new install.
+# Only runs when dump.complete was set, so the table must exist.
 count=$(psql -h "${host}" -U "${user}" -d "${db}" -At -v ON_ERROR_STOP=1 \
   -c "SELECT count(*) FROM asset;")
 echo "Restore: post-restore asset row count = ${count}."


### PR DESCRIPTION
## Summary

The upstream `ixsystems/postgres-upgrade` image dropped `postgresql-15` apt packages in `1.2.x`, so the in-place `pg_upgrade` sidecar that `tpl.deps.postgres()` auto-attaches now refuses to start for any Immich user still on PG15. This PR replaces that sidecar (for the immich app only) with an automated `pg_dump` → fresh-init → `pg_restore` flow expressed as init containers in immich's compose template. All steps are idempotent (marker files in `_upgrade_workdir/`) so fresh installs and re-runs after partial state are safe.

The flow is structured around a configurable `consts.dump_source_versions` list rather than being pinned to PG15, so future PG major bumps don't need a redesign — just register a new `vectorchord_<v>_image` and append the previous major to the list.

## Approach

- The postgres container is built directly via `tpl.add_container()` rather than `tpl.deps.postgres()` so the broken upstream `_upgrade` sidecar isn't attached. A library-level opt-out kwarg is a candidate follow-up; this PR keeps the change immich-local.
- Init-container chain: `pgvecto-precheck` (validates on-disk PG version, `.immich` marker, 2x disk-space, ownership, and that the on-disk version is in `dump_source_versions`) → one `pgvecto-dump-<v>` per entry in `dump_source_versions`, sequentially chained, each gated by an `OLD_VERSION` env (only the matching one does work; the rest exit 0) → main `pgvecto` container initdbs a fresh cluster on the empty target dir → `pgvecto-restore` (after PG18 healthy, runs `pg_restore --clean --if-exists`, archives the dump, clears the `vchordrq.prewarm_dim` GUC).
- New `vectorchord_15_image` pinned to `ghcr.io/immich-app/postgres:15-vectorchord0.4.3-pgvectors0.2.0` — the last vchord-PG15 build that ships both `vchord` and the legacy `vectors` extension. If that tag is GC'd, fall back to `ixsystems/postgres-upgrade:1.1.11`, which still has `postgresql-15` apt-installed.
- Pre-dump sanitisation in the temp PG15 container clears the legacy pgvecto.rs `vectors` extension (#3882) and the `vchordrq.prewarm_dim` reserved-prefix GUC (#4667). Both idempotent.
- Notes-card warning recommends a recursive ZFS snapshot via the TrueNAS UI before upgrade — there is no framework-level pre-upgrade hook to do that automatically.
- Stale `deprecations.yaml` rewritten with the new automated-flow notice and a 3-month deprecation window for the old in-place behaviour.
- `migrations/set_default_vectorchord_image` was setting a non-existent `vectorchord_15_image` key as the default for unset `postgres_image_selector`; fixed to default to `vectorchord_18_image`.

## Risk

- Users still on the legacy pgvecto.rs `vectors` extension (no vchord migration yet) will lose vector data when the dump phase drops `vectors CASCADE`. Modern Immich requires vchord upstream so this affects only very old installs.
- vchord 0.4.3 (dump source) → vchord 0.5.3 (restore target) — generally forward-compat across these versions; `REINDEX` is the safety net if any index data is unreadable.
- The dump containers always render even on fresh installs and pull ~500 MB of vchord-15 image only to exit 0 immediately. Accepted trade-off; rendering conditionally would require threading prior-config history into the values dict.

## Testing

- `pytest library/2.3.5/tests/` — 359 / 359 passing (library is untouched in this PR).
- Local render with `templates/test_values/basic-values.yaml` succeeds; the rendered compose has the `permissions → precheck → dump-15 → pgvecto (healthy) → restore → server` dependency chain wired up and the three shell scripts mounted via `tpl.configs.add()`.
- **Cannot test end-to-end without TrueNAS hardware.** Reviewers should validate against a seeded PG15 cluster on a real system. Critical paths:
  - PG15 → PG18 happy path: confirm the dump container completes, the main PG18 cluster initdbs cleanly, the restore container runs `pg_restore --clean --if-exists` against the new PG18, and the immich server comes up against the restored data.
  - Idempotency: kill the dump container mid-flight (`docker kill`), redeploy, confirm dump retries; once `dump.complete` exists, confirm subsequent re-runs short-circuit cleanly.
  - Failure modes: insufficient disk space (precheck refuses with sizing in the error), missing `/data/.immich` marker (precheck refuses), wrong ownership on `pgData` (precheck refuses with chown hint), unsupported on-disk version (precheck refuses with the supported-source list).
  - Vector index integrity post-restore: `REINDEX` if needed.

## Future PG major bumps

When PG21 (or whatever's next) arrives, the maintainer change is mechanical:

1. Register `vectorchord_21_image` in `ix_values.yaml`
2. Bump `target_pg_major: 18` → `21`
3. Append `18` to `dump_source_versions: [15, 18]`
4. Update `questions.yaml` enum from `vectorchord_18_image` to `vectorchord_21_image`

No `truenas/containers` change required, no binary-compat dependency.

## Follow-ups (out of scope for this PR)

- Add `skip_upgrade_container=True` kwarg to `tpl.deps.postgres()` so other apps can opt out of the upstream sidecar without rolling their own postgres container. Skipped here because the repo's library-versioning convention would force renaming `library/2.3.5 → 2.3.6` and bumping the four other apps still pinning 2.3.5.
- Apply the same dump/restore pattern to other catalog apps hit by similar fragility (nextcloud, paperless-ngx, home-assistant, gitea, mealie, vaultwarden, …).
- A framework-level pre-upgrade hook (in `truenas/middleware`) for ZFS snapshots and validation, so this kind of orchestration doesn't have to live as init containers in every app's compose template.
- Pre-existing `templates/test_values/root-values.yaml` is broken on master (missing `db_storage_type`); separate one-line fix.
- Consider an automated upgrade-test harness — `ci.py` currently only validates fresh deploys, not catalog version → version transitions with seeded data.

---

Closes #4628
Closes #4645
Closes #4648
Closes #4667
Closes #4695

Related #3882 #3949 (older `vectors`-extension / pgvecto.rs migration context)