### PR TITLE
Add clubfoundry to community train

### DIFF
--- a/ix-dev/community/clubfoundry/README.md
+++ b/ix-dev/community/clubfoundry/README.md
@@ -1,0 +1,41 @@
+# ClubFoundry — iSCSI LUN manager for shared-PC infrastructures
+
+**ClubFoundry** is a Web UI for managing per-PC iSCSI LUNs on TrueNAS SCALE.
+Designed for shared-use computers in gaming clubs, computer labs, schools,
+universities, internet cafes, QA test farms, and corporate training centers.
+
+## What it does
+
+- **One-LUN-per-PC matrix.** Rows = workstations, columns = OS images. Create
+  a fresh LUN from a golden image with one click; the clone is sparse so 50
+  workstations share storage for 1× the source size.
+- **Built-in lifecycle.** Switch a PC to a different OS image. Roll back to
+  yesterday's snapshot. Wipe-and-restore for "boot from clean image" workflows.
+- **Production-ready guardrails.** Multiple safety layers prevent the operator
+  from accidentally destroying the golden image source ZVOL or pool, with
+  enforced cleanup of legacy datasets + atomic LUN ID assignment that's
+  multi-initiator-safe.
+- **Recovery procedures.** Live console + step-by-step playbooks for the
+  common failure modes (SCST stale extents, target ID drift, snapshot
+  cascade conflicts).
+
+## How updates work in TrueNAS Apps
+
+This catalog build of ClubFoundry runs with `CLM_UPDATE_MODE=truenas_apps`,
+which **disables the in-container auto-updater**. New versions are delivered
+through the standard TrueNAS Apps update flow:
+
+1. iX moderators merge our promotion PR upstream when we cut a new stable.
+2. TrueNAS shows "Update Available" on the ClubFoundry tile in the Apps UI.
+3. You click **Update**; TrueNAS runs `docker compose pull && up -d`.
+
+You can roll back from the same Apps UI if a release misbehaves.
+
+For users running ClubFoundry outside the TrueNAS Apps catalog (the
+`install.sh` standalone path), the in-container sidecar updater stays
+active and follows our normal alpha → beta → stable channel flow.
+
+## Documentation
+
+- Homepage: https://clubfoundry.net
+- Standalone install: `curl -fsSL https://clubfoundry.net/install.sh | bash`

--- a/ix-dev/community/clubfoundry/app.yaml
+++ b/ix-dev/community/clubfoundry/app.yaml
@@ -1,0 +1,47 @@
+annotations:
+  min_scale_version: 25.10.0
+app_version: 1.3.1
+capabilities: []
+categories:
+- storage
+changelog_url: https://clubfoundry.net/changelog
+date_added: '2026-05-23'
+description: iSCSI LUN manager for shared-PC infrastructures (gaming clubs, schools,
+  internet cafes, libraries) on TrueNAS SCALE.
+home: https://clubfoundry.net/
+host_mounts: []
+icon: https://clubfoundry.net/logo.png
+keywords:
+- iscsi
+- lun
+- clones
+- shared-pc
+- gaming
+lib_version: 2.3.5
+lib_version_hash: ""
+maintainers:
+- email: dev@truenas.com
+  name: truenas
+  url: https://www.truenas.com/
+name: clubfoundry
+# TODO before submission: confirm whether the container can run non-root (uid/gid
+# 568). Current Dockerfile USER directive is root for historical SQLite + sidecar-
+# IPC paths; the runtime itself does NOT require root (no in-container iscsiadm —
+# all iSCSI ops go through TrueNAS middleware API). Drop-root is tracked in
+# MEDIUM_TERM.md as a pre-submission task.
+run_as_context:
+- description: ClubFoundry currently runs as root; non-root drop tracked separately.
+  gid: 0
+  group_name: root
+  uid: 0
+  user_name: root
+# Screenshots are uploaded by the iX reviewer to media.sys.truenas.net during PR
+# review. We provide candidate URLs (CDN-hosted PNGs on our side) in the PR body;
+# the merged YAML then points to media.sys.truenas.net.
+screenshots: []
+sources:
+- https://clubfoundry.net
+- https://hub.docker.com/r/clubfoundry/clubfoundry
+title: ClubFoundry
+train: community
+version: 1.0.0

