### PR TITLE
aistor: allow uid/gid as low as 473

### DIFF
--- a/ix-dev/stable/aistor/README.md
+++ b/ix-dev/stable/aistor/README.md
@@ -1,3 +1,10 @@
 # AIStor
 
 [AIStor](https://min.io) delivers unmatched enterprise performance, scale, agility and economics for AI data, agentic computing, and analytics.
+
+**Users who migrate from MinIO, will need to make sure that at least the User and Group Configuration and Storage Configuration match the previous MinIO configuration.**
+Network, Resources and other sections can be changed later.
+
+For example you can stop MinIO app, take a snapshot of your data, then install the AIStore app.
+Make sure everything works, then delete the MinIO app.
+If anything goes wrong you can restore the snapshot and start MinIO app again.

--- a/ix-dev/stable/aistor/app.yaml
+++ b/ix-dev/stable/aistor/app.yaml
@@ -32,4 +32,4 @@ sources:
 - https://quay.io/repository/minio/aistor/minio
 title: AIStor
 train: stable
-version: 1.1.15
+version: 1.1.16

--- a/ix-dev/stable/aistor/questions.yaml
+++ b/ix-dev/stable/aistor/questions.yaml
@@ -81,7 +81,7 @@ questions:
           description: The user id that AIStor files will be owned by.
           schema:
             type: int
-            min: 568
+            min: 473
             default: 568
             required: true
         - variable: group
@@ -89,7 +89,7 @@ questions:
           description: The group id that AIStor files will be owned by.
           schema:
             type: int
-            min: 568
+            min: 473
             default: 568
             required: true
 


### PR DESCRIPTION
Allows users that were running the previous minio app, to select 473 which matched previous default. that makes it easy to migrate without having to chown the files