### PR TITLE
fix: some luanti games have diverging names

### DIFF
--- a/trains/community/luanti/1.1.9/templates/macros/init.sh
+++ b/trains/community/luanti/1.1.9/templates/macros/init.sh
@@ -22,7 +22,7 @@ if [ -z "$(ls -A '{{ games_dir }}/{{ values.luanti.map_name }}')" ]; then
         echo "Failed to download {{ values.luanti.map_name }} from {{ download_url.x }}"; exit 1
     }
     echo "Unzipping {{ values.luanti.map_name }} to {{ games_dir }}"
-    unzip -q "/tmp/{{ values.luanti.map_name }}.zip" -d "{{ games_dir }}" || {
+    unzip -q "/tmp/{{ values.luanti.map_name }}.zip" -d "{{ games_dir }}" && touch "{{ games_dir }}/{{ values.luanti.map_name }}/.keep" || {
         echo "Downloaded file is not a valid zip archive."; exit 1
     }
 else


### PR DESCRIPTION
 i.e. URL `Wuzzy/mineclone2` contains game `voxelibre` - thus re-download und re-unzipping is tried ... but fails :cry: 

## FIX
Add .keep file creation after unzipping if successful, to avoid re-downloading and failure on re-unzip due to pre-existing files

error msg
```
root@truenas[...s/app_mounts/minecraft/data/.minetest]# docker logs cb800a326c8a
Downloading Wuzzy/mineclone2 from https://content.luanti.org/packages/Wuzzy/mineclone2/download/
Connecting to content.luanti.org
saving to '/tmp/mineclone2.zip'
mineclone2.zip       100% |********************************| 57.4M  0:00:00 ETA
'/tmp/mineclone2.zip' saved
Unzipping mineclone2 to /var/lib/minetest/.minetest/games
unzip: can't read standard input: File exists
replace voxelibre/.editorconfig? [y]es, [n]o, [A]ll, [N]one, [r]ename: Downloaded file is not a valid zip archive.
```

## Checklist
- [x] fix has been tested locally sucessfully