### PR TITLE
Update Oikos to v0.62.2

### DIFF
--- a/ix-dev/community/oikos/app.yaml
+++ b/ix-dev/community/oikos/app.yaml
@@ -1,4 +1,4 @@
-app_version: 0.60.11
+app_version: 0.62.2
 capabilities: []
 categories:
 - productivity
@@ -39,4 +39,4 @@ sources:
 - https://github.com/ulsklyc/oikos/pkgs/container/oikos
 title: Oikos
 train: community
-version: 1.0.0
+version: 1.0.5

--- a/ix-dev/community/oikos/ix_values.yaml
+++ b/ix-dev/community/oikos/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/ulsklyc/oikos
-    tag: 0.60.11
+    tag: 0.62.2
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Bumps Oikos to v0.62.2 (catalog 1.0.5). Generated by the Oikos truenas-publish workflow.