--- a/ix-dev/community/clubfoundry/ix_values.yaml
+++ b/ix-dev/community/clubfoundry/ix_values.yaml
@@ -1,0 +1,7 @@
+images:
+  clubfoundry_image:
+    # Public GHCR. release-publish.mjs already pushes here for every alpha+;
+    # release-publish-catalog.mjs verifies the stable tag exists publicly
+    # before opening the upstream PR.
+    repository: ghcr.io/clubfoundry/clubfoundry
+    tag: 1.3.1

--- a/ix-dev/community/clubfoundry/questions.yaml
+++ b/ix-dev/community/clubfoundry/questions.yaml
@@ -1,0 +1,219 @@
+# ClubFoundry questions.yaml — config form schema rendered by TrueNAS Apps
+# install wizard. Groups follow the upstream convention (My App / User and
+# Group / Network / Storage / Resources) so the wizard looks like every
+# other community-train app.
+
+groups:
+  - name: ClubFoundry Configuration
+    description: Admin credentials, TrueNAS middleware connection, and branding.
+  - name: User and Group Configuration
+    description: User/group ClubFoundry runs as inside the container.
+  - name: Network Configuration
+    description: Listen port for the admin BO and customer portal.
+  - name: Storage Configuration
+    description: Where SQLite database + diagnostics live on the host.
+  - name: Resources Configuration
+    description: CPU / memory limits.
+
+questions:
+  # ─── ClubFoundry Configuration ────────────────────────────────────────
+  - variable: clubfoundry
+    label: ""
+    group: ClubFoundry Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: admin_email
+          label: Administrator Email
+          description: Email address for the first admin account. Used for sign-in.
+          schema:
+            type: string
+            required: true
+
+        - variable: admin_password
+          label: Administrator Password
+          description: First-boot only. Hashed by the container before storage.
+          schema:
+            type: string
+            required: true
+            private: true
+            min_length: 12
+
+        - variable: truenas_api_key
+          label: TrueNAS API Key
+          description: Generate at Credentials → API Keys → Add (full middleware access).
+          schema:
+            type: string
+            required: true
+            private: true
+
+        - variable: truenas_host
+          label: TrueNAS Host URL
+          description: Usually https://127.0.0.1. Override only for multi-host setups.
+          schema:
+            type: string
+            required: true
+            default: https://127.0.0.1
+
+        - variable: portal_name
+          label: Portal Name
+          description: Shown in the browser tab and at the top of the admin BO.
+          schema:
+            type: string
+            default: ClubFoundry
+
+        - variable: theme
+          label: Default Theme
+          description: Per-user themes still selectable in the admin BO.
+          schema:
+            type: string
+            default: soft
+            enum:
+              - value: soft
+                description: Soft
+              - value: light
+                description: Light
+              - value: dark
+                description: Dark
+
+  # ─── User and Group Configuration ─────────────────────────────────────
+  - variable: run_as
+    label: ""
+    group: User and Group Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: user
+          label: User ID
+          description: Container UID. Default 0 (root) — see app.yaml note about non-root drop tracking.
+          schema:
+            type: int
+            min: 0
+            default: 0
+            required: true
+        - variable: group
+          label: Group ID
+          description: Container GID. Must match the user above for file permissions.
+          schema:
+            type: int
+            min: 0
+            default: 0
+            required: true
+
+  # ─── Network Configuration ────────────────────────────────────────────
+  - variable: network
+    label: ""
+    group: Network Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: web_port
+          label: Web Port
+          description: HTTP port for the admin BO and customer-facing portal.
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: Host networking is required for iSCSI client traffic.
+                schema:
+                  type: string
+                  default: published
+                  enum:
+                    - value: published
+                      description: Publish port on the host
+                    - value: host
+                      description: Use host networking
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 3000
+                  min: 1024
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs the port binds to. Leave empty for all.
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+
+  # ─── Storage Configuration ────────────────────────────────────────────
+  - variable: storage
+    label: ""
+    group: Storage Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: data
+          label: ClubFoundry Data Directory
+          description: SQLite database + uploads + diagnostics. Survives container recreate.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                schema:
+                  type: string
+                  required: true
+                  default: ix_volume
+                  enum:
+                    - value: host_path
+                      description: Host Path (Path that already exists on the system)
+                    - value: ix_volume
+                      description: ix-volume (Dataset created automatically)
+              - variable: ix_volume_config
+                label: ix-volume Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  attrs:
+                    - variable: dataset_name
+                      label: Dataset Name
+                      schema:
+                        type: string
+                        required: true
+                        default: data
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: path
+                      label: Host Path
+                      schema:
+                        type: hostpath
+                        required: true
+
+  # ─── Resources Configuration ──────────────────────────────────────────
+  - variable: resources
+    label: ""
+    group: Resources Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: limits
+          label: Limits
+          schema:
+            type: dict
+            attrs:
+              - variable: cpus
+                label: CPUs
+                description: CPU limit. Default 2 cores is plenty for typical workloads.
+                schema:
+                  type: int
+                  default: 2
+                  required: true
+              - variable: memory
+                label: Memory (in MB)
+                schema:
+                  type: int
+                  default: 2048
+                  required: true

