### PR TITLE
Add Fodaris

### DIFF
--- a/ix-dev/community/fodaris/README.md
+++ b/ix-dev/community/fodaris/README.md
@@ -1,0 +1,45 @@
+# Fodaris
+
+[Fodaris](https://fodaris.co.uk) - Self-hosted monitoring and observability for servers, containers, websites, network devices and databases. One container with PostgreSQL bundled in.
+
+## What it monitors
+
+- **Endpoints**: CPU, memory, disk, network, GPU and temperature across Linux, Windows and macOS via lightweight native agents
+- **Containers**: per-container resource usage for Docker and Podman
+- **Websites and APIs**: HTTP/HTTPS availability, response time, status codes, SSL expiry
+- **Databases**: PostgreSQL, MySQL, MariaDB, Redis, MongoDB, MSSQL, Oracle, SQLite
+- **Applications**: Nginx, Apache, HAProxy, Caddy, IIS, Tomcat
+- **Network devices**: SNMP v1/v2c/v3 for switches, routers, firewalls and NAS
+- **Logs**: centralised log shipping with search and redaction
+- **IPAM**: IP address allocation tracking and subnet scanning
+
+## Key features
+
+- Built-in PostgreSQL database - no external DB required
+- Encryption at rest for credentials and sensitive labels (key auto-generated on first boot)
+- Real-time dashboards with per-endpoint customisation
+- Alerts via email, Slack, Discord, Microsoft Teams, PagerDuty, ntfy and webhooks
+- Backup schedules (local and S3-compatible)
+- Multi-factor authentication and role-based access control
+- Native agents for Linux, macOS, Windows and Docker
+
+## First-time setup
+
+After the app starts, open the Web UI (default port 8443) and sign in with:
+
+- Username: `admin`
+- Password: `Fodaris2026`
+
+You will be required to change the password on first sign-in.
+
+## Licensing
+
+The free tier includes 5 endpoints, 5 websites, 5 databases and 5 applications. Paid tiers available at [fodaris.co.uk/pricing](https://fodaris.co.uk/pricing.html).
+
+## Sources
+
+- Website: [fodaris.co.uk](https://fodaris.co.uk)
+- Documentation: [docs.fodaris.co.uk](https://docs.fodaris.co.uk)
+- Live demo: [demo.fodaris.co.uk](https://demo.fodaris.co.uk)
+- Docker Hub: [goodhallsolutions/fodaris](https://hub.docker.com/r/goodhallsolutions/fodaris)
+- Community Discord: [discord.gg/9HN47kBFgm](https://discord.gg/9HN47kBFgm)

--- a/ix-dev/community/fodaris/app.yaml
+++ b/ix-dev/community/fodaris/app.yaml
@@ -1,0 +1,46 @@
+annotations:
+  min_scale_version: 24.10.2.2
+app_version: 1.0.5
+capabilities: []
+categories:
+- monitoring
+- networking
+changelog_url: https://docs.fodaris.co.uk/quick-start/docker-image-tags
+date_added: '2026-07-02'
+description: Self-hosted monitoring and observability for servers, containers, websites, network devices and databases. One container with PostgreSQL bundled in.
+home: https://fodaris.co.uk
+host_mounts: []
+icon: https://fodaris.co.uk/images/icon.png
+keywords:
+- monitoring
+- observability
+- self-hosted
+- alerts
+- dashboards
+lib_version: 2.3.4
+lib_version_hash: 2e3a8847308fb2eb0da046018f287c73822c094b5950a10377c3235794ff1242
+maintainers:
+- email: contact@goodhallsolutions.co.uk
+  name: Goodhall Solutions
+  url: https://fodaris.co.uk
+name: fodaris
+run_as_context:
+- description: Container [fodaris] runs as root user and group. Root is required so the bundled host monitor can read the host CPU, memory and process information.
+  gid: 0
+  group_name: Host group is [root]
+  uid: 0
+  user_name: Host user is [root]
+screenshots:
+- https://fodaris.co.uk/images/screenshots/dashboard.png
+- https://fodaris.co.uk/images/screenshots/topology.png
+- https://fodaris.co.uk/images/screenshots/alerts.png
+- https://fodaris.co.uk/images/screenshots/uptime.png
+- https://fodaris.co.uk/images/screenshots/databases.png
+- https://fodaris.co.uk/images/screenshots/logviewer.png
+sources:
+- https://fodaris.co.uk
+- https://docs.fodaris.co.uk
+- https://hub.docker.com/r/goodhallsolutions/fodaris
+title: Fodaris
+train: community
+version: 1.0.5

--- a/ix-dev/community/fodaris/app_migrations.yaml
+++ b/ix-dev/community/fodaris/app_migrations.yaml
@@ -1,0 +1,1 @@
+migrations: []

--- a/ix-dev/community/fodaris/item.yaml
+++ b/ix-dev/community/fodaris/item.yaml
@@ -1,0 +1,18 @@
+categories:
+- monitoring
+- networking
+icon_url: https://fodaris.co.uk/images/icon.png
+screenshots:
+- https://fodaris.co.uk/images/screenshots/dashboard.png
+- https://fodaris.co.uk/images/screenshots/topology.png
+- https://fodaris.co.uk/images/screenshots/alerts.png
+- https://fodaris.co.uk/images/screenshots/uptime.png
+- https://fodaris.co.uk/images/screenshots/databases.png
+- https://fodaris.co.uk/images/screenshots/logviewer.png
+tags:
+- monitoring
+- observability
+- self-hosted
+- alerts
+- dashboards
+- snmp

--- a/ix-dev/community/fodaris/ix_values.yaml
+++ b/ix-dev/community/fodaris/ix_values.yaml
@@ -1,0 +1,7 @@
+images:
+  image:
+    repository: goodhallsolutions/fodaris
+    tag: "1.0.5"
+
+consts:
+  fodaris_container_name: fodaris

--- a/ix-dev/community/fodaris/questions.yaml
+++ b/ix-dev/community/fodaris/questions.yaml
@@ -1,0 +1,567 @@
+groups:
+  - name: Fodaris Configuration
+    description: Configure Fodaris core settings
+  - name: Network Configuration
+    description: Configure network ports for Fodaris
+  - name: Storage Configuration
+    description: Configure persistent storage for Fodaris
+  - name: Labels Configuration
+    description: Configure Docker labels
+  - name: Resources Configuration
+    description: Configure CPU and memory limits
+
+questions:
+  # ────────────────────────────────────────────────────────────────────────
+  # Timezone (standard TrueNAS pattern)
+  # ────────────────────────────────────────────────────────────────────────
+  - variable: TZ
+    label: Timezone
+    group: Fodaris Configuration
+    schema:
+      type: string
+      default: Etc/UTC
+      $ref:
+        - definitions/timezone
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Fodaris application settings
+  # ────────────────────────────────────────────────────────────────────────
+  - variable: fodaris
+    label: ""
+    group: Fodaris Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: server_name
+          label: Server display name
+          description: Name shown in the Fodaris dashboard for this instance. Defaults to the container hostname.
+          schema:
+            type: string
+            default: fodaris
+
+        - variable: retention_days
+          label: Metric retention (days)
+          description: Number of days of monitoring data to retain before pruning.
+          schema:
+            type: int
+            default: 30
+            min: 7
+            max: 730
+
+        - variable: mount_docker_socket
+          label: Mount Docker socket (read-only)
+          description: |
+            Mount /var/run/docker.sock read-only so Fodaris can monitor Docker containers running on this host.
+            Leave off if you only want to monitor remote endpoints via the Fodaris agent.
+          schema:
+            type: boolean
+            default: true
+
+        - variable: additional_envs
+          label: Additional Environment Variables
+          description: Extra environment variables passed to the Fodaris container.
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: env
+                label: Environment Variable
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: Name
+                      schema:
+                        type: string
+                        required: true
+                    - variable: value
+                      label: Value
+                      schema:
+                        type: string
+                        required: true
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Network ports
+  # Fodaris exposes three ports:
+  #   8443  - Web UI and management API (browser-facing)
+  #   24443 - Agent ingest (agents push metrics here)
+  #   24444 - OpenTelemetry ingest (OTLP/HTTP)
+  # ────────────────────────────────────────────────────────────────────────
+  - variable: network
+    label: ""
+    group: Network Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: web_port
+          label: Web UI Port
+          description: Port for the Fodaris web UI and management API.
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish on the host for external access
+                    - value: "exposed"
+                      description: Expose for inter-container communication only
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 8443
+                  min: 1024
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: Host IPs to bind the port to. Empty binds all.
+                schema:
+                  type: list
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
+
+        - variable: agent_ingest_port
+          label: Agent Ingest Port
+          description: Port for Fodaris agents to push metrics to.
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish on the host for agent access
+                    - value: "exposed"
+                      description: Expose for inter-container communication only
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 24443
+                  min: 1024
+                  max: 65535
+                  required: true
+
+        - variable: otel_ingest_port
+          label: OpenTelemetry Ingest Port
+          description: Port for OpenTelemetry OTLP/HTTP ingestion. Optional - leave the default if unsure.
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish on the host
+                    - value: "exposed"
+                      description: Expose for inter-container communication only
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 24444
+                  min: 1024
+                  max: 65535
+                  required: true
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Persistent storage
+  # Three volumes:
+  #   config  - server config and settings
+  #   data    - PostgreSQL DB, encryption key and monitoring history
+  #   backups - backup archives from the built-in scheduler
+  # ────────────────────────────────────────────────────────────────────────
+  - variable: storage
+    label: ""
+    group: Storage Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: config
+          label: Config Storage
+          description: Persistent storage for Fodaris server configuration.
+          schema:
+            type: dict
+            $ref:
+              - normalize/ix_volume
+            attrs:
+              - variable: type
+                label: Type
+                schema:
+                  type: string
+                  default: ix_volume
+                  required: true
+                  enum:
+                    - value: host_path
+                      description: Host Path (Path that already exists on the system)
+                    - value: ix_volume
+                      description: ix_volume (Managed by TrueNAS SCALE)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - normalize/ix_volume
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      schema:
+                        type: string
+                        default: config
+                        required: true
+                        hidden: true
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        show_if: [["acl_enable", "=", true]]
+                        type: dict
+                        $ref:
+                          - normalize/acl
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        $ref:
+                          - normalize/acl
+                    - variable: path
+                      label: Host Path
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+
+        - variable: data
+          label: Data Storage
+          description: Persistent storage for the Fodaris PostgreSQL database, encryption key and monitoring history. This is the critical volume - back it up regularly.
+          schema:
+            type: dict
+            $ref:
+              - normalize/ix_volume
+            attrs:
+              - variable: type
+                label: Type
+                schema:
+                  type: string
+                  default: ix_volume
+                  required: true
+                  enum:
+                    - value: host_path
+                      description: Host Path (Path that already exists on the system)
+                    - value: ix_volume
+                      description: ix_volume (Managed by TrueNAS SCALE)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - normalize/ix_volume
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      schema:
+                        type: string
+                        default: data
+                        required: true
+                        hidden: true
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        show_if: [["acl_enable", "=", true]]
+                        type: dict
+                        $ref:
+                          - normalize/acl
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        $ref:
+                          - normalize/acl
+                    - variable: path
+                      label: Host Path
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+
+        - variable: backups
+          label: Backups Storage
+          description: Persistent storage for Fodaris backup archives produced by the built-in backup scheduler.
+          schema:
+            type: dict
+            $ref:
+              - normalize/ix_volume
+            attrs:
+              - variable: type
+                label: Type
+                schema:
+                  type: string
+                  default: ix_volume
+                  required: true
+                  enum:
+                    - value: host_path
+                      description: Host Path (Path that already exists on the system)
+                    - value: ix_volume
+                      description: ix_volume (Managed by TrueNAS SCALE)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - normalize/ix_volume
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      schema:
+                        type: string
+                        default: backups
+                        required: true
+                        hidden: true
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        show_if: [["acl_enable", "=", true]]
+                        type: dict
+                        $ref:
+                          - normalize/acl
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        $ref:
+                          - normalize/acl
+                    - variable: path
+                      label: Host Path
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+
+        - variable: additional_storage
+          label: Additional Storage
+          description: Add extra volumes if needed for your setup.
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: storage_entry
+                label: Storage Entry
+                schema:
+                  type: dict
+                  $ref:
+                    - normalize/ix_volume
+                  attrs:
+                    - variable: type
+                      label: Type
+                      schema:
+                        type: string
+                        required: true
+                        default: ix_volume
+                        enum:
+                          - value: host_path
+                            description: Host Path (Path that already exists on the system)
+                          - value: ix_volume
+                            description: ix_volume (Managed by TrueNAS SCALE)
+                    - variable: mount_path
+                      label: Mount Path
+                      description: The path inside the container to mount the storage.
+                      schema:
+                        type: path
+                        required: true
+                    - variable: ix_volume_config
+                      label: ixVolume Configuration
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "ix_volume"]]
+                        $ref:
+                          - normalize/ix_volume
+                        attrs:
+                          - variable: acl_enable
+                            label: Enable ACL
+                            schema:
+                              type: boolean
+                              default: false
+                          - variable: dataset_name
+                            label: Dataset Name
+                            schema:
+                              type: string
+                              required: true
+                              default: storage_entry
+                          - variable: acl_entries
+                            label: ACL Configuration
+                            schema:
+                              show_if: [["acl_enable", "=", true]]
+                              type: dict
+                              $ref:
+                                - normalize/acl
+                    - variable: host_path_config
+                      label: Host Path Configuration
+                      schema:
+                        type: dict
+                        show_if: [["type", "=", "host_path"]]
+                        attrs:
+                          - variable: acl_enable
+                            label: Enable ACL
+                            schema:
+                              type: boolean
+                              default: false
+                          - variable: acl
+                            label: ACL Configuration
+                            schema:
+                              type: dict
+                              show_if: [["acl_enable", "=", true]]
+                              $ref:
+                                - normalize/acl
+                          - variable: path
+                            label: Host Path
+                            schema:
+                              type: hostpath
+                              show_if: [["acl_enable", "=", false]]
+                              required: true
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Labels
+  # ────────────────────────────────────────────────────────────────────────
+  - variable: labels
+    label: ""
+    group: Labels Configuration
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: label
+          label: Label
+          schema:
+            type: dict
+            attrs:
+              - variable: key
+                label: Key
+                schema:
+                  type: string
+                  required: true
+              - variable: value
+                label: Value
+                schema:
+                  type: string
+                  required: true
+              - variable: containers
+                label: Containers
+                description: Containers to apply the label to
+                schema:
+                  type: list
+                  items:
+                    - variable: container
+                      label: Container
+                      schema:
+                        type: string
+                        required: true
+                        enum:
+                          - value: fodaris
+                            description: fodaris
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Resources
+  # ────────────────────────────────────────────────────────────────────────
+  - variable: resources
+    label: ""
+    group: Resources Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: limits
+          label: Limits
+          schema:
+            type: dict
+            attrs:
+              - variable: cpus
+                label: CPUs
+                description: CPU limit for Fodaris.
+                schema:
+                  type: int
+                  default: 2
+                  required: true
+              - variable: memory
+                label: Memory (in MB)
+                description: Memory limit for Fodaris in megabytes.
+                schema:
+                  type: int
+                  default: 2048
+                  required: true

--- a/ix-dev/community/fodaris/templates/docker-compose.yaml
+++ b/ix-dev/community/fodaris/templates/docker-compose.yaml
@@ -1,0 +1,46 @@
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{% set c1 = tpl.add_container(values.consts.fodaris_container_name, "image") %}
+
+{% do c1.set_user(0, 0) %}
+
+{% do c1.healthcheck.set_custom_test(["CMD-SHELL", "wget -qO- --no-check-certificate https://localhost:" ~ values.network.web_port.port_number|string ~ "/api/health > /dev/null || exit 1"]) %}
+{% do c1.healthcheck.set_interval_sec(30) %}
+{% do c1.healthcheck.set_timeout_sec(5) %}
+{% do c1.healthcheck.set_retries(5) %}
+{% do c1.healthcheck.set_start_period_sec(90) %}
+
+{% do c1.add_storage("/app/server/config", values.storage.config) %}
+{% do c1.add_storage("/app/server/data", values.storage.data) %}
+{% do c1.add_storage("/app/server/backups", values.storage.backups) %}
+
+{% if values.fodaris.mount_docker_socket %}
+  {% do c1.add_docker_socket() %}
+{% endif %}
+
+{% for store in values.storage.additional_storage %}
+  {% do c1.add_storage(store.mount_path, store) %}
+{% endfor %}
+
+{% do c1.add_port(values.network.web_port) %}
+{% do c1.add_port(values.network.agent_ingest_port) %}
+{% do c1.add_port(values.network.otel_ingest_port) %}
+
+{% do c1.environment.add_env("FODARIS_HOST", "0.0.0.0") %}
+{% do c1.environment.add_env("FODARIS_PORT", values.network.web_port.port_number) %}
+{% do c1.environment.add_env("FODARIS_INGEST_PORT", values.network.agent_ingest_port.port_number) %}
+{% do c1.environment.add_env("FODARIS_OTEL_PORT", values.network.otel_ingest_port.port_number) %}
+{% do c1.environment.add_env("FODARIS_CONFIG_DIR", "/app/server/config") %}
+{% do c1.environment.add_env("FODARIS_DATA_DIR", "/app/server/data") %}
+{% do c1.environment.add_env("FODARIS_SERVER_NAME", values.fodaris.server_name) %}
+{% do c1.environment.add_env("FODARIS_RETENTION_DAYS", values.fodaris.retention_days) %}
+
+{% do c1.environment.add_user_envs(values.fodaris.additional_envs) %}
+
+{% do c1.labels.add_labels(values.labels) %}
+{% do c1.resources.limits.set_cpus(values.resources.limits.cpus) %}
+{% do c1.resources.limits.set_memory(values.resources.limits.memory) %}
+
+{% do tpl.portals.add(values.network.web_port) %}
+
+{{ tpl.render() | tojson }}

--- a/ix-dev/community/fodaris/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/fodaris/templates/test_values/basic-values.yaml
@@ -1,0 +1,48 @@
+TZ: Etc/UTC
+
+fodaris:
+  server_name: fodaris-test
+  retention_days: 30
+  mount_docker_socket: false
+  additional_envs: []
+
+network:
+  web_port:
+    bind_mode: published
+    port_number: 8443
+  agent_ingest_port:
+    bind_mode: published
+    port_number: 24443
+  otel_ingest_port:
+    bind_mode: published
+    port_number: 24444
+
+ix_volumes:
+  config: /opt/tests/mnt/config
+  data: /opt/tests/mnt/data
+  backups: /opt/tests/mnt/backups
+
+storage:
+  config:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: config
+      create_host_path: true
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: data
+      create_host_path: true
+  backups:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: backups
+      create_host_path: true
+  additional_storage: []
+
+labels: []
+
+resources:
+  limits:
+    cpus: 2
+    memory: 2048


### PR DESCRIPTION
# App Addition

- [x] I have opened an [issue](https://github.com/truenas/apps/issues/5286) to discuss this app addition before submitting this pull request.

# AI

- [ ] Part or All of this PR was generated by an LLM.

## Description

Adds Fodaris to the community train.

Fodaris is a self-hosted monitoring and observability platform for homelabs and small businesses. One Docker container with PostgreSQL bundled in, monitoring servers, Docker containers, network devices over SNMP, websites with SSL expiry tracking, and databases (PostgreSQL, MySQL, MariaDB, Redis, MongoDB, MSSQL, Oracle, SQLite). Native lightweight agents for Linux, macOS, Windows and Docker push metrics over an encrypted channel. Free tier covers 5 endpoints, 5 websites, 5 databases and 5 applications.

## App Information

- **Website**: https://fodaris.co.uk
- **Documentation**: https://docs.fodaris.co.uk
- **Live demo**: https://demo.fodaris.co.uk
- **Docker Hub**: https://hub.docker.com/r/goodhallsolutions/fodaris
- **App Version**: 1.0.5 (image tag `goodhallsolutions/fodaris:1.0.5`, multi-arch amd64/arm64)

## Testing

Tested locally with:

- [x] basic-values.yaml

Template renders cleanly against `ix_lib` 2.3.4. Fodaris container starts, `/api/health` returns 200 after the 90s start_period, default login `admin/Fodaris2026` prompts for password change on first sign-in.

## Icons and Screenshots

Assets currently linked from https://fodaris.co.uk. Happy to swap to CDN URLs on request.

- Icon: https://fodaris.co.uk/images/icon.png
- Screenshots: dashboard, topology, alerts, uptime, databases, log viewer under https://fodaris.co.uk/images/screenshots/

## Special Notes

- **First-time setup**: web UI on port 8443, default credentials `admin` / `Fodaris2026`, forced password change on first sign-in.
- **Encryption key**: auto-generated on first boot, stored in the `data` volume. Users should back the `data` volume up regularly - restoring without the key means encrypted labels/credentials cannot be decrypted.
- **Three ports** (8443 web UI, 24443 Fodaris agent ingest, 24444 OTel ingest). Only 8443 is needed for a single-node install; the other two are for users deploying Fodaris agents on additional monitored hosts.
- **Docker socket mount** defaults to enabled (read-only) so Fodaris can monitor containers on the TrueNAS host. Users can disable in questions if they only want to monitor remote endpoints.
- **Host monitoring** (privileged + pid:host) intentionally omitted from this initial version - see linked issue for context. Can be added as an opt-in in a follow-up version.
- **Bundled PostgreSQL 17** inside the container - no external database or separate service required.

## Checklist

- [x] App runs successfully locally
- [x] Only modified files under `/ix-dev/community/fodaris/`
- [x] README.md included
- [x] questions.yaml has clear descriptions and follows structure of existing apps
- [ ] All automated CI checks pass (will confirm after PR opens and CI runs)
