### PR TITLE
Fix omnom missing data storage in questions

### DIFF
--- a/ix-dev/community/omnom/app.yaml
+++ b/ix-dev/community/omnom/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://github.com/asciimoo/omnom
 title: Omnom
 train: community
-version: 1.1.6
+version: 1.1.7

--- a/ix-dev/community/omnom/questions.yaml
+++ b/ix-dev/community/omnom/questions.yaml
@@ -309,6 +309,82 @@ questions:
                         type: hostpath
                         show_if: [["acl_enable", "=", false]]
                         required: true
+        - variable: data
+          label: Omnom Data Storage
+          description: The path to store Omnom Data.
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "data"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
         - variable: additional_storage
           label: Additional Storage
           schema:

--- a/ix-dev/community/omnom/questions.yaml
+++ b/ix-dev/community/omnom/questions.yaml
@@ -234,8 +234,7 @@ questions:
       type: dict
       attrs:
         - variable: config
-          label: Omnom Config Storage
-          description: The path to store Omnom Config.
+          label: Config Storage
           schema:
             type: dict
             attrs:
@@ -310,8 +309,7 @@ questions:
                         show_if: [["acl_enable", "=", false]]
                         required: true
         - variable: data
-          label: Omnom Data Storage
-          description: The path to store Omnom Data.
+          label: Data Storage
           schema:
             type: dict
             attrs:


### PR DESCRIPTION
## Summary

The omnom `docker-compose.yaml` template mounts `values.storage.data` at `/omnom/static/data`, and the test values define `storage.data`, but `questions.yaml` was missing the corresponding `storage.data` question. As a result the data volume could not be configured from the UI.

This adds an **Omnom Data Storage** question mirroring the existing **Omnom Config Storage** question (default dataset name `data`), and bumps the chart version `1.1.6` → `1.1.7`.

## Changes
- `ix-dev/community/omnom/questions.yaml`: add `storage.data` question
- `ix-dev/community/omnom/app.yaml`: bump version to `1.1.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)