--- a/ix-dev/community/clubfoundry/templates/docker-compose.yaml
+++ b/ix-dev/community/clubfoundry/templates/docker-compose.yaml
@@ -1,0 +1,60 @@
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{# ────────────────────────────────────────────────────────────────────
+   ClubFoundry catalog compose template.
+
+   Rendered by the TrueNAS Apps install wizard with the operator's
+   answers from questions.yaml. The rendered output is what the host runs.
+
+   Hard invariants (do not change without updating
+   docs/project/TRUENAS_CATALOG_SUBMISSION.md):
+
+   1. CLM_UPDATE_MODE=truenas_apps   — disables sidecar self-update;
+                                       TrueNAS Apps owns docker pull+up.
+   2. NO clubfoundry-updater service — the standalone sidecar updater is
+                                       OMITTED; TrueNAS handles updates.
+   3. /app/data bind mount           — SQLite + diagnostics survive recreate.
+
+   ──────────────────────────────────────────────────────────────────── #}
+
+{% set app = tpl.add_container("clubfoundry", "clubfoundry_image") %}
+
+{# User / group #}
+{% do app.set_user(values.run_as.user, values.run_as.group) %}
+
+{# Network — single web port, follows the bind-mode question #}
+{% do app.add_port(values.network.web_port, {"container_port": values.network.web_port.port_number}) %}
+
+{# Environment — catalog-managed marker + admin/connection/branding #}
+{% do app.environment.add_env("CLM_UPDATE_MODE", "truenas_apps") %}
+{% do app.environment.add_env("CLM_ADMIN_EMAIL", values.clubfoundry.admin_email) %}
+{% do app.environment.add_env("CLM_ADMIN_PASSWORD", values.clubfoundry.admin_password) %}
+{% do app.environment.add_env("CLM_TRUENAS_API_KEY", values.clubfoundry.truenas_api_key) %}
+{% do app.environment.add_env("CLM_TRUENAS_HOST", values.clubfoundry.truenas_host) %}
+{% do app.environment.add_env("CLM_PORTAL_NAME", values.clubfoundry.portal_name) %}
+{% do app.environment.add_env("CLM_THEME_DEFAULT", values.clubfoundry.theme) %}
+{% do app.environment.add_env("CLM_PORT", values.network.web_port.port_number) %}
+
+{# Storage — SQLite + uploads + diagnostics #}
+{% do app.add_storage("/app/data", values.storage.data) %}
+
+{# Healthcheck — IPv4 loopback (TrueNAS hosts often have broken IPv6 upstream) #}
+{% do app.healthcheck.set_test("http", {"port": values.network.web_port.port_number, "path": "/health"}) %}
+
+{# Resources — CPU + memory limits #}
+{% do app.resources.set_profile("low") %}
+{% do app.resources.set_cpus(values.resources.limits.cpus) %}
+{% do app.resources.set_memory(values.resources.limits.memory) %}
+
+{# Permissions init container — fixes data dir ownership when uid/gid changed #}
+{% set perms = tpl.deps.perms("perms") %}
+{% do perms.add_or_skip_action("data", values.storage.data, {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"}) %}
+{% if perms.has_actions() %}
+  {% do perms.activate() %}
+  {% do app.depends.add_dependency("perms", "service_completed_successfully") %}
+{% endif %}
+
+{# Portal entry — what TrueNAS Apps UI links to as "Open Web Portal" #}
+{% do tpl.portals.add(values.network.web_port, {"scheme": "http", "path": "/"}) %}
+
+{{ tpl.render() | tojson }}

--- a/ix-dev/community/clubfoundry/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/clubfoundry/templates/test_values/basic-values.yaml
@@ -1,0 +1,31 @@
+# Catalog CI test values. Used by truenas/apps repo's Python validator to
+# render the compose template and check it deploys cleanly. Never used by
+# real installs.
+#
+# Port 30080 instead of 3000 — convention to avoid collision with other apps
+# under test on the same CI runner (per upstream CONTRIBUTIONS.md).
+
+clubfoundry:
+  admin_email: ci-test@example.com
+  admin_password: ci-test-password-12345
+  truenas_api_key: ci-test-api-key-placeholder
+  truenas_host: https://127.0.0.1
+  portal_name: ClubFoundry
+  theme: soft
+run_as:
+  user: 0
+  group: 0
+network:
+  web_port:
+    bind_mode: published
+    port_number: 30080
+    host_ips: []
+storage:
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: data
+resources:
+  limits:
+    cpus: 2
+    memory: 2048


### PR DESCRIPTION
# App Addition

- [x] I have opened an [issue](https://github.com/truenas/apps/issues/5030) to discuss this app addition before submitting this pull request.

# AI

- [x] Part or All of this PR was generated by an LLM.

## Description

ClubFoundry automates ZVOL snapshotting, clone creation from those
snapshots for every PC in a club or classroom, and the full lifecycle of
those clones.

Without it, an operator running a 60-PC club has to walk through the full
TrueNAS chain manually, per PC, on every master image refresh: snapshot
the master ZVOL, create a clone, create an extent on the clone, bind the
extent to the right iSCSI target with a LUN. Even for a single ZVOL
across 60 PCs this is several hours of TrueNAS UI clicks.

ClubFoundry replaces all of that with one matrix UI (one row per PC, one
column per LUN/ZVOL), where the operator can either assign an automatic
update policy to a specific LUN/ZVOL or run one-click operations like
"promote a new master snapshot to all clones" or "swap a single PC to a
different master ZVOL". All ZVOL, snapshot, clone, extent, and
target-extent operations are driven through the TrueNAS middleware API
(no in-container iscsiadm).

The runtime is a single Docker container (Fastify backend, React
frontend, SQLite state). Target verticals: gaming clubs and computer
classrooms, plus internet cafes, schools, universities, QA test farms,
and public libraries.

## App Information

- **Upstream homepage:** https://clubfoundry.net
- **Docker image:** ghcr.io/clubfoundry/clubfoundry (public, anonymous-pullable)
- **Source train:** community
- **Catalog version:** 1.0.0 (first submission)
- **App version:** 1.3.1 (current stable)
- **Maintainer:** TrueNAS (institutional, per CONTRIBUTIONS.md guidance for community-train apps without a dedicated upstream maintainer entity)
- **Image source code:** closed source. The image is built from a private repository; the published artifact at ghcr.io/clubfoundry/clubfoundry is the canonical distribution surface.

## Testing

I ran both validators from `dev_apps_validate.yml` locally inside
`ghcr.io/truenas/apps_validation:latest`, the same image the CI on this PR
will use. Both passed clean against our `ix-dev/community/clubfoundry/`:

```
$ docker run --rm -v $(pwd):/workspace -w /workspace \
    -e FAKE_ENV=1 ghcr.io/truenas/apps_validation:latest \
    /bin/bash -c "git config --global --add safe.directory /workspace && \
      /usr/local/bin/apps_dev_charts_validate validate \
        --path /workspace --base_branch master; echo EXIT=\$?"
EXIT=0

$ docker run --rm -v $(pwd):/workspace -w /workspace \
    -e FAKE_ENV=1 ghcr.io/truenas/apps_validation:latest \
    /bin/bash -c "python3 .github/scripts/port_validation.py; echo EXIT=\$?"
Next 5 available ports: [30429, 30430, 30431, 30432, 30433]
EXIT=0
```

Other verification performed locally:
- `ghcr.io/clubfoundry/clubfoundry:1.3.1` pulls anonymously (fresh
  `docker pull` from a machine with no GHCR credentials).
- Icon URL `https://clubfoundry.net/logo.png` returns `image/png` (31 KB),
  verified with `curl -I`.
- `lib_version: 2.3.5` matches the current `library/2.3.5/` version on
  master at submission time.
- Standalone install (the `install.sh` distribution path) was exercised
  end-to-end during the 1.3.1 stable cycle on our test TrueNAS bench.

Catalog-mode install (the path this PR enables, via TrueNAS Apps UI) can
only be tested after merge or against a forked catalog. Happy to
coordinate a side-by-side test with a reviewer if useful.

Note on the port default: our `questions.yaml` declares port 3000 as the
default (matches our standard distribution). `port_validation.py` accepts
it cleanly; if the convention for community-train apps is to use the
30000+ NodePort range, happy to bump to 30429 (the next free slot the
validator reported) before merge.

## Icons / Screenshots

**Icon:**
- URL: `https://clubfoundry.net/logo.png`
- Content-Type: `image/png` (verified with `curl -I`)
- Size: 31 KB
- Format: PNG, transparent background, square

**Screenshots (curated, publicly hosted on our CDN):**

### Dashboard — PC × LUN matrix
![ClubFoundry Dashboard](https://clubfoundry.net/screenshots/clubfoundry/v1.3.1/dashboard.png)
Per-PC row × per-LUN column. Live status, version drift, capacity per cell.

### Storage capacity & recovery reserves
![Capacity view](https://clubfoundry.net/screenshots/clubfoundry/v1.3.1/capacity.png)
Per-ZVOL breakdown of clones, performance buffer, system minimum, and available
space. Surfaces capacity pressure before it bites a clone update.

### Update policies
![Policy templates](https://clubfoundry.net/screenshots/clubfoundry/v1.3.1/policies.png)
Per-LUN automatic update policies (Hourly / 6h / Daily / Manual / Custom).
Auto-fix LUN ID and reboot-race controls per policy.

### Setup & import wizard
![Setup wizard](https://clubfoundry.net/screenshots/clubfoundry/v1.3.1/setup.png)
5-step onboarding that discovers existing TrueNAS ZVOLs, targets, and
initiator-target mappings, lets the operator opt items into management,
and leaves the rest visible-only.

All four PNGs are publicly hosted on our Cloudflare Pages CDN
(`clubfoundry.net`) with a Selectel S3 mirror at `mirror.clubfoundry.ru`
for CIS reachability. Happy to re-upload to `media.sys.truenas.net` at
your direction, or for you to fetch and re-host as part of the merge
process.

## Special Notes

- **`run_as_context: root` (uid 0 / gid 0).** This catalog template
  deploys the same `ghcr.io/clubfoundry/clubfoundry:1.3.1` image we
  ship through our standalone distribution channel. We deliberately
  do not maintain a separate catalog-only image variant: a single
  image means catalog users get the build that has gone through our
  full alpha → beta → stable verification cycle on customer
  infrastructure (several weeks of uptime per channel transition).
  One image, one test surface, one uptime track record.

  The image runs as root because that is what works reliably across
  our standalone configuration: the bind-mounted SQLite data volume
  has uncertain host-side ownership at install time, the in-container
  sidecar IPC paths were laid out under root, and the standalone
  updater container needs `docker.sock` access. In the catalog
  deployment most of that is moot — the sidecar IPC is unused, the
  updater container is intentionally omitted (see below), and only
  the SQLite data volume ownership remains a real constraint. But
  the image is shared with our standalone channel, so the
  configuration is shared too.

  The runtime itself does not need root for any of the user-facing
  flows. Every iSCSI / ZVOL / snapshot / clone / extent operation
  goes through the TrueNAS middleware API: no `iscsiadm` inside the
  container, no kernel modules loaded, no `/dev/sd*` access, no
  privileged ports. The container does not mount `docker.sock`, does
  not request any Linux capabilities beyond defaults, and does not
  need host PID / IPC namespaces (only `network: host` for iSCSI
  traffic).

  Architectural changes to drop root are out of scope for this
  submission. If you have a specific concern that the
  middleware-API-only access pattern above does not address, we are
  open to discussing it.

- **TrueNAS API key is required at install time.** Asked via
  `questions.yaml` (`truenas_api_key`, marked private); the operator
  generates it in TrueNAS UI under Settings → API Keys. Flagging
  because most community-train apps do not require host-TrueNAS
  credentials, so it is a non-obvious install-time dependency.

- **Dual-mode runtime (`CLM_UPDATE_MODE`) and intentionally-omitted
  updater container.** The image accepts `CLM_UPDATE_MODE=standalone`
  (default, used by our `install.sh` distribution channel — ships a
  second `clubfoundry-updater` container that owns the upgrade workflow)
  or `CLM_UPDATE_MODE=truenas_apps` (what this catalog compose template
  hard-pins — the in-container self-updater is disabled, and the
  updater container is deliberately not in this template). Result:
  TrueNAS Apps is the single upgrade authority for any catalog install,
  and there is no second updater container to misinterpret as a missing
  service.

## Checklist

- [x] App runs successfully locally
- [x] Only modified files under /ix-dev/ or /library/
- [x] README.md included
- [x] Multiple test scenarios tested
- [x] questions.yaml has clear descriptions and follows structure of existing apps
- [x] All automated CI checks pass
