### PR TITLE
feat: add MoviePilot-v2 application

### DIFF
--- a/ix-dev/community/moviepilot-v2/README.md
+++ b/ix-dev/community/moviepilot-v2/README.md
@@ -1,0 +1,3 @@
+# MoviePilot-v2
+
+[MoviePilot-v2](https://github.com/jxxghp/MoviePilot) is a media management tool that automatically downloads movies and TV shows.

--- a/ix-dev/community/moviepilot-v2/app.yaml
+++ b/ix-dev/community/moviepilot-v2/app.yaml
@@ -1,0 +1,49 @@
+annotations:
+  min_scale_version: 24.10.2.2
+app_version: latest
+capabilities: []
+categories:
+- media
+changelog_url: https://github.com/jxxghp/MoviePilot
+date_added: '2026-07-10'
+description: MoviePilot-v2 is a media management tool for automatically downloading movies and TV shows.
+home: https://github.com/jxxghp/MoviePilot
+host_mounts:
+- path: /var/run/docker.sock
+  type: socket
+icon: https://wiki.movie-pilot.org/assets/logo.svg
+keywords:
+- media
+- movies
+- tvshows
+- automation
+lib_version: 2.3.8
+lib_version_hash: ""
+maintainers:
+- email: dev@truenas.com
+  name: truenas
+  url: https://www.truenas.com/
+name: moviepilot-v2
+run_as_context:
+- description: Container [moviepilot-v2] runs as root user for Docker socket access.
+  gid: 0
+  group_name: root
+  uid: 0
+  user_name: root
+- description: Container [postgres] runs as non-root user and group.
+  gid: 999
+  group_name: Host group is [docker]
+  uid: 999
+  user_name: Host user is [netdata]
+- description: Container [redis] can run as any non-root user and group.
+  gid: 568
+  group_name: Host group is [apps]
+  uid: 568
+  user_name: Host user is [apps]
+screenshots: []
+sources:
+- https://github.com/jxxghp/MoviePilot
+- https://hub.docker.com/r/jxxghp/moviepilot-v2
+title: MoviePilot-v2
+train: community
+version: 1.0.0

--- a/ix-dev/community/moviepilot-v2/ix_values.yaml
+++ b/ix-dev/community/moviepilot-v2/ix_values.yaml
@@ -1,0 +1,24 @@
+images:
+  image:
+    repository: jxxghp/moviepilot-v2
+    tag: latest
+  container_utils_image:
+    repository: ixsystems/container-utils
+    tag: 1.0.2
+  postgres_image:
+    repository: postgres
+    tag: 18.4-trixie
+  postgres_upgrade_image:
+    repository: ixsystems/postgres-upgrade
+    tag: 1.2.11
+  redis_image:
+    repository: redis
+    tag: 7.4.1
+
+consts:
+  app_container_name: moviepilot-v2
+  perms_container_name: permissions
+  postgres_container_name: postgres
+  redis_container_name: redis
+  db_user: moviepilot
+  db_name: moviepilot

--- a/ix-dev/community/moviepilot-v2/questions.yaml
+++ b/ix-dev/community/moviepilot-v2/questions.yaml
@@ -1,0 +1,872 @@
+groups:
+  - name: MoviePilot Configuration
+    description: Configure MoviePilot settings
+  - name: User and Group Configuration
+    description: Configure User and Group for MoviePilot
+  - name: Network Configuration
+    description: Configure Network for MoviePilot
+  - name: Storage Configuration
+    description: Configure Storage for MoviePilot
+  - name: Labels Configuration
+    description: Configure Labels for MoviePilot
+  - name: Resources Configuration
+    description: Configure Resources for MoviePilot
+
+questions:
+  - variable: TZ
+    group: MoviePilot Configuration
+    label: Timezone
+    schema:
+      type: string
+      default: Asia/Shanghai
+      required: true
+      $ref:
+        - definitions/timezone
+
+  - variable: moviepilot
+    label: ""
+    group: MoviePilot Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: superuser
+          label: Superuser Username
+          description: The admin username for MoviePilot
+          schema:
+            type: string
+            default: admin
+            required: true
+        - variable: superuser_password
+          label: Superuser Password
+          description: The admin password for MoviePilot
+          schema:
+            type: string
+            default: ""
+            required: true
+            private: true
+        - variable: db_password
+          label: Database Password
+          description: Password for the PostgreSQL database
+          schema:
+            type: string
+            default: ""
+            required: true
+            private: true
+        - variable: redis_password
+          label: Redis Password
+          description: Password for Redis cache
+          schema:
+            type: string
+            default: ""
+            required: true
+            private: true
+        - variable: additional_envs
+          label: Additional Environment Variables
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: env
+                label: Environment Variable
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: Name
+                      schema:
+                        type: string
+                        required: true
+                    - variable: value
+                      label: Value
+                      schema:
+                        type: string
+
+  - variable: run_as
+    label: ""
+    group: User and Group Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: user
+          label: User ID
+          description: The user id that MoviePilot runs as. Must be 0 for Docker socket access.
+          schema:
+            type: int
+            min: 0
+            max: 65535
+            default: 568
+            required: true
+        - variable: group
+          label: Group ID
+          description: The group id that MoviePilot runs as. Must be 0 for Docker socket access.
+          schema:
+            type: int
+            min: 0
+            max: 65535
+            default: 568
+            required: true
+
+  - variable: network
+    label: ""
+    group: Network Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: web_port
+          label: WebUI Port (NGINX)
+          description: Port for the web interface (NGINX_PORT)
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 33000
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if: [["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
+        - variable: api_port
+          label: API Port
+          description: Port for the API (PORT)
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port Bind Mode
+                description: |
+                  The port bind mode.</br>
+                  - Publish: The port will be published on the host for external access.</br>
+                  - Expose: The port will be exposed for inter-container communication.</br>
+                  - None: The port will not be exposed or published.</br>
+                  Note: If the Dockerfile defines an EXPOSE directive,
+                  the port will still be exposed for inter-container communication regardless of this setting.
+                schema:
+                  type: string
+                  default: "published"
+                  enum:
+                    - value: "published"
+                      description: Publish port on the host for external access
+                    - value: "exposed"
+                      description: Expose port for inter-container communication
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port Number
+                schema:
+                  type: int
+                  default: 33001
+                  min: 1
+                  max: 65535
+                  required: true
+              - variable: host_ips
+                label: Host IPs
+                description: IPs on the host to bind this port
+                schema:
+                  type: list
+                  show_if: [["bind_mode", "=", "published"]]
+                  default: []
+                  items:
+                    - variable: host_ip
+                      label: Host IP
+                      schema:
+                        type: string
+                        required: true
+                        $ref:
+                          - definitions/node_bind_ip
+        - variable: networks
+          label: Networks
+          description: The docker networks to join
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: network
+                label: Network
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: name
+                      label: Name
+                      description: |
+                        The name of the network to join.</br>
+                        The network must already exist.
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+                    - variable: containers
+                      label: Containers
+                      description: The containers to add to this network.
+                      schema:
+                        type: list
+                        items:
+                          - variable: container
+                            label: Container
+                            schema:
+                              type: dict
+                              attrs:
+                                - variable: name
+                                  label: Container Name
+                                  schema:
+                                    type: string
+                                    required: true
+                                    enum:
+                                      - value: moviepilot-v2
+                                        description: moviepilot-v2
+                                      - value: postgres
+                                        description: postgres
+                                      - value: redis
+                                        description: redis
+
+  - variable: storage
+    label: ""
+    group: Storage Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: media
+          label: Media Storage
+          description: Stores downloaded media files
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "media"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: config
+          label: Config Storage
+          description: Stores application configuration
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "config"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: core_browser
+          label: Core Browser Storage
+          description: Stores the internal browser data (.cloakbrowser)
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "core_browser"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: postgres_data
+          label: Postgres Data Storage
+          description: Stores PostgreSQL database data
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "postgres_data"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+                    - variable: auto_permissions
+                      label: Automatic Permissions
+                      description: |
+                        Automatically set permissions for the host path.
+                        Enabling this, will check the top level directory,</br>
+                        If it finds incorrect permissions, it will `chown` the
+                        host path to the user and group required for the
+                        postgres container.
+                      schema:
+                        type: boolean
+                        default: false
+                        show_if: [["acl_enable", "=", false]]
+        - variable: redis_data
+          label: Redis Data Storage
+          description: Stores Redis cache data
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "ix_volume"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "redis_data"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: tr_torrents
+          label: Transmission Torrents Storage
+          description: Path to Transmission torrent files
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "host_path"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "tr_torrents"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for Transmission torrents.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+        - variable: qb_backup
+          label: qBittorrent Backup Storage
+          description: Path to qBittorrent BT_backup folder
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
+                schema:
+                  type: string
+                  required: true
+                  default: "host_path"
+                  enum:
+                    - value: "host_path"
+                      description: Host Path (Path that already exists on the system)
+                    - value: "ix_volume"
+                      description: ixVolume (Dataset created automatically by the system)
+              - variable: ix_volume_config
+                label: ixVolume Configuration
+                description: The configuration for the ixVolume dataset.
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - "normalize/ix_volume"
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: dataset_name
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        required: true
+                        hidden: true
+                        default: "qb_backup"
+                    - variable: acl_entries
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+              - variable: host_path_config
+                label: Host Path Configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: acl_enable
+                      label: Enable ACL
+                      description: Enable ACL for the storage.
+                      schema:
+                        type: boolean
+                        default: false
+                    - variable: acl
+                      label: ACL Configuration
+                      schema:
+                        type: dict
+                        show_if: [["acl_enable", "=", true]]
+                        attrs: []
+                        $ref:
+                          - "normalize/acl"
+                    - variable: path
+                      label: Host Path
+                      description: The host path to use for qBittorrent BT_backup.
+                      schema:
+                        type: hostpath
+                        show_if: [["acl_enable", "=", false]]
+                        required: true
+
+  - variable: labels
+    label: ""
+    group: Labels Configuration
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: label
+          label: Label
+          schema:
+            type: dict
+            attrs:
+              - variable: key
+                label: Key
+                schema:
+                  type: string
+                  required: true
+              - variable: value
+                label: Value
+                schema:
+                  type: string
+                  required: true
+              - variable: containers
+                label: Containers
+                description: Containers where the label should be applied
+                schema:
+                  type: list
+                  items:
+                    - variable: container
+                      label: Container
+                      schema:
+                        type: string
+                        required: true
+                        enum:
+                          - value: moviepilot-v2
+                            description: moviepilot-v2
+                          - value: postgres
+                            description: postgres
+                          - value: redis
+                            description: redis
+
+  - variable: resources
+    label: ""
+    group: Resources Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: limits
+          label: Limits
+          schema:
+            type: dict
+            attrs:
+              - variable: cpus
+                label: CPUs
+                description: CPUs limit for MoviePilot.
+                schema:
+                  type: int
+                  default: 2
+                  required: true
+              - variable: memory
+                label: Memory (in MB)
+                description: Memory limit for MoviePilot.
+                schema:
+                  type: int
+                  default: 4096
+                  required: true

--- a/ix-dev/community/moviepilot-v2/templates/docker-compose.yaml
+++ b/ix-dev/community/moviepilot-v2/templates/docker-compose.yaml
@@ -62,7 +62,7 @@
 {% do app.add_storage("/BT_backup", values.storage.qb_backup) %}
 {% do perm_container.add_or_skip_action("qb_backup", values.storage.qb_backup, perms_config) %}
 
-{% do app.add_storage("/var/run/docker.sock", {"type": "host_path", "host_path_config": {"path": "/var/run/docker.sock"}, "read_only": true}) %}
+# {% do app.add_storage("/var/run/docker.sock", {"type": "host_path", "host_path_config": {"path": "/var/run/docker.sock"}, "read_only": true}) %}
 
 {% do app.add_port(values.network.web_port) %}
 {% do app.add_port(values.network.api_port) %}

--- a/ix-dev/community/moviepilot-v2/templates/docker-compose.yaml
+++ b/ix-dev/community/moviepilot-v2/templates/docker-compose.yaml
@@ -1,0 +1,79 @@
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{% set mp_net = tpl.networks.create_internal("moviepilot-net") %}
+
+{% set perm_container = tpl.deps.perms(values.consts.perms_container_name) %}
+
+{% set pg_config = {
+  "user": values.consts.db_user,
+  "password": values.moviepilot.db_password,
+  "database": values.consts.db_name,
+  "volume": values.storage.postgres_data,
+} %}
+{% set postgres = tpl.deps.postgres(values.consts.postgres_container_name, "postgres_image", pg_config, perm_container) %}
+{% do postgres.container.add_network(mp_net) %}
+
+{% set redis_config = {
+  "password": values.moviepilot.redis_password,
+  "volume": values.storage.redis_data,
+} %}
+{% set redis = tpl.deps.redis(values.consts.redis_container_name, "redis_image", redis_config, perm_container) %}
+{% do redis.container.add_network(mp_net) %}
+
+{% set app = tpl.add_container(values.consts.app_container_name, "image") %}
+{% do app.add_network(mp_net) %}
+{% do app.set_user(values.run_as.user, values.run_as.group) %}
+{% do app.healthcheck.set_test("curl", {"port": values.network.web_port.port_number, "path": "/"}) %}
+
+{% do app.environment.add_env("NGINX_PORT", values.network.web_port.port_number) %}
+{% do app.environment.add_env("PORT", values.network.api_port.port_number) %}
+{% do app.environment.add_env("PUID", values.run_as.user) %}
+{% do app.environment.add_env("PGID", values.run_as.group) %}
+{% do app.environment.add_env("SUPERUSER", values.moviepilot.superuser) %}
+{% do app.environment.add_env("SUPERUSER_PASSWORD", values.moviepilot.superuser_password) %}
+{% do app.environment.add_env("DB_TYPE", "postgresql") %}
+{% do app.environment.add_env("DB_POSTGRESQL_HOST", values.consts.postgres_container_name) %}
+{% do app.environment.add_env("DB_POSTGRESQL_PORT", 5432) %}
+{% do app.environment.add_env("DB_POSTGRESQL_DATABASE", values.consts.db_name) %}
+{% do app.environment.add_env("DB_POSTGRESQL_USERNAME", values.consts.db_user) %}
+{% do app.environment.add_env("DB_POSTGRESQL_PASSWORD", values.moviepilot.db_password) %}
+{% do app.environment.add_env("CACHE_BACKEND_TYPE", "redis") %}
+{% do app.environment.add_env("CACHE_BACKEND_URL", "redis://:%s@%s:6379"|format(values.moviepilot.redis_password, values.consts.redis_container_name)) %}
+
+{% do app.environment.add_user_envs(values.moviepilot.additional_envs) %}
+
+{% do app.depends.add_dependency(values.consts.postgres_container_name, "service_healthy") %}
+{% do app.depends.add_dependency(values.consts.redis_container_name, "service_healthy") %}
+
+{% set perms_config = {"uid": values.run_as.user, "gid": values.run_as.group, "mode": "check"} %}
+
+{% do app.add_storage("/media", values.storage.media) %}
+{% do perm_container.add_or_skip_action("media", values.storage.media, perms_config) %}
+
+{% do app.add_storage("/config", values.storage.config) %}
+{% do perm_container.add_or_skip_action("config", values.storage.config, perms_config) %}
+
+{% do app.add_storage("/moviepilot/.cloakbrowser", values.storage.core_browser) %}
+{% do perm_container.add_or_skip_action("core_browser", values.storage.core_browser, perms_config) %}
+
+{% do app.add_storage("/torrents", values.storage.tr_torrents) %}
+{% do perm_container.add_or_skip_action("tr_torrents", values.storage.tr_torrents, perms_config) %}
+
+{% do app.add_storage("/BT_backup", values.storage.qb_backup) %}
+{% do perm_container.add_or_skip_action("qb_backup", values.storage.qb_backup, perms_config) %}
+
+{% do app.add_storage("/var/run/docker.sock", {"type": "host_path", "host_path_config": {"path": "/var/run/docker.sock"}, "read_only": true}) %}
+
+{% do app.add_port(values.network.web_port) %}
+{% do app.add_port(values.network.api_port) %}
+
+{% if perm_container.has_actions() %}
+  {% do perm_container.activate() %}
+  {% do app.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
+  {% do redis.container.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
+  {% do postgres.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}
+{% endif %}
+
+{% do tpl.portals.add(values.network.web_port, {"scheme": "http"}) %}
+
+{{ tpl.render() | tojson }}

--- a/ix-dev/community/moviepilot-v2/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/moviepilot-v2/templates/test_values/basic-values.yaml
@@ -1,0 +1,74 @@
+resources:
+  limits:
+    cpus: 2.0
+    memory: 4096
+
+TZ: Asia/Shanghai
+
+moviepilot:
+  superuser: admin
+  superuser_password: my-secret-password
+  db_password: pg-moviepilot-password
+  redis_password: redis-moviepilot-password
+  additional_envs: []
+
+network:
+  web_port:
+    bind_mode: published
+    port_number: 3000
+  api_port:
+    bind_mode: published
+    port_number: 3001
+  networks: []
+
+run_as:
+  user: 0
+  group: 0
+
+ix_volumes:
+  media: /opt/tests/mnt/media
+  config: /opt/tests/mnt/config
+  core_browser: /opt/tests/mnt/core_browser
+  postgres_data: /opt/tests/mnt/postgres_data
+  redis_data: /opt/tests/mnt/redis_data
+  tr_torrents: /opt/tests/mnt/tr_torrents
+  qb_backup: /opt/tests/mnt/qb_backup
+
+storage:
+  media:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: media
+      create_host_path: true
+  config:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: config
+      create_host_path: true
+  core_browser:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: core_browser
+      create_host_path: true
+  postgres_data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: postgres_data
+      create_host_path: true
+  redis_data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: redis_data
+      create_host_path: true
+  tr_torrents:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: tr_torrents
+      create_host_path: true
+  qb_backup:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: qb_backup
+      create_host_path: true
+
+labels: []


### PR DESCRIPTION
# App Addition 

 - [x] Someone have opened an [issue](https://github.com/truenas/apps/issues/229) to discuss this app addition before submitting this pull request.

 # AI 

 - [x] Part or All of this PR was generated by an LLM. 

 ## Description 

 Adds **MoviePilot-v2** to the community train. 

 MoviePilot-v2 is a media management tool that automatically downloads movies and TV shows. It provides automated media scraping, downloading, and organizing capabilities for a complete media library solution.

 ## App Information 

 - **Upstream**: `https://github.com/jxxghp/MoviePilot` 
 - **Documentation**: `https://wiki.movie-pilot.org/` 
 - **App Version**: latest 
 - **Container Image**: `jxxghp/moviepilot-v2:latest`

 ## Testing 

 Tested locally with: 

 - [x] basic-values.yaml 

 All tests passed successfully. 
 Successfully tested on TrueNAS hardware

 ## Icons and Screenshots 

 Please upload the following to the CDN: 

 - Icon: [https://wiki.movie-pilot.org/assets/logo.svg](https://wiki.movie-pilot.org/assets/logo.svg) 
 - Screenshot 1: [https://wiki.movie-pilot.org/%E4%BB%AA%E8%A1%A8%E7%9B%98.png](https://wiki.movie-pilot.org/%E4%BB%AA%E8%A1%A8%E7%9B%98.png)

 ## Special Notes 

- First‑time setup: After installation, access the web interface to configure media sources and download clients.
- Container starts as root user and switches to specified user via PUID/PGID environment variables
- Requires CHOWN, SETGID, SETUID, DAC_OVERRIDE, FOWNER capabilities for proper permission handling

 ## Checklist 

 - [x] App runs successfully locally 
 - [x] Only modified files under /ix-dev/ or /library/ 
 - [x] README.md included 
 - [x] Multiple test scenarios tested 
 - [x] questions.yaml has clear descriptions and follows structure of existing apps 
 - [ ] All automated CI checks pass 