### PR TITLE
RustFS: New versioning format

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -318,8 +318,8 @@ module.exports = {
       ["opencloudeu/web-extensions"],
     ),
     customVersioning(
-      // 1.0.0-alpha.67
-      "^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-alpha\\.(?<build>\\d+))?$",
+      // 1.0.0-beta.4
+      "^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-beta\\.(?<build>\\d+))?$",
       ["rustfs/rustfs"],
     ),
     customVersioning(


### PR DESCRIPTION
Update customVersioning for rustfs/rustfs becasue upstream has changed from using "alpha" to "beta" for their tags and releases
