### PR TITLE
Update AE NetScope to 0.1.6-alpha.1

### DIFF
--- a/ix-dev/community/ae-netscope/app.yaml
+++ b/ix-dev/community/ae-netscope/app.yaml
@@ -1,4 +1,4 @@
-app_version: 0.1.5-alpha
+app_version: 0.1.6-alpha
 capabilities: []
 categories:
 - networking

--- a/ix-dev/community/ae-netscope/app.yaml
+++ b/ix-dev/community/ae-netscope/app.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/WhiteAssassins/AE-NetScope
 title: AE NetScope
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/ae-netscope/app.yaml
+++ b/ix-dev/community/ae-netscope/app.yaml
@@ -1,4 +1,4 @@
-app_version: 0.1.6-alpha
+app_version: 0.1.6-alpha.1
 capabilities: []
 categories:
 - networking
@@ -44,4 +44,4 @@ sources:
 - https://github.com/WhiteAssassins/AE-NetScope
 title: AE NetScope
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/ae-netscope/ix_values.yaml
+++ b/ix-dev/community/ae-netscope/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/whiteassassins/ae-netscope
-    tag: v0.1.5-alpha
+    tag: v0.1.6-alpha
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2

--- a/ix-dev/community/ae-netscope/ix_values.yaml
+++ b/ix-dev/community/ae-netscope/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/whiteassassins/ae-netscope
-    tag: v0.1.6-alpha
+    tag: v0.1.6-alpha.1
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
## Changes

Updated AE NetScope to 0.1.6-alpha.1.

This release fixes startup migrations against PostgreSQL 18 by publishing an AE NetScope image with PostgreSQL client 18, so pre-migration pg_dump backups no longer fail with a server/client version mismatch.

## Files changed

- ix-dev/community/ae-netscope/app.yaml
- ix-dev/community/ae-netscope/ix_values.yaml