### PR TITLE
feat(nextcloud): add optional background jobs worker container

### DIFF
--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -2,20 +2,21 @@ annotations:
   min_scale_version: 24.10.2.2
 app_version: 34.0.1
 capabilities:
-- description: Cron, Nextcloud, Nginx are able to change file ownership arbitrarily
+- description: Cron, Nextcloud, Nginx, Worker are able to change file ownership arbitrarily
   name: CHOWN
-- description: Cron, Nextcloud, Nginx are able to bypass file permission checks
+- description: Cron, Nextcloud, Nginx, Worker are able to bypass file permission checks
   name: DAC_OVERRIDE
-- description: Cron, Nextcloud, Nginx are able to bypass permission checks for file
-    operations
+- description: Cron, Nextcloud, Nginx, Worker are able to bypass permission checks
+    for file operations
   name: FOWNER
-- description: Cron, Nextcloud, Nginx are able to bind to privileged ports (< 1024)
+- description: Cron, Nextcloud, Nginx, Worker are able to bind to privileged ports
+    (< 1024)
   name: NET_BIND_SERVICE
-- description: Cron, Nextcloud, Nginx are able to use raw and packet sockets
+- description: Cron, Nextcloud, Nginx, Worker are able to use raw and packet sockets
   name: NET_RAW
-- description: Cron, Nextcloud, Nginx are able to change group ID of processes
+- description: Cron, Nextcloud, Nginx, Worker are able to change group ID of processes
   name: SETGID
-- description: Cron, Nextcloud, Nginx are able to change user ID of processes
+- description: Cron, Nextcloud, Nginx, Worker are able to change user ID of processes
   name: SETUID
 - description: Imaginary is able to modify process scheduling priority
   name: SYS_NICE
@@ -73,6 +74,11 @@ run_as_context:
   group_name: Host group is [apps]
   uid: 568
   user_name: Host user is [apps]
+- description: Container [worker] runs as root user and group.
+  gid: 0
+  group_name: Host group is [root]
+  uid: 0
+  user_name: Host user is [root]
 screenshots:
 - https://media.sys.truenas.net/apps/nextcloud/screenshots/screenshot1.png
 - https://media.sys.truenas.net/apps/nextcloud/screenshots/screenshot2.png
@@ -82,4 +88,4 @@ sources:
 - https://github.com/nextcloud/docker
 title: Nextcloud
 train: stable
-version: 2.3.45
+version: 2.3.46

--- a/ix-dev/stable/nextcloud/ix_values.yaml
+++ b/ix-dev/stable/nextcloud/ix_values.yaml
@@ -27,6 +27,7 @@ images:
 consts:
   nextcloud_container_name: nextcloud
   cron_container_name: cron
+  worker_container_name: worker
   perms_container_name: permissions
   redis_container_name: redis
   postgres_container_name: postgres

--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -233,6 +233,44 @@ questions:
                   show_if: [["enabled", "=", true]]
                   default: "*/5 * * * *"
                   required: true
+        - variable: worker
+          label: Background Jobs Worker
+          description: Run a dedicated container that processes background jobs.
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: Enabled
+                description: Enable the background jobs worker container.
+                schema:
+                  type: boolean
+                  default: false
+              - variable: processes
+                label: Worker Processes
+                description: The number of worker processes to run inside the container.
+                schema:
+                  type: int
+                  show_if: [["enabled", "=", true]]
+                  min: 1
+                  max: 8
+                  default: 1
+                  required: true
+              - variable: job_classes
+                label: Job Classes
+                description: |
+                  Limit the worker to specific background job classes.</br>
+                  Leave empty to process all background job classes.</br>
+                  Example - OC\TaskProcessing\SynchronousBackgroundJob
+                schema:
+                  type: list
+                  show_if: [["enabled", "=", true]]
+                  default: []
+                  items:
+                    - variable: job_class
+                      label: Job Class
+                      schema:
+                        type: string
+                        required: true
         - variable: additional_envs
           label: Additional Environment Variables
           schema:

--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -461,6 +461,8 @@ questions:
                                         description: imaginary
                                       - value: cron
                                         description: cron
+                                      - value: worker
+                                        description: worker
                                       - value: nginx
                                         description: nginx
                                       - value: postgres
@@ -959,6 +961,8 @@ questions:
                             description: imaginary
                           - value: cron
                             description: cron
+                          - value: worker
+                            description: worker
                           - value: nginx
                             description: nginx
                           - value: postgres

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -191,6 +191,38 @@
   {% do cron_container.environment.add_user_envs(values.nextcloud.additional_envs) %}
 {% endif %}
 
