### PR TITLE
feat(nextcloud): add optional Client Push (notify_push) support

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -330,6 +330,7 @@ words:
   - nocopy
   - noip
   - notifiarr
+  - notifypush
   - nowdns
   - npmplus
   - ntfy
@@ -569,6 +570,7 @@ words:
   - wiki-js
   - wizarr
   - woodpeckerci
+  - wstunnel
   - wtfismyip
   - wyze
   - xattr

--- a/ix-dev/stable/nextcloud/app.yaml
+++ b/ix-dev/stable/nextcloud/app.yaml
@@ -63,6 +63,11 @@ run_as_context:
   group_name: Host group is [root]
   uid: 0
   user_name: Host user is [root]
+- description: Container [notifypush] can run as any non-root user and group.
+  gid: 568
+  group_name: Host group is [apps]
+  uid: 568
+  user_name: Host user is [apps]
 - description: Container [postgres] runs as non-root user and group.
   gid: 999
   group_name: Host group is [docker]
@@ -82,4 +87,4 @@ sources:
 - https://github.com/nextcloud/docker
 title: Nextcloud
 train: stable
-version: 2.3.45
+version: 2.3.46

--- a/ix-dev/stable/nextcloud/ix_values.yaml
+++ b/ix-dev/stable/nextcloud/ix_values.yaml
@@ -33,6 +33,8 @@ consts:
   nginx_container_name: nginx
   imaginary_container_name: imaginary
   imaginary_port: 9000
+  notifypush_container_name: notifypush
+  notifypush_port: 7867
   db_name: nextcloud
   ssl_key_path: /etc/nginx-certs/private.key
   ssl_cert_path: /etc/nginx-certs/public.crt

--- a/ix-dev/stable/nextcloud/questions.yaml
+++ b/ix-dev/stable/nextcloud/questions.yaml
@@ -118,6 +118,23 @@ questions:
                 schema:
                   type: boolean
                   default: false
+        - variable: notify_push
+          label: Client Push (notify_push)
+          description: |
+            Runs the [notify_push] push daemon and automatically installs the notify_push app from the app store.</br>
+            Push notifications reduce the load caused by desktop and mobile clients polling for changes.</br>
+            Please see https://github.com/nextcloud/notify_push for more information.</br>
+            Requires the [Host] field to be set and clients must be able to reach that host.</br>
+            The push endpoint is served under [/push] on the Nextcloud web port.
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: Enabled
+                description: Enable Client Push
+                schema:
+                  type: boolean
+                  default: false
         - variable: host
           label: Host
           description: |
@@ -421,6 +438,8 @@ questions:
                                         description: nextcloud
                                       - value: imaginary
                                         description: imaginary
+                                      - value: notifypush
+                                        description: notifypush
                                       - value: cron
                                         description: cron
                                       - value: nginx
@@ -919,6 +938,8 @@ questions:
                             description: nextcloud
                           - value: imaginary
                             description: imaginary
+                          - value: notifypush
+                            description: notifypush
                           - value: cron
                             description: cron
                           - value: nginx

--- a/ix-dev/stable/nextcloud/templates/docker-compose.yaml
+++ b/ix-dev/stable/nextcloud/templates/docker-compose.yaml
@@ -1,5 +1,5 @@
-{% from "macros/nc.jinja.sh" import occ, hosts_update, trusted_domains_update, imaginary_url %}
-{% from "macros/nc.jinja.conf" import opcache, php, limit_request_body, use_x_real_ip_in_logs, nginx_conf %}
+{% from "macros/nc.jinja.sh" import occ, hosts_update, trusted_domains_update, imaginary_url, notify_push_setup %}
+{% from "macros/nc.jinja.conf" import opcache, php, limit_request_body, use_x_real_ip_in_logs, nginx_conf, notify_push_apache_conf %}
 
 {% set tpl = ix_lib.base.render.Render(values) %}
 
@@ -39,6 +39,14 @@
       {% do nc_custom_image.x.append("RUN apt install -y --no-install-recommends %s || { echo 'Failed to install [%s]. Exiting...'; exit 1; }"|format(lang_pack, lang_pack)) %}
     {% endfor %}
   {% endfor %}
+{% endif %}
+
+{% if values.nextcloud.notify_push.enabled %}
+  {% if not values.nextcloud.host %}
+    {% do tpl.funcs.fail("Client Push (notify_push) requires the [Host] field to be set, so that clients can reach the push endpoint.") %}
+  {% endif %}
+  {# Apache proxies [/push] to the notify_push daemon #}
+  {% do nc_custom_image.x.append("RUN a2enmod proxy proxy_http proxy_wstunnel || { echo 'Failed to enable apache proxy modules. Exiting...'; exit 1; }") %}
 {% endif %}
 
 {% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
@@ -162,6 +170,19 @@
     "/docker-entrypoint-hooks.d/before-starting/ix-imaginary-url.sh", "0755",
   ) %}
 {% endif %}
