### PR TITLE
feat(nextcloud): add ability to install custom PHP extensions

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -11,6 +11,7 @@ words:
   - altran
   - anki
   - anythingllm
+  - apcu
   - apikey
   - arcadiatechnology
   - archisteamfarm
@@ -30,6 +31,7 @@ words:
   - bambuddy
   - baserow
   - bazarr
+  - bcmath
   - bearbinary
   - bentopdf
   - beszel

--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -82,4 +82,4 @@ sources:
 - https://github.com/nextcloud/docker
 title: Nextcloud
 train: stable
-version: 2.3.45
+version: 2.3.46

--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -104,6 +104,44 @@ questions:
                   # eg deu_frak
                   max_length: 8
                   required: true
+        - variable: php_extensions
+          label: Custom PHP Extensions
+          description: |
+            Additional PHP extensions to install into the Nextcloud image.</br>
+            - PECL: The extension is installed with [pecl install] and enabled afterwards.</br>
+            - Core: The extension is compiled with [docker-php-ext-install].</br>
+            Extensions that are already included in the image are skipped.</br>
+            Note: Extensions that require additional system libraries to build may fail to install.</br>
+            Typing a wrong extension name will block the container from starting.
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: php_extension
+                label: PHP Extension
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: installer
+                      label: Installer
+                      description: How the extension is installed.
+                      schema:
+                        type: string
+                        default: pecl
+                        required: true
+                        enum:
+                          - value: pecl
+                            description: PECL extension (e.g. apcu, memcached)
+                          - value: core
+                            description: Core PHP extension (e.g. bcmath, gmp)
+                    - variable: name
+                      label: Name
+                      description: The name of the PHP extension.
+                      schema:
+                        type: string
+                        min_length: 2
+                        max_length: 64
+                        required: true
         - variable: imaginary
           label: Imaginary
           description: |

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -41,6 +41,23 @@
   {% endfor %}
 {% endif %}
 
+{# Custom PHP Extensions #}
+{% set php_ext_allowed_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-" %}
+{% for ext in values.nextcloud.php_extensions %}
+  {% for char in ext.name if char not in php_ext_allowed_chars %}
+    {% do tpl.funcs.fail("PHP extension name [%s] contains an invalid character [%s]"|format(ext.name, char)) %}
+  {% endfor %}
+  {# Skip extensions that are already loaded (e.g. apcu, bcmath ship with the image), pecl install fails on them #}
+  {% if ext.installer == "pecl" %}
+    {% do nc_custom_image.x.append("RUN php -m | grep -qix %s || pecl install %s || { echo 'Failed to install [%s]. Exiting...'; exit 1; }"|format(ext.name, ext.name, ext.name)) %}
+    {% do nc_custom_image.x.append("RUN php -m | grep -qix %s || docker-php-ext-enable %s || { echo 'Failed to enable [%s]. Exiting...'; exit 1; }"|format(ext.name, ext.name, ext.name)) %}
+  {% elif ext.installer == "core" %}
+    {% do nc_custom_image.x.append("RUN php -m | grep -qix %s || docker-php-ext-install -j\"$(nproc)\" %s || { echo 'Failed to install [%s]. Exiting...'; exit 1; }"|format(ext.name, ext.name, ext.name)) %}
+  {% else %}
+    {% do tpl.funcs.fail("Unknown PHP extension installer [%s]"|format(ext.installer)) %}
+  {% endif %}
+{% endfor %}
+
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
 {% set nc_container = tpl.add_container(values.consts.nextcloud_container_name, "image") %}
 {% do nc_container.add_network(nc_net) %}

--- a/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
@@ -15,6 +15,7 @@ nextcloud:
   tesseract_languages:
     - eng
     - chi-sim
+  php_extensions: []
   host: "[aaaa:bbbb:ffff:cccc::dddd]:8080"
   data_dir_path: /var/www/html/data
   redis_password: YFtYK25GBfr!UsX5mu2Dnd5L5W

--- a/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
@@ -12,6 +12,7 @@ nextcloud:
     - smbclient
   tesseract_languages:
     - eng
+  php_extensions: []
   host: nextcloud.example.com:12345
   data_dir_path: /var/www/html/data
   redis_password: password

--- a/ix-dev/stable/nextcloud/templates/test_values/imaginary-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/imaginary-values.yaml
@@ -14,6 +14,7 @@ nextcloud:
   tesseract_languages:
     - eng
     - chi-sim
+  php_extensions: []
   imaginary:
     enabled: true
   host: localhost:8080

--- a/ix-dev/stable/nextcloud/templates/test_values/php-extensions-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/php-extensions-values.yaml
@@ -10,11 +10,16 @@ nextcloud:
   apt_packages:
     - ffmpeg
     - smbclient
-    - ocrmypdf
   tesseract_languages:
     - eng
-    - chi-sim
-  php_extensions: []
+  php_extensions:
+    # apcu ships with the image, exercises the already-installed skip path
+    - installer: pecl
+      name: apcu
+    - installer: pecl
+      name: ds
+    - installer: core
+      name: calendar
   host: localhost:8080
   data_dir_path: /var/www/html/data
   redis_password: password


### PR DESCRIPTION
## Summary

Adds a **Custom PHP Extensions** option to the Nextcloud app so users can install additional PHP extensions into the custom-built image, without having to wait for them to be added to the curated `apt_packages`/`consts.packages` list.

## Changes

- **questions.yaml**: new `nextcloud.php_extensions` list. Each entry has a `name` and an `installer` type:
  - `pecl` — installed with `pecl install` and enabled with `docker-php-ext-enable` (e.g. `ds`, `xdebug`)
  - `core` — compiled with `docker-php-ext-install -j"$(nproc)"` (e.g. `calendar`, `sockets`)
- **templates/docker-compose.yaml**: extensions are appended as `RUN` steps to the same inline Dockerfile that already handles `apt_packages`, so they apply to the Nextcloud and cron containers alike. Two safeguards:
  - Every step is guarded with `php -m | grep -qix <name> ||` so extensions already shipped in the image (`apcu`, `bcmath`, `memcached`, `redis`, `imagick`, …) are skipped — `pecl install` exits non-zero for already-installed extensions and would otherwise break the build.
  - Extension names are validated at render time against a strict character whitelist (`a-z A-Z 0-9 . _ -`); anything else fails the render, so user input cannot break out of the generated Dockerfile.
- **test_values**: `php_extensions: []` added to existing scenarios, plus a new `php-extensions-values.yaml` scenario covering all three paths: `apcu` (pecl, preinstalled → skipped), `ds` (pecl, compiled), `calendar` (core, compiled).
- `cspell.config.yaml`: added `apcu`, `bcmath`.
- App version bumped to 2.3.46.

## Testing

- All five test scenarios render successfully with `ghcr.io/truenas/apps_validation:latest` and pass `docker compose config` validation.
- The generated Dockerfile layers were built for real against `nextcloud:34.0.1`: the build succeeds, `apcu` is skipped, `ds` and `calendar` compile, and all three extensions are loaded in the resulting image.
- The injection guard was verified: a name like `apcu; rm -rf /` fails the render with `contains an invalid character [;]`.