### PR TITLE
hermes-agent: add opt-in webhook port

### DIFF
--- a/ix-dev/community/hermes-agent/app.yaml
+++ b/ix-dev/community/hermes-agent/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://hub.docker.com/r/nousresearch/hermes-agent
 title: Hermes-Agent
 train: community
-version: 1.0.4
+version: 1.0.5

--- a/ix-dev/community/hermes-agent/questions.yaml
+++ b/ix-dev/community/hermes-agent/questions.yaml
@@ -171,6 +171,53 @@ questions:
                         required: true
                         $ref:
                           - definitions/node_bind_ip
+        - variable: webhook_port
+          label: Webhook Port
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode for the webhook adapter.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The webhook adapter is disabled.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: ""
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 30440
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if: [["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
         - variable: networks
           label: Networks
           description: The docker networks to join

--- a/ix-dev/community/hermes-agent/templates/docker-compose.yaml
+++ b/ix-dev/community/hermes-agent/templates/docker-compose.yaml
@@ -21,10 +21,18 @@
   {% do tpl.portals.add(values.network.dashboard_port) %}
 {% endif %}
 
+{% do c1.environment.add_env("WEBHOOK_ENABLED", values.network.webhook_port.bind_mode != "") %}
+{% if values.network.webhook_port.bind_mode %}
+  {# The webhook adapter binds to 0.0.0.0 by default, so no host env is needed. #}
+  {# The HMAC secret and routes are application-level config (hermes gateway setup / config.yaml), not exposed here. #}
+  {% do c1.environment.add_env("WEBHOOK_PORT", values.network.webhook_port.port_number) %}
+{% endif %}
+
 {% do c1.environment.add_user_envs(values.hermes_agent.additional_envs) %}
 
 {% do c1.add_port(values.network.gateway_port) %}
 {% do c1.add_port(values.network.dashboard_port) %}
+{% do c1.add_port(values.network.webhook_port) %}
 
 {% do c1.add_storage("/opt/data", values.storage.data) %}
 {% for store in values.storage.additional_storage %}

--- a/ix-dev/community/hermes-agent/templates/docker-compose.yaml
+++ b/ix-dev/community/hermes-agent/templates/docker-compose.yaml
@@ -23,8 +23,6 @@
 
 {% do c1.environment.add_env("WEBHOOK_ENABLED", values.network.webhook_port.bind_mode != "") %}
 {% if values.network.webhook_port.bind_mode %}
-  {# The webhook adapter binds to 0.0.0.0 by default, so no host env is needed. #}
-  {# The HMAC secret and routes are application-level config (hermes gateway setup / config.yaml), not exposed here. #}
   {% do c1.environment.add_env("WEBHOOK_PORT", values.network.webhook_port.port_number) %}
 {% endif %}
 

--- a/ix-dev/community/hermes-agent/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/hermes-agent/templates/test_values/basic-values.yaml
@@ -17,6 +17,9 @@ network:
   dashboard_port:
     bind_mode: published
     port_number: 8081
+  webhook_port:
+    bind_mode: published
+    port_number: 8082
 
 ix_volumes:
   data: /opt/tests/mnt/hermes-agent/data


### PR DESCRIPTION
hermes-agent's gateway has a webhook adapter for inbound webhooks (`POST /webhooks/<route>`) that listens on its own port, separate from the API server and dashboard. See https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/. The app currently only exposes the Gateway (API server) and Dashboard ports, so there's no way to reach the webhook adapter from outside the container.

This adds a Webhook Port under Network Configuration, alongside the existing two. Bind mode defaults to None, so the adapter stays off and existing installs are unchanged. Setting it to Publish or Expose sets `WEBHOOK_ENABLED=true` and `WEBHOOK_PORT=<port_number>` and maps the port; the adapter binds 0.0.0.0 internally, so it listens on the same number that gets published. This mirrors the existing `API_SERVER_*` and `HERMES_DASHBOARD_*` handling in the template.

Default port 30440, verified unique via `.github/scripts/port_validation.py`. Version bumped to 1.0.5. Rendered locally with the webhook enabled and disabled to confirm the env vars and port mappings.