### PR TITLE
feat(teslamate): update to 4.0.1

### DIFF
--- a/ix-dev/community/teslamate/app.yaml
+++ b/ix-dev/community/teslamate/app.yaml
@@ -1,4 +1,4 @@
-app_version: 3.1.0
+app_version: 4.0.1
 capabilities: []
 categories:
 - monitoring
@@ -44,4 +44,4 @@ sources:
 - https://hub.docker.com/r/teslamate/teslamate
 title: TeslaMate
 train: community
-version: 1.0.10
+version: 1.0.11

--- a/ix-dev/community/teslamate/ix_values.yaml
+++ b/ix-dev/community/teslamate/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: teslamate/teslamate
-    tag: "3.1.0"
+    tag: "4.0.1"
   api_image:
     repository: tobiasehlert/teslamateapi
     tag: "1.24.2"


### PR DESCRIPTION
## TeslaMate update to v4.0.1

This is a **critical fix** release that resolves the refresh token issue which made TeslaMate completely unusable.

### Changes
- `teslamate/teslamate`: `3.1.0` → `4.0.1`
- App version bumped: `1.0.10` → `1.0.11`

### Why this matters
v4.0.1 specifically resolves the refresh token authentication issue. See upstream release notes: https://github.com/teslamate-org/teslamate/releases/tag/v4.0.1