### PR TITLE
Fix repo link for Actual Budget

### DIFF
--- a/trains/community/actual-budget/1.4.13/app.yaml
+++ b/trains/community/actual-budget/1.4.13/app.yaml
@@ -33,7 +33,7 @@ screenshots:
 - https://media.sys.truenas.net/apps/actual-budget/screenshots/screenshot3.png
 sources:
 - https://apps.truenas.com/catalog/actual-budget_community/
-- https://github.com/actualbudget/actual-server
+- https://github.com/actualbudget/actual
 - https://hub.docker.com/r/actualbudget/actual-server
 title: Actual Budget
 train: community


### PR DESCRIPTION
Repo for Actual Budget moved to https://github.com/actualbudget/actual some time ago so the link given was to an archived repository.

