### PR TITLE
Fix: LanguageTool JVM memory rendering error

### DIFF
--- a/ix-dev/community/languagetool/app.yaml
+++ b/ix-dev/community/languagetool/app.yaml
@@ -31,4 +31,4 @@ sources:
 - https://github.com/erikvl87/docker-languagetool
 title: LanguageTool Server
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/languagetool/questions.yaml
+++ b/ix-dev/community/languagetool/questions.yaml
@@ -36,7 +36,7 @@ questions:
             type: int
             default: 256
             required: true
-        - variable: java_xmx
+        - variable: java_xmx_mb
           label: JVM Maximum Memory (Xmx) (MB)
           description: Maximum memory allocated to the JVM (e.g. 512m, 1g).
           schema:


### PR DESCRIPTION
LanguageTool has been recently added and in the merge process a variable name mismatch has happend which causes the intallation to fail.