+{% if values.nextcloud.worker.enabled %}
+  {% set worker_container = tpl.add_container(values.consts.worker_container_name, "image") %}
+  {% do worker_container.add_network(nc_net) %}
+  {% do worker_container.build_image(nc_custom_image.x) %}
+  {% do worker_container.set_user(0,0) %}
+  {% do worker_container.add_caps(nc_caps) %}
+  {% do worker_container.healthcheck.set_test("pidof", {"process": "php"}) %}
+  {% do worker_container.set_entrypoint(["/bin/sh", "-c"]) %}
+  {% set worker_classes = namespace(x="") %}
+  {% for cls in values.nextcloud.worker.job_classes %}
+    {% do tpl.funcs.disallow_chars(cls, ["'", '"', " ", ";", "&", "|", "$", "`"], "worker job_class") %}
+    {% set worker_classes.x = "%s '%s'"|format(worker_classes.x, cls) %}
+  {% endfor %}
+  {% set worker_cmd = [
+    "echo 'Starting %d Nextcloud background job worker process(es)...'"|format(values.nextcloud.worker.processes),
+    "for i in $(seq 1 %d); do occ background-job:worker%s & done"|format(values.nextcloud.worker.processes, worker_classes.x),
+    "wait"
+  ]|join("\n") %}
+  {% do worker_container.set_command([worker_cmd]) %}
+  {% do worker_container.depends.add_dependency(values.consts.nextcloud_container_name, "service_healthy") %}
+  {% for c in nc_confs %}
+    {% do worker_container.configs.add(c[0], c[1], c[2], c[3]) %}
+  {% endfor %}
+  {% for e in nc_env.x %}
+    {% do worker_container.environment.add_env(e[0], e[1]) %}
+  {% endfor %}
+  {% for s in nc_storage.x %}
+    {% do worker_container.add_storage(s[0], s[1]) %}
+  {% endfor %}
+  {% do worker_container.environment.add_user_envs(values.nextcloud.additional_envs) %}
+{% endif %}
+
 {% if values.nextcloud.imaginary.enabled %}
   {% set imaginary_container = tpl.add_container(values.consts.imaginary_container_name, "imaginary_image") %}
   {% do imaginary_container.add_network(nc_net) %}

--- a/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
@@ -30,6 +30,8 @@ nextcloud:
   cron:
     enabled: true
     schedule: "*/5 * * * *"
+  worker:
+    enabled: false
   additional_envs: []
 network:
   web_port:

--- a/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
@@ -27,6 +27,8 @@ nextcloud:
   cron:
     enabled: true
     schedule: "*/5 * * * *"
+  worker:
+    enabled: false
   additional_envs: []
 network:
   web_port:

--- a/ix-dev/stable/nextcloud/templates/test_values/no-cron-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/no-cron-values.yaml
@@ -29,6 +29,8 @@ nextcloud:
   cron:
     enabled: true
     schedule: "*/5 * * * *"
+  worker:
+    enabled: false
   additional_envs: []
 network:
   web_port:

--- a/ix-dev/stable/nextcloud/templates/test_values/worker-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/worker-values.yaml
@@ -10,15 +10,11 @@ nextcloud:
   apt_packages:
     - ffmpeg
     - smbclient
-    - ocrmypdf
   tesseract_languages:
     - eng
-    - chi-sim
-  imaginary:
-    enabled: true
   host: localhost:8080
   data_dir_path: /var/www/html/data
-  redis_password: YFtYK25GBfr!UsX5mu2Dnd5L5W
+  redis_password: password
   db_user: nextcloud
   db_password: password
   php_upload_limit: 3
@@ -26,11 +22,16 @@ nextcloud:
   op_cache_interned_strings_buffer: 32
   op_cache_memory_consumption: 128
   max_execution_time: 30
+  imaginary:
+    enabled: false
   cron:
     enabled: true
     schedule: "*/5 * * * *"
   worker:
-    enabled: false
+    enabled: true
+    processes: 2
+    job_classes:
+      - OC\TaskProcessing\SynchronousBackgroundJob
   additional_envs: []
 network:
   web_port:


### PR DESCRIPTION
## Summary

Adds an opt-in **Background Jobs Worker** container to the Nextcloud app (disabled by default). It runs one or more `occ background-job:worker` processes in a dedicated container, which the Nextcloud documentation recommends for heavy background workloads — most notably AI task processing via `OC\TaskProcessing\SynchronousBackgroundJob`.

## Changes

- **questions.yaml**: new `nextcloud.worker` section with `enabled` (default `false`), `processes` (1–8) and an optional `job_classes` list to dedicate the worker to specific background job classes (empty = all classes).
- **templates/docker-compose.yaml**: new `worker` container modeled on the existing cron container — same custom-built image (apt/PECL packages match the main container), same env/configs/storage. It depends on the main container being healthy, spawns the configured number of `occ background-job:worker` processes and is health-checked via `pidof php`. Job class values are validated with `disallow_chars` to keep shell quoting safe.
- **ix_values.yaml**: `worker_container_name` const.
- **app.yaml**: version `2.3.45` → `2.3.46`, capabilities and `run_as_context` updated to include the worker container.
- **test_values**: `worker.enabled: false` added to existing scenarios, plus a new `worker-values.yaml` scenario (2 processes, one job class).

## Testing

- Rendered all five test scenarios with `ghcr.io/truenas/apps_validation:latest` (`catalog_templating.render.render_templates`) — all succeed.
- All rendered compose files pass `docker compose config` validation.
- The `worker` service only appears when `worker.enabled: true`; the generated worker command passes `sh -n`.