### PR TITLE
[hermes-agent] Set API_SERVER_HOST=0.0.0.0 so the API server is reachable

### DIFF
--- a/ix-dev/community/hermes-agent/app.yaml
+++ b/ix-dev/community/hermes-agent/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://hub.docker.com/r/nousresearch/hermes-agent
 title: Hermes-Agent
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/hermes-agent/templates/docker-compose.yaml
+++ b/ix-dev/community/hermes-agent/templates/docker-compose.yaml
@@ -7,6 +7,8 @@
 {% do c1.healthcheck.set_test("curl", {"port": values.network.gateway_port.port_number, "path": "/health"}) %}
 
 {% do c1.environment.add_env("API_SERVER_ENABLED", true) %}
+{# Bind to all interfaces so the published port is reachable; the server otherwise defaults to loopback inside the container. #}
+{% do c1.environment.add_env("API_SERVER_HOST", "0.0.0.0") %}
 {% do c1.environment.add_env("API_SERVER_PORT", values.network.gateway_port.port_number) %}
 {% do c1.environment.add_env("API_SERVER_KEY", values.hermes_agent.gateway_key) %}
 {% do c1.environment.add_env("GATEWAY_ALLOW_ALL_USERS", values.hermes_agent.allow_all_users_access) %}


### PR DESCRIPTION
## Summary

The hermes-agent OpenAI-compatible **API server is unreachable on its published port** because `API_SERVER_HOST` is never set. The server defaults to binding `127.0.0.1` inside the container, so the published port forwards to the container's network interface where nothing is listening — connections are reset.

This is **silent**: the healthcheck curls `http://127.0.0.1:<port>/health` (loopback works), so the app reports **healthy** while external/host access to the API is broken.

Fixes #5064.

## Change

Add one env var in `templates/docker-compose.yaml`:

```jinja
{% do c1.environment.add_env("API_SERVER_HOST", "0.0.0.0") %}
```

This matches the upstream Docker guidance, which sets `API_SERVER_HOST=0.0.0.0` for containerized deployments: https://hermes-agent.nousresearch.com/docs/user-guide/docker

`version` bumped `1.0.0` → `1.0.1`. No config-structure change, so no migration needed.

## Reproduction (on 1.0.0)

1. Install hermes-agent, Gateway port published (default `30432`), wait until **healthy**.
2. `curl http://<host>:30432/v1/models` → connection reset (`curl` exit 56), from host and remote.
3. Dashboard port works fine.

`docker inspect` of the running container (1.0.0) confirms the env has `API_SERVER_ENABLED=true`, `API_SERVER_PORT`, `API_SERVER_KEY` but **no `API_SERVER_HOST`**, and the healthcheck targets `127.0.0.1` — which is why the broken state still reports healthy.

## Testing

- Template parses cleanly (jinja2).
- Change mirrors the four adjacent `add_env` calls.
- Full render/validation deferred to CI (local renderer requires the validation container image).
