### PR TITLE
netbootxyz: update image to 0.7.6-nbxyz23

### DIFF
--- a/ix-dev/community/netbootxyz/app.yaml
+++ b/ix-dev/community/netbootxyz/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: 0.7.6-nbxyz4
+app_version: 0.7.6-nbxyz23
 capabilities:
 - description: Netboot is able to change file ownership arbitrarily
   name: CHOWN
@@ -55,4 +55,4 @@ sources:
 - https://netboot.xyz
 title: Netboot.xyz
 train: community
-version: 1.3.6
+version: 1.3.7

--- a/ix-dev/community/netbootxyz/ix_values.yaml
+++ b/ix-dev/community/netbootxyz/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/netbootxyz/netbootxyz
-    tag: 0.7.6-nbxyz4
+    tag: 0.7.6-nbxyz23
 
 consts:
   netboot_container_name: netboot


### PR DESCRIPTION
## Summary

- Update netbootxyz Docker image tag from `0.7.6-nbxyz4` to `0.7.6-nbxyz23`
- Bump chart version from `1.3.6` to `1.3.7`

The current image (`0.7.6-nbxyz4`) ships outdated PXE boot menus — for example, the newest Fedora listed is Fedora 42, which reached EOL in May 2026. The latest image (`0.7.6-nbxyz23`) picks up current OS entries (Fedora 44, etc.) and includes netboot.xyz 3.x boot files with UEFI Secure Boot support via iPXE v2.0.0 signed binaries.

Upstream changelog: https://github.com/netbootxyz/docker-netbootxyz/tags

## Test plan

- [x] Verified `ghcr.io/netbootxyz/netbootxyz:0.7.6-nbxyz23` image exists and pulls successfully
- [x] Confirmed TFTP, web UI, and web assets ports all function correctly
- [x] PXE booted a UEFI VM via netboot.xyz and verified the boot menu loads