### PR TITLE
collabora: use tcp healthcheck

### DIFF
--- a/ix-dev/stable/collabora/app.yaml
+++ b/ix-dev/stable/collabora/app.yaml
@@ -56,4 +56,4 @@ sources:
 - https://www.collaboraoffice.com/
 title: Collabora
 train: stable
-version: 1.5.19
+version: 1.5.20

--- a/ix-dev/stable/collabora/templates/docker-compose.yaml
+++ b/ix-dev/stable/collabora/templates/docker-compose.yaml
@@ -33,7 +33,7 @@
 {% do c1.set_user(values.consts.run_as_user, values.consts.run_as_group) %}
 {% do c1.add_security_opt("apparmor", "unconfined") %}
 {% do c1.add_caps(caps=["CHOWN", "FOWNER", "SYS_CHROOT", "SYS_ADMIN"]) %}
-{% do c1.healthcheck.set_test("http", {"port": values.consts.internal_collabora_web_port}) %}
+{% do c1.healthcheck.set_test("tcp", {"port": values.consts.internal_collabora_web_port}) %}
 
 {% do c1.environment.add_env("timezone", values.TZ) %}
 {% do c1.environment.add_env("aliasgroup1", values.collabora.aliasgroup1|join(",")) %}


### PR DESCRIPTION
Closes #5250

Given that collabora does not have a real healthcheck endpoint to relay that actually everything is fine, we can switch to tcp which is simpler and allows the subpath setup user wants #5250, whithout compromising the truthness of the check.