### PR TITLE
chore(community): bump smart-home-dashboard app version to 3.10.2

### DIFF
--- a/ix-dev/community/smart-home-dashboard/app.yaml
+++ b/ix-dev/community/smart-home-dashboard/app.yaml
@@ -1,4 +1,4 @@
-app_version: 3.9.8
+app_version: 3.10.2
 capabilities: []
 categories:
 - home-automation
@@ -34,4 +34,4 @@ sources:
 - https://hub.docker.com/r/daddelgreis74/smart-home-dashboard
 title: Smart Home Dashboard
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/smart-home-dashboard/ix_values.yaml
+++ b/ix-dev/community/smart-home-dashboard/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/daddelgreis74/smart-home-dashboard
-    tag: 3.9.8
+    tag: 3.10.2
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
This PR bumps the community app `smart-home-dashboard` to app version `3.10.2` (chart version `1.0.7`).

### Key Changes:
- Migrates settings from browser local storage to central server-side `/app/data/config.json`.
- Supports multi-device settings & J.A.R.V.I.S. chat history sync.
- Adds ElevenLabs TTS integration and J.A.R.V.I.S. web search capabilities via Brave Search.
- General bugfixes and UI adjustments.