### PR TITLE
frigate: add Privileged Mode toggle

### DIFF
--- a/ix-dev/community/frigate/app.yaml
+++ b/ix-dev/community/frigate/app.yaml
@@ -49,4 +49,4 @@ sources:
 - https://github.com/blakeblackshear/frigate
 title: Frigate
 train: community
-version: 1.3.8
+version: 1.3.9

--- a/ix-dev/community/frigate/questions.yaml
+++ b/ix-dev/community/frigate/questions.yaml
@@ -56,6 +56,16 @@ questions:
           schema:
             type: boolean
             default: false
+        - variable: privileged
+          label: Privileged Mode
+          description: |
+            Run the Frigate container in privileged mode.</br>
+            This grants the container full access to the host, equivalent to root
+            on the host system. Only enable this if you need hardware/device access
+            that the "Devices" and "Mount USB Bus" options above cannot provide.
+          schema:
+            type: boolean
+            default: false
         - variable: devices
           label: Devices
           description: |

--- a/ix-dev/community/frigate/templates/docker-compose.yaml
+++ b/ix-dev/community/frigate/templates/docker-compose.yaml
@@ -4,6 +4,7 @@
 
 {% do c1.set_user(0, 0) %}
 {% do c1.add_caps(["CHOWN", "FOWNER", "DAC_OVERRIDE", "SETGID", "SETUID", "PERFMON", "KILL"]) %}
+{% if values.frigate.privileged %}{% do c1.set_privileged(true) %}{% endif %}
 {% do c1.set_shm_size_mb(tpl.funcs.or_default(values.frigate.shm_size_mb, 30)) %}
 {% if values.frigate.mount_usb_bus %}
   {% do c1.devices.add_usb_bus() %}

--- a/ix-dev/community/frigate/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/frigate/templates/test_values/basic-values.yaml
@@ -7,6 +7,7 @@ frigate:
   image_selector: image
   shm_size_mb: 64
   mount_usb_bus: false
+  privileged: false
   additional_envs: []
 
 network:

--- a/ix-dev/community/frigate/templates/test_values/https-values.yaml
+++ b/ix-dev/community/frigate/templates/test_values/https-values.yaml
@@ -7,6 +7,7 @@ frigate:
   image_selector: image
   shm_size_mb: 64
   mount_usb_bus: false
+  privileged: true
   additional_envs: []
 
 network:


### PR DESCRIPTION
## Description

Adds an optional **Privileged Mode** toggle to the existing Frigate community app. When enabled the container runs privileged; when off (the default) nothing changes, so existing installs are unaffected.

Some Frigate deployments need privileged access for hardware that the existing **Devices** / **Mount USB Bus** options can't cover - for example PCIE MemryX MX3 device. 

The base library already emits a "Privileged mode is enabled" security note for privileged containers, so the toggle surfaces that automatically.

> This modifies an existing app, so the "App Addition" template doesn't apply.

## AI

- [x] Part or All of this PR was generated by an LLM.

## Changes

- `questions.yaml`: new `privileged` boolean (default `false`) with a warning
- `templates/docker-compose.yaml`: `set_privileged(true)` when enabled
- `templates/test_values/{basic,https}-values.yaml`: cover off / on
- `app.yaml`: version `1.3.8` → `1.3.9`

## Testing

Verified on real hardware (TrueNAS 25.10.4): the toggle appears in Frigate's
config form, enabling it sets the container privileged
(`docker inspect … Privileged=true`), and the app's Security/Notes card shows
"Privileged mode is enabled". Defaults to off.

## Checklist

- [x] Only files under `/ix-dev/` are modified (no auto-generated files)
- [x] `version` bumped in `app.yaml`
- [x] `questions.yaml` has a clear label and description
