### PR TITLE
Crafty 4.10.5 is broken, update to 4.10.6

### DIFF
--- a/ix-dev/community/crafty-4/app.yaml
+++ b/ix-dev/community/crafty-4/app.yaml
@@ -1,4 +1,4 @@
-app_version: 4.10.5
+app_version: 4.10.6
 capabilities: []
 categories:
 - games

--- a/ix-dev/community/crafty-4/ix_values.yaml
+++ b/ix-dev/community/crafty-4/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: arcadiatechnology/crafty-4
-    tag: 4.10.5
+    tag: 4.10.6
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Crafty 4.10.5 was broken as released due to a missing python package (see https://gitlab.com/crafty-controller/crafty-4/-/merge_requests/1042)

Update to 4.10.6