+{% if values.nextcloud.notify_push.enabled %}
+  {% set push_url = "%s://%s/push"|format("https" if values.network.certificate_id else "http", host.x) %}
+  {% do nc_container.configs.add(
+    "ix-notify-push-setup.sh",
+    notify_push_setup(push_url),
+    "/docker-entrypoint-hooks.d/before-starting/ix-notify-push-setup.sh", "0755",
+  ) %}
+  {% do nc_container.configs.add(
+    "notify-push.conf",
+    notify_push_apache_conf(values.consts.notifypush_container_name, values.consts.notifypush_port),
+    "/etc/apache2/conf-enabled/notify-push.conf", "",
+  ) %}
+{% endif %}
 
 {% do nc_container.environment.add_user_envs(values.nextcloud.additional_envs) %}
 
@@ -197,6 +218,36 @@
   {% do imaginary_container.add_caps(["SYS_NICE"]) %}
   {% do imaginary_container.set_user(568, 568) %}
   {% do imaginary_container.healthcheck.set_test("wget", {"port": 9000, "path": "/health"}) %}
+{% endif %}
+
+{% if values.nextcloud.notify_push.enabled %}
+  {# Runs the push daemon binary that ships with the notify_push app (installed by the nextcloud container), #}
+  {# so the daemon version always matches the app version #}
+  {% set notifypush_container = tpl.add_container(values.consts.notifypush_container_name, "image") %}
+  {% do notifypush_container.add_network(nc_net) %}
+  {% do notifypush_container.set_user(568, 568) %}
+  {# The daemon has no dedicated health endpoint, check that it accepts TCP connections #}
+  {% do notifypush_container.healthcheck.set_test("tcp", {"port": values.consts.notifypush_port}) %}
+  {% do notifypush_container.set_entrypoint(["/bin/sh", "-c"]) %}
+  {% set notifypush_cmd = [
+    'BIN="/var/www/html/custom_apps/notify_push/bin/$(uname -m)/notify_push"',
+    'echo "Waiting for the notify_push app to be installed (done automatically by the Nextcloud container)..."',
+    'until [ -f "$BIN" ]; do sleep 5; done',
+    'exec "$BIN"',
+  ]|join("\n") %}
+  {% do notifypush_container.set_command([notifypush_cmd]) %}
+  {% do notifypush_container.depends.add_dependency(values.consts.nextcloud_container_name, "service_healthy") %}
+  {% do notifypush_container.environment.add_env("PORT", values.consts.notifypush_port) %}
+  {% do notifypush_container.environment.add_env("BIND", "0.0.0.0") %}
+  {% do notifypush_container.environment.add_env("NEXTCLOUD_URL", "http://%s"|format(values.consts.nextcloud_container_name)) %}
+  {% do notifypush_container.environment.add_env("DATABASE_URL", "postgres://%s:%s@%s/%s"|format(
+    values.nextcloud.db_user|urlencode, values.nextcloud.db_password|urlencode, postgres.get_url("host_port"), values.consts.db_name
+  )) %}
+  {% do notifypush_container.environment.add_env("DATABASE_PREFIX", "oc_") %}
+  {% do notifypush_container.environment.add_env("REDIS_URL", "redis://:%s@%s:6379"|format(
+    values.nextcloud.redis_password|urlencode, values.consts.redis_container_name
+  )) %}
+  {% do notifypush_container.add_storage("/var/www/html", values.storage.html) %}
 {% endif %}
 
 {% if values.network.certificate_id %}

--- a/ix-dev/stable/nextcloud/templates/macros/nc.jinja.conf
+++ b/ix-dev/stable/nextcloud/templates/macros/nc.jinja.conf
@@ -7,6 +7,12 @@ opcache.memory_consumption={{ values.nextcloud.op_cache_memory_consumption }}
 max_execution_time={{ values.nextcloud.max_execution_time }}
 {%- endmacro -%}
 
+{% macro notify_push_apache_conf(host, port) -%}
+ProxyPass /push/ws ws://{{ host }}:{{ port }}/ws
+ProxyPass /push/ http://{{ host }}:{{ port }}/
+ProxyPassReverse /push/ http://{{ host }}:{{ port }}/
+{%- endmacro -%}
+
 {% macro limit_request_body(values) -%}
 {%- set bytes_gb = 1024 * 1024 * 1024 -%}
 LimitRequestBody {{ values.nextcloud.php_upload_limit * bytes_gb }}

--- a/ix-dev/stable/nextcloud/templates/macros/nc.jinja.sh
+++ b/ix-dev/stable/nextcloud/templates/macros/nc.jinja.sh
@@ -83,3 +83,13 @@ set_list "trusted_domains" "${NEXTCLOUD_TRUSTED_DOMAINS}" || { echo "Failed to u
 echo '## Configuring Imaginary...'
 occ config:system:set preview_imaginary_url --value={{ "http://%s:%d"|format(host, port) }}
 {%- endmacro -%}
+
+{% macro notify_push_setup(url) -%}
+#!/bin/bash
+echo '## Configuring notify_push...'
+if ! occ app:enable notify_push; then
+  echo 'The notify_push app is not installed yet. Installing it from the app store...'
+  occ app:install notify_push || { echo 'Failed to install the notify_push app from the app store. Continuing without it...'; exit 0; }
+fi
+occ config:app:set notify_push base_endpoint --value={{ url }} || { echo 'Failed to set the notify_push base_endpoint. Continuing...'; exit 0; }
+{%- endmacro -%}

--- a/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/basic-values.yaml
@@ -27,6 +27,8 @@ nextcloud:
   max_execution_time: 30
   imaginary:
     enabled: false
+  notify_push:
+    enabled: false
   cron:
     enabled: true
     schedule: "*/5 * * * *"

--- a/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/https-values.yaml
@@ -24,6 +24,8 @@ nextcloud:
   max_execution_time: 30
   imaginary:
     enabled: false
+  notify_push:
+    enabled: false
   cron:
     enabled: true
     schedule: "*/5 * * * *"

--- a/ix-dev/stable/nextcloud/templates/test_values/imaginary-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/imaginary-values.yaml
@@ -16,6 +16,8 @@ nextcloud:
     - chi-sim
   imaginary:
     enabled: true
+  notify_push:
+    enabled: false
   host: localhost:8080
   data_dir_path: /var/www/html/data
   redis_password: YFtYK25GBfr!UsX5mu2Dnd5L5W

--- a/ix-dev/stable/nextcloud/templates/test_values/notify-push-values.yaml
+++ b/ix-dev/stable/nextcloud/templates/test_values/notify-push-values.yaml
@@ -10,10 +10,8 @@ nextcloud:
   apt_packages:
     - ffmpeg
     - smbclient
-    - ocrmypdf
   tesseract_languages:
     - eng
-    - chi-sim
   host: localhost:8080
   data_dir_path: /var/www/html/data
   redis_password: password
@@ -27,7 +25,7 @@ nextcloud:
   imaginary:
     enabled: false
   notify_push:
-    enabled: false
+    enabled: true
   cron:
     enabled: true
     schedule: "*/5 * * * *"


### PR DESCRIPTION
## Summary

Adds an opt-in **Client Push (notify_push)** integration to the Nextcloud app. notify_push replaces the constant polling of desktop/mobile clients with server push notifications, significantly reducing server load — one of the most requested Nextcloud performance features. Enabling the toggle gives a fully working push setup with no manual `occ` commands or sidecar containers.

## Design

- **`notifypush` container** — reuses the existing `nextcloud` image (unbuilt) and runs the push daemon binary that ships **inside the notify_push app** on the shared html volume. This guarantees the daemon version always matches the installed app version (the same approach Nextcloud AIO uses). The entrypoint waits until the app is installed, then `exec`s the binary.
- **Automatic app setup** — a `before-starting` hook on the nextcloud container runs `occ app:enable notify_push || occ app:install notify_push` and sets `base_endpoint` to `http(s)://<host>/push` (scheme follows the certificate setting). All failures are non-fatal so Nextcloud always starts even if the app store is unreachable.
- **`/push` route via Apache** — `proxy`, `proxy_http` and `proxy_wstunnel` are enabled in the image build (only when the feature is on) and a conf proxies `/push/ws` (websocket) and `/push/` to the daemon. This works identically in plain-HTTP mode and behind the app's nginx/HTTPS container, with no additional published ports.
- **Least privilege** — the daemon runs as `568:568` (the release binaries are world-executable), is configured purely via environment variables (`DATABASE_URL`/`REDIS_URL` with URL-encoded credentials, `NEXTCLOUD_URL`, `PORT`), and needs no added capabilities.
- Healthcheck is a TCP-accept probe on port 7867 — the daemon has no dedicated health endpoint (`/test/cookie` returns 400 unless a test cookie is staged).
- Requires the `Host` field to be set (validated at render time), since clients must be able to reach the push endpoint.

## Testing

- All six test scenarios render with `ghcr.io/truenas/apps_validation:latest` and pass `docker compose config`; new `notify-push-values.yaml` scenario included.
- **Full local smoke deployment** of the rendered compose: the hook installed notify_push 1.3.3 from the app store, the daemon started as uid 568 and connected to Redis (`occ notify_push:self-test`: redis ✓), `/push` was reachable through Apache (websocket module path verified), and the container reported **healthy**. The self-test's remaining warnings (plain HTTP, localhost URL) are artifacts of the test values, not the implementation.
- The smoke test caught and fixed a healthcheck bug (`/test/cookie` → TCP probe) before CI.
- Container enums in the labels/networks sections, `run_as_context`, and the version bump are included.