### PR TITLE
fix(penpot): include MCP server port in PENPOT_MCP_URI

### DIFF
--- a/ix-dev/community/penpot/app.yaml
+++ b/ix-dev/community/penpot/app.yaml
@@ -62,4 +62,4 @@ sources:
 - https://github.com/penpot/penpot
 title: Penpot
 train: community
-version: 1.5.26
+version: 1.5.27

--- a/ix-dev/community/penpot/templates/docker-compose.yaml
+++ b/ix-dev/community/penpot/templates/docker-compose.yaml
@@ -57,7 +57,12 @@
 
 {% do exporter.healthcheck.set_test("curl", {"port": values.consts.exporter_port, "path": "/readyz"}) %}
 {% do exporter.depends.add_dependency(values.consts.penpot_backend_container_name, "service_healthy") %}
-{% do exporter.environment.add_env("PENPOT_PUBLIC_URI", values.penpot.public_uri) %}
+{# The exporter is a headless browser that navigates to $PENPOT_PUBLIC_URI/render.html to render exports
+   (exporter/src/app/renderer/bitmap.cljs uses its own cf/get :public-uri). It runs on the internal app
+   network with no access to external DNS or the reverse proxy, so pointing it at the user-facing public
+   URI breaks PNG/PDF export (ERR_NAME_NOT_RESOLVED / unreachable proxy). Point it at the internal frontend
+   instead, which serves render.html and same-origin /api. Backend/frontend keep the public URI for users. #}
+{% do exporter.environment.add_env("PENPOT_PUBLIC_URI", "http://%s:%d"|format(values.consts.penpot_frontend_container_name, values.consts.frontend_port)) %}
 {% do exporter.environment.add_env("PENPOT_REDIS_URI", redis_uri) %}
 {% do exporter.environment.add_env("PENPOT_HTTP_SERVER_PORT", values.consts.exporter_port) %}
 {% do exporter.environment.add_env("PENPOT_HTTP_SERVER_HOST", "0.0.0.0") %}

--- a/ix-dev/community/penpot/templates/docker-compose.yaml
+++ b/ix-dev/community/penpot/templates/docker-compose.yaml
@@ -57,11 +57,8 @@
 
 {% do exporter.healthcheck.set_test("curl", {"port": values.consts.exporter_port, "path": "/readyz"}) %}
 {% do exporter.depends.add_dependency(values.consts.penpot_backend_container_name, "service_healthy") %}
-{# The exporter is a headless browser that navigates to $PENPOT_PUBLIC_URI/render.html to render exports
-   (exporter/src/app/renderer/bitmap.cljs uses its own cf/get :public-uri). It runs on the internal app
-   network with no access to external DNS or the reverse proxy, so pointing it at the user-facing public
-   URI breaks PNG/PDF export (ERR_NAME_NOT_RESOLVED / unreachable proxy). Point it at the internal frontend
-   instead, which serves render.html and same-origin /api. Backend/frontend keep the public URI for users. #}
+{# The exporter is a headless browser that navigates to $PENPOT_PUBLIC_URI/render.html to render exports.
+  It runs on the internal app network with no access to external DNS or the reverse proxy.#}
 {% do exporter.environment.add_env("PENPOT_PUBLIC_URI", "http://%s:%d"|format(values.consts.penpot_frontend_container_name, values.consts.frontend_port)) %}
 {% do exporter.environment.add_env("PENPOT_REDIS_URI", redis_uri) %}
 {% do exporter.environment.add_env("PENPOT_HTTP_SERVER_PORT", values.consts.exporter_port) %}
@@ -73,10 +70,6 @@
 {% do frontend.environment.add_env("PENPOT_PUBLIC_URI", values.penpot.public_uri) %}
 {% do frontend.environment.add_env("PENPOT_BACKEND_URI", "http://%s:%d"|format(values.consts.penpot_backend_container_name, values.consts.backend_port)) %}
 {% do frontend.environment.add_env("PENPOT_EXPORTER_URI", "http://%s:%d"|format(values.consts.penpot_exporter_container_name, values.consts.exporter_port)) %}
-{# The frontend nginx proxies /mcp/stream and /mcp/sse to $PENPOT_MCP_URI (which must be host:port,
-   the path is appended in the template) and /mcp/ws to $PENPOT_MCP_URI_WS. The image defaults these to
-   http://penpot-mcp:4401 / :4402 (see entrypoint.sh), so $PENPOT_MCP_URI MUST include the server port —
-   without it nginx proxies to :80 and /mcp/stream returns 502. Set both explicitly from our port consts. #}
 {% do frontend.environment.add_env("PENPOT_MCP_URI", "http://%s:%d"|format(values.consts.penpot_mcp_container_name, values.consts.mcp_server_port)) %}
 {% do frontend.environment.add_env("PENPOT_MCP_URI_WS", "http://%s:%d"|format(values.consts.penpot_mcp_container_name, values.consts.mcp_ws_port)) %}
 

--- a/ix-dev/community/penpot/templates/docker-compose.yaml
+++ b/ix-dev/community/penpot/templates/docker-compose.yaml
@@ -68,9 +68,12 @@
 {% do frontend.environment.add_env("PENPOT_PUBLIC_URI", values.penpot.public_uri) %}
 {% do frontend.environment.add_env("PENPOT_BACKEND_URI", "http://%s:%d"|format(values.consts.penpot_backend_container_name, values.consts.backend_port)) %}
 {% do frontend.environment.add_env("PENPOT_EXPORTER_URI", "http://%s:%d"|format(values.consts.penpot_exporter_container_name, values.consts.exporter_port)) %}
-{# Looks like port is added statically #}
-{# https://github.com/penpot/penpot/blob/884b125cf5de0e3cec39da0fecdc813ec20c3c49/docker/images/files/nginx.conf.template#L150 #}
-{% do frontend.environment.add_env("PENPOT_MCP_URI", "http://%s"|format(values.consts.penpot_mcp_container_name)) %}
+{# The frontend nginx proxies /mcp/stream and /mcp/sse to $PENPOT_MCP_URI (which must be host:port,
+   the path is appended in the template) and /mcp/ws to $PENPOT_MCP_URI_WS. The image defaults these to
+   http://penpot-mcp:4401 / :4402 (see entrypoint.sh), so $PENPOT_MCP_URI MUST include the server port —
+   without it nginx proxies to :80 and /mcp/stream returns 502. Set both explicitly from our port consts. #}
+{% do frontend.environment.add_env("PENPOT_MCP_URI", "http://%s:%d"|format(values.consts.penpot_mcp_container_name, values.consts.mcp_server_port)) %}
+{% do frontend.environment.add_env("PENPOT_MCP_URI_WS", "http://%s:%d"|format(values.consts.penpot_mcp_container_name, values.consts.mcp_ws_port)) %}
 
 {% do mcp.healthcheck.set_test("curl", {"port": values.consts.mcp_repl_port}) %}
 {% do mcp.environment.add_env("PENPOT_MCP_SERVER_PORT", values.consts.mcp_server_port) %}


### PR DESCRIPTION
The linked template has changed since the pinned commit in the comment. I tested this by manually changing it locally.

## Problem

With `enable-mcp`, the Penpot MCP endpoints `/mcp/stream` and `/mcp/sse` return **502 Bad Gateway**. `/mcp/ws` works.

## Root cause

The frontend image's nginx template proxies:
- `/mcp/stream` → `$PENPOT_MCP_URI/mcp`
- `/mcp/sse`    → `$PENPOT_MCP_URI/sse`
- `/mcp/ws`     → `$PENPOT_MCP_URI_WS`

and its `entrypoint.sh` defaults `PENPOT_MCP_URI=http://penpot-mcp:4401` / `PENPOT_MCP_URI_WS=http://penpot-mcp:4402`.

The compose template set `PENPOT_MCP_URI` to `http://penpot-mcp` (no port), overriding the correct default, so nginx proxied stream/sse to **:80** → 502. ws survived only because `PENPOT_MCP_URI_WS` was left unset and fell back to the image default.

## Fix

Set both URIs explicitly from the existing `mcp_server_port` / `mcp_ws_port` consts (4401 / 4402).

## Verification

Running the image's `envsubst` with the corrected env yields:

/mcp/ws     → http://penpot-mcp:4402/
/mcp/stream → http://penpot-mcp:4401/mcp
/mcp/sse    → http://penpot-mcp:4401/sse

and the MCP `initialize` handshake succeeds end-to-end.