### PR TITLE
Update Hermes Agent in preparation for v0.18.x

### DIFF
--- a/ix-dev/community/hermes-agent/app.yaml
+++ b/ix-dev/community/hermes-agent/app.yaml
@@ -1,4 +1,4 @@
-app_version: v2026.6.19
+app_version: v2026.7.7.2
 capabilities:
 - description: Hermes-Agent is able to change file ownership arbitrarily
   name: CHOWN

--- a/ix-dev/community/hermes-agent/app.yaml
+++ b/ix-dev/community/hermes-agent/app.yaml
@@ -40,4 +40,4 @@ sources:
 - https://hub.docker.com/r/nousresearch/hermes-agent
 title: Hermes-Agent
 train: community
-version: 1.0.5
+version: 1.0.6

--- a/ix-dev/community/hermes-agent/ix_values.yaml
+++ b/ix-dev/community/hermes-agent/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: nousresearch/hermes-agent
-    tag: v2026.6.19
+    tag: v2026.7.7.2
 
 consts:
   hermes_agent_container_name: hermes-agent

--- a/ix-dev/community/hermes-agent/questions.yaml
+++ b/ix-dev/community/hermes-agent/questions.yaml
@@ -19,11 +19,17 @@ questions:
       attrs:
         - variable: gateway_key
           label: Gateway API Key
+          description: |
+            The API key used to authenticate against the gateway API server. <br>
+            Must be at least 16 characters long, as the gateway refuses to start with
+            a short or placeholder key. Generate a strong secret, for example with
+            [openssl rand -hex 32].
           schema:
             type: string
             default: ""
             private: true
             required: true
+            min_length: 16
         - variable: allow_all_users_access
           label: Allow All Users Access the Gateway
           description: |
@@ -601,14 +607,14 @@ questions:
             attrs:
               - variable: cpus
                 label: CPUs
-                description: CPUs limit for Headscale.
+                description: CPUs limit for Hermes-Agent.
                 schema:
                   type: int
                   default: 2
                   required: true
               - variable: memory
                 label: Memory (in MB)
-                description: Memory limit for Headscale.
+                description: Memory limit for Hermes-Agent.
                 schema:
                   type: int
                   default: 4096

--- a/ix-dev/community/hermes-agent/questions.yaml
+++ b/ix-dev/community/hermes-agent/questions.yaml
@@ -21,15 +21,14 @@ questions:
           label: Gateway API Key
           description: |
             The API key used to authenticate against the gateway API server. <br>
-            Must be at least 16 characters long, as the gateway refuses to start with
-            a short or placeholder key. Generate a strong secret, for example with
-            [openssl rand -hex 32].
+            Must be at least 16 characters long. </br>
+            Generate a strong secret with `openssl rand -hex 32`.
           schema:
             type: string
             default: ""
+            min_length: 16
             private: true
             required: true
-            min_length: 16
         - variable: allow_all_users_access
           label: Allow All Users Access the Gateway
           description: |

--- a/ix-dev/community/hermes-agent/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/hermes-agent/templates/test_values/basic-values.yaml
@@ -5,7 +5,7 @@ resources:
 
 hermes_agent:
   enable_insecure_dashboard_access: true
-  gateway_key: test-password
+  gateway_key: 89c49b325ba54ce7397ca192d2b43fc483437a3f20c692328083c79c9a767ed8
   allow_all_users_access: true
   shm_size_mb: 64
   additional_envs: []


### PR DESCRIPTION
# App Update

- [X] I have opened an [issue](https://github.com/truenas/apps/issues) to discuss this app addition before submitting this pull request.
Closes #5382

# AI

- [X] Part or All of this PR was generated by an LLM.

## Description

Updates Hermes Agent to the community train.

This is an update in preparation for Hermes Agent v0.18.0 (v2026.7.1). The latest version of Hermes Agent refuses to start the API server when `API_SERVER_KEY` is a placeholder or shorter than 16 characters, which leaves the container unhealthy in CI. Enforce `min_length: 16` with a helper text on the gateway key field, and use a strong key in the CI test values.
Also fix two leftover "Headscale" descriptions in the resources group.

## App Information

- **Upstream**: https://github.com/NousResearch/hermes-agent
- **Documentation**: https://hermes-agent.nousresearch.com/docs/
- **App Version**: v2026.6.19

## Testing

Tested locally with:

- [X] basic-values.yaml

All tests passed successfully.

<!--
## Icons and Screenshots

Please upload the following to the CDN:

- Icon: [attach or link]
- Screenshot 1 (optional): [attach or link]

## Special Notes

- First-time setup instructions: [if applicable]
- Any other important information
- -->

## Checklist

- [X] App runs successfully locally
- [X] Only modified files under /ix-dev/ or /library/
- [X] README.md included
- [X] Multiple test scenarios tested
- [X] questions.yaml has clear descriptions and follows structure of existing apps
- [X] All automated CI checks pass
