### PR TITLE
Add Tailscale Services configuration

### DIFF
--- a/ix-dev/community/tailscale/README.md
+++ b/ix-dev/community/tailscale/README.md
@@ -3,3 +3,6 @@
 [Tailscale](https://tailscale.com) Secure remote access to shared resources
 
 - When `Userspace` is **disabled**, `Tailscale` will run with `/dev/net/tun` device mounted from the host.
+- Tailscale Services can optionally forward TCP ports to applications published on the NAS. Define each Service
+  and its TCP ports in the Tailscale admin console first, authenticate this node with a tag-based identity, and
+  approve the Service advertisement or configure an auto-approver policy.

--- a/ix-dev/community/tailscale/README.md
+++ b/ix-dev/community/tailscale/README.md
@@ -5,6 +5,7 @@
 - When `Userspace` is **disabled**, `Tailscale` will run with `/dev/net/tun` device mounted from the host.
 - Tailscale Services can optionally expose applications published on the NAS. HTTPS endpoints terminate
   Tailscale-managed TLS and proxy to the application's backend port, so a Service on port 443 can reach an app
-  published on a different port. Define each Service and its ports in the Tailscale admin console first, enable
-  HTTPS for the tailnet when using HTTPS endpoints, authenticate this node with a tag-based identity, and approve
-  the Service advertisement or configure an auto-approver policy.
+  published on a different port. HTTP and HTTPS endpoints require the Tailnet DNS Suffix from the Tailscale DNS
+  settings. Define each Service and its ports in the Tailscale admin console first, enable HTTPS for the tailnet
+  when using HTTPS endpoints, authenticate this node with a tag-based identity, and approve the Service
+  advertisement or configure an auto-approver policy.

--- a/ix-dev/community/tailscale/README.md
+++ b/ix-dev/community/tailscale/README.md
@@ -3,6 +3,8 @@
 [Tailscale](https://tailscale.com) Secure remote access to shared resources
 
 - When `Userspace` is **disabled**, `Tailscale` will run with `/dev/net/tun` device mounted from the host.
-- Tailscale Services can optionally forward TCP ports to applications published on the NAS. Define each Service
-  and its TCP ports in the Tailscale admin console first, authenticate this node with a tag-based identity, and
-  approve the Service advertisement or configure an auto-approver policy.
+- Tailscale Services can optionally expose applications published on the NAS. HTTPS endpoints terminate
+  Tailscale-managed TLS and proxy to the application's backend port, so a Service on port 443 can reach an app
+  published on a different port. Define each Service and its ports in the Tailscale admin console first, enable
+  HTTPS for the tailnet when using HTTPS endpoints, authenticate this node with a tag-based identity, and approve
+  the Service advertisement or configure an auto-approver policy.

--- a/ix-dev/community/tailscale/app.yaml
+++ b/ix-dev/community/tailscale/app.yaml
@@ -46,4 +46,4 @@ sources:
 - https://tailscale.com/
 title: Tailscale
 train: community
-version: 1.4.12
+version: 1.4.13

--- a/ix-dev/community/tailscale/ix_values.yaml
+++ b/ix-dev/community/tailscale/ix_values.yaml
@@ -6,14 +6,16 @@ images:
     repository: ixsystems/container-utils
     tag: 1.0.2
 
+services_enabled: false
+tailnet_dns_suffix: ""
+services: []
+
 consts:
   tailscale_container_name: tailscale
-  service_configurator_container_name: service-configurator
   perms_container_name: permissions
   state_path: /var/lib/tailscale
   socket_path: /var/run/tailscale/tailscaled.sock
-  service_config_script_path: /etc/tailscale/configure-services.sh
-  empty_services_config_path: /etc/tailscale/empty-services.json
+  serve_config_path: /etc/tailscale/serve.json
   reserved_keys:
     - --advertise-exit-node
     - --accept-routes

--- a/ix-dev/community/tailscale/ix_values.yaml
+++ b/ix-dev/community/tailscale/ix_values.yaml
@@ -8,9 +8,12 @@ images:
 
 consts:
   tailscale_container_name: tailscale
+  service_configurator_container_name: service-configurator
   perms_container_name: permissions
   state_path: /var/lib/tailscale
-  serve_config_path: /etc/tailscale/serve.json
+  socket_path: /var/run/tailscale/tailscaled.sock
+  service_config_script_path: /etc/tailscale/configure-services.sh
+  empty_services_config_path: /etc/tailscale/empty-services.json
   reserved_keys:
     - --advertise-exit-node
     - --accept-routes

--- a/ix-dev/community/tailscale/ix_values.yaml
+++ b/ix-dev/community/tailscale/ix_values.yaml
@@ -10,6 +10,7 @@ consts:
   tailscale_container_name: tailscale
   perms_container_name: permissions
   state_path: /var/lib/tailscale
+  serve_config_path: /etc/tailscale/serve.json
   reserved_keys:
     - --advertise-exit-node
     - --accept-routes

--- a/ix-dev/community/tailscale/questions.yaml
+++ b/ix-dev/community/tailscale/questions.yaml
@@ -169,6 +169,28 @@ questions:
                       schema:
                         type: string
 
+  - variable: services_enabled
+    label: Manage Tailscale Services
+    description: Generate and apply a Tailscale Services configuration for this node.
+    group: Tailscale Services Configuration
+    schema:
+      type: boolean
+      default: false
+
+  - variable: tailnet_dns_suffix
+    label: Tailnet DNS Suffix
+    description: |
+      Tailnet DNS suffix used to construct HTTP and HTTPS Service names.</br>
+      Find it under Tailscale DNS settings. For example: `example-tailnet.ts.net`.</br>
+      This is not required when every configured endpoint uses raw TCP forwarding.
+    group: Tailscale Services Configuration
+    schema:
+      type: string
+      default: ""
+      show_if: [["services_enabled", "=", true]]
+      valid_chars: "^$|^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$"
+      valid_chars_error: Enter a lowercase DNS suffix without a scheme, trailing dot, or port.
+
   - variable: services
     label: Tailscale Services
     description: |
@@ -180,6 +202,7 @@ questions:
     schema:
       type: list
       default: []
+      show_if: [["services_enabled", "=", true]]
       items:
         - variable: service
           label: Service

--- a/ix-dev/community/tailscale/questions.yaml
+++ b/ix-dev/community/tailscale/questions.yaml
@@ -1,6 +1,8 @@
 groups:
   - name: Tailscale Configuration
     description: Configure Tailscale
+  - name: Tailscale Services Configuration
+    description: Configure Tailscale Services hosted by this node
   - name: Network Configuration
     description: Configure Network for Tailscale
   - name: Storage Configuration
@@ -166,6 +168,75 @@ questions:
                       label: Value
                       schema:
                         type: string
+
+  - variable: services
+    label: Tailscale Services
+    description: |
+      Optionally advertise applications reachable from this NAS as Tailscale Services.</br>
+      Each Service must already be defined in the Tailscale admin console with matching TCP ports.</br>
+      This Tailscale node must use a tag-based identity and the Service advertisement must be approved</br>
+      or covered by an auto-approver policy. See https://tailscale.com/kb/1552/tailscale-services
+    group: Tailscale Services Configuration
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: service
+          label: Service
+          schema:
+            type: dict
+            attrs:
+              - variable: name
+                label: Service Name
+                description: |
+                  Name of a Service already defined in the Tailscale admin console.</br>
+                  Enter the name without the `svc:` prefix.
+                schema:
+                  type: string
+                  required: true
+                  valid_chars: "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+                  valid_chars_error: |
+                    Use 1 to 63 lowercase letters, numbers, or hyphens, and do not start or end with a hyphen.
+              - variable: endpoints
+                label: Endpoints
+                description: TCP ports and destinations provided by this Service.
+                schema:
+                  type: list
+                  min: 1
+                  required: true
+                  items:
+                    - variable: endpoint
+                      label: Endpoint
+                      schema:
+                        type: dict
+                        attrs:
+                          - variable: service_port
+                            label: Service Port
+                            description: |
+                              TCP port clients use when connecting to this Tailscale Service.</br>
+                              This must match a port defined for the Service in the Tailscale admin console.
+                            schema:
+                              type: int
+                              min: 1
+                              max: 65535
+                              required: true
+                          - variable: target_host
+                            label: Target Host
+                            description: |
+                              Hostname or IP address to which Tailscale forwards traffic.</br>
+                              Use 127.0.0.1 for an app port published on this NAS when Host Network is enabled.
+                            schema:
+                              type: string
+                              default: "127.0.0.1"
+                              required: true
+                          - variable: target_port
+                            label: Target Port
+                            description: Port on the target host where the application is listening.
+                            schema:
+                              type: int
+                              min: 1
+                              max: 65535
+                              required: true
 
   - variable: network
     label: ""

--- a/ix-dev/community/tailscale/questions.yaml
+++ b/ix-dev/community/tailscale/questions.yaml
@@ -199,7 +199,7 @@ questions:
                     Use 1 to 63 lowercase letters, numbers, or hyphens, and do not start or end with a hyphen.
               - variable: endpoints
                 label: Endpoints
-                description: TCP ports and destinations provided by this Service.
+                description: Public ports and backend destinations provided by this Service.
                 schema:
                   type: list
                   min: 1
@@ -210,16 +210,49 @@ questions:
                       schema:
                         type: dict
                         attrs:
+                          - variable: protocol
+                            label: Service Protocol
+                            description: |
+                              HTTPS terminates Tailscale-managed TLS and proxies to the backend.</br>
+                              HTTP provides an unencrypted web endpoint. TCP performs raw port forwarding.
+                            schema:
+                              type: string
+                              default: https
+                              required: true
+                              enum:
+                                - value: https
+                                  description: HTTPS (Recommended)
+                                - value: http
+                                  description: HTTP
+                                - value: tcp
+                                  description: TCP
                           - variable: service_port
                             label: Service Port
                             description: |
-                              TCP port clients use when connecting to this Tailscale Service.</br>
+                              Port clients use when connecting to this Tailscale Service.</br>
+                              HTTPS defaults to 443. For HTTP, normally change this to 80.</br>
                               This must match a port defined for the Service in the Tailscale admin console.
                             schema:
                               type: int
+                              default: 443
                               min: 1
                               max: 65535
                               required: true
+                          - variable: target_protocol
+                            label: Backend Protocol
+                            description: Protocol used between Tailscale and the backend application.
+                            schema:
+                              type: string
+                              default: http
+                              required: true
+                              show_if: [["protocol", "!=", "tcp"]]
+                              enum:
+                                - value: http
+                                  description: HTTP (Recommended)
+                                - value: https
+                                  description: HTTPS
+                                - value: https+insecure
+                                  description: HTTPS (Allow an untrusted backend certificate)
                           - variable: target_host
                             label: Target Host
                             description: |
@@ -229,6 +262,8 @@ questions:
                               type: string
                               default: "127.0.0.1"
                               required: true
+                              valid_chars: "^[a-zA-Z0-9:][a-zA-Z0-9._:-]*$"
+                              valid_chars_error: Use a hostname or IP address without a URL scheme, path, or port.
                           - variable: target_port
                             label: Target Port
                             description: Port on the target host where the application is listening.

--- a/ix-dev/community/tailscale/templates/docker-compose.yaml
+++ b/ix-dev/community/tailscale/templates/docker-compose.yaml
@@ -30,40 +30,88 @@
 {% do c1.environment.add_env("TS_USERSPACE", values.tailscale.userspace) %}
 {% do c1.environment.add_env("TS_AUTH_ONCE", values.tailscale.auth_once) %}
 {% do c1.environment.add_env("TS_AUTHKEY", values.tailscale.auth_key) %}
-{% do c1.environment.add_env("TS_SOCKET", "/var/run/tailscale/tailscaled.sock") %}
+{% do c1.environment.add_env("TS_SOCKET", values.consts.socket_path) %}
+
+{% set run_config = {"type": "temporary", "volume_config": {"volume_name": "tailscale-run"}} %}
+{% set service_script = namespace(lines=[
+  "#!/bin/sh",
+  "set -eu",
+  "",
+  "attempt=0",
+  "until tailscale --socket=%s status --json 2>/dev/null | grep -q '\"BackendState\": \"Running\"'; do" | format(values.consts.socket_path),
+  "  attempt=$((attempt + 1))",
+  "  if [ \"$attempt\" -ge 120 ]; then",
+  "    echo 'Timed out waiting for Tailscale to reach the Running state' >&2",
+  "    exit 1",
+  "  fi",
+  "  sleep 1",
+  "done",
+  "",
+  "tailscale --socket=%s serve set-config --all %s" | format(
+    values.consts.socket_path, values.consts.empty_services_config_path
+  ),
+]) %}
+{% set configured_services = namespace(names=[]) %}
 {% if values.services %}
   {% if not values.network.host_network %}
     {% do tpl.funcs.fail("Tailscale Services require Host Network to reach applications published on this NAS") %}
   {% endif %}
 
-  {% set serve_config = namespace(x={"Services": {}}) %}
   {% for service in values.services %}
     {% set service_name = "svc:%s" | format(service.name) %}
-    {% if service_name in serve_config.x.Services %}
+    {% if service_name in configured_services.names %}
       {% do tpl.funcs.fail("Tailscale Service [%s] is configured more than once" | format(service_name)) %}
     {% endif %}
+    {% do configured_services.names.append(service_name) %}
 
-    {% set tcp = namespace(x={}) %}
+    {% set configured_ports = namespace(x=[]) %}
     {% for endpoint in service.endpoints %}
       {% set service_port = endpoint.service_port | string %}
-      {% if service_port in tcp.x %}
+      {% if service_port in configured_ports.x %}
         {% do tpl.funcs.fail(
           "Tailscale Service [%s] has TCP port [%s] configured more than once" | format(service_name, service_port)
+        ) %}
+      {% endif %}
+      {% do configured_ports.x.append(service_port) %}
+      {% set protocol = endpoint.get("protocol", "https") %}
+      {% if protocol not in ["https", "http", "tcp"] %}
+        {% do tpl.funcs.fail("Invalid protocol [%s] for Tailscale Service [%s]" | format(protocol, service_name)) %}
+      {% endif %}
+      {% if not tpl.funcs.match_regex(endpoint.target_host, "^[a-zA-Z0-9:][a-zA-Z0-9._:-]*$") %}
+        {% do tpl.funcs.fail(
+          "Invalid target host [%s] for Tailscale Service [%s]" | format(endpoint.target_host, service_name)
         ) %}
       {% endif %}
       {% set target = "[%s]:%d" | format(endpoint.target_host, endpoint.target_port)
         if ":" in endpoint.target_host else
         "%s:%d" | format(endpoint.target_host, endpoint.target_port) %}
-      {% do tcp.x.update({service_port: {
-        "TCPForward": target
-      }}) %}
+      {% set target_protocol = "tcp" if protocol == "tcp" else endpoint.get("target_protocol", "http") %}
+      {% set valid_target_protocols = ["tcp"] if protocol == "tcp" else ["http", "https", "https+insecure"] %}
+      {% if target_protocol not in valid_target_protocols %}
+        {% do tpl.funcs.fail(
+          "Invalid backend protocol [%s] for Tailscale Service [%s]" | format(target_protocol, service_name)
+        ) %}
+      {% endif %}
+      {% do service_script.lines.append(
+        "tailscale --socket=%s serve --service=%s --%s=%s %s://%s" | format(
+          values.consts.socket_path, service_name, protocol, service_port, target_protocol, target
+        )
+      ) %}
     {% endfor %}
-    {% do serve_config.x.Services.update({service_name: {"TCP": tcp.x}}) %}
   {% endfor %}
-
-  {% do c1.configs.add("serve-config", serve_config.x | tojson, values.consts.serve_config_path, "0444") %}
-  {% do c1.environment.add_env("TS_SERVE_CONFIG", values.consts.serve_config_path) %}
 {% endif %}
+
+{% set service_configurator = tpl.add_container(values.consts.service_configurator_container_name, "image") %}
+{% do service_configurator.setup_as_helper() %}
+{% do service_configurator.set_entrypoint([values.consts.service_config_script_path]) %}
+{% do service_configurator.configs.add(
+  "configure-services", service_script.lines | join("\n"), values.consts.service_config_script_path, "0555"
+) %}
+{% do service_configurator.configs.add(
+  "empty-services", '{"version":"0.0.1","services":{}}', values.consts.empty_services_config_path, "0444"
+) %}
+{% do service_configurator.add_storage("/var/run/tailscale", run_config) %}
+{% do service_configurator.depends.add_dependency(values.consts.tailscale_container_name, "service_healthy") %}
 {% if values.tailscale.tailscaled_args %}
   {% do c1.environment.add_env("TS_TAILSCALED_EXTRA_ARGS", values.tailscale.tailscaled_args|unique|list|join(" ")) %}
 {% endif %}
@@ -81,7 +129,7 @@
   {% do c1.add_tun_device() %}
 {% endif %}
 
-{% do c1.add_storage("/var/run/tailscale", {"type":"tmpfs", "tmpfs_config": {"mode": "0755"}}) %}
+{% do c1.add_storage("/var/run/tailscale", run_config) %}
 
 {% do c1.add_storage(values.consts.state_path, values.storage.state) %}
 {% if values.tailscale.userspace %}

--- a/ix-dev/community/tailscale/templates/docker-compose.yaml
+++ b/ix-dev/community/tailscale/templates/docker-compose.yaml
@@ -31,6 +31,39 @@
 {% do c1.environment.add_env("TS_AUTH_ONCE", values.tailscale.auth_once) %}
 {% do c1.environment.add_env("TS_AUTHKEY", values.tailscale.auth_key) %}
 {% do c1.environment.add_env("TS_SOCKET", "/var/run/tailscale/tailscaled.sock") %}
+{% if values.services %}
+  {% if not values.network.host_network %}
+    {% do tpl.funcs.fail("Tailscale Services require Host Network to reach applications published on this NAS") %}
+  {% endif %}
+
+  {% set serve_config = namespace(x={"Services": {}}) %}
+  {% for service in values.services %}
+    {% set service_name = "svc:%s" | format(service.name) %}
+    {% if service_name in serve_config.x.Services %}
+      {% do tpl.funcs.fail("Tailscale Service [%s] is configured more than once" | format(service_name)) %}
+    {% endif %}
+
+    {% set tcp = namespace(x={}) %}
+    {% for endpoint in service.endpoints %}
+      {% set service_port = endpoint.service_port | string %}
+      {% if service_port in tcp.x %}
+        {% do tpl.funcs.fail(
+          "Tailscale Service [%s] has TCP port [%s] configured more than once" | format(service_name, service_port)
+        ) %}
+      {% endif %}
+      {% set target = "[%s]:%d" | format(endpoint.target_host, endpoint.target_port)
+        if ":" in endpoint.target_host else
+        "%s:%d" | format(endpoint.target_host, endpoint.target_port) %}
+      {% do tcp.x.update({service_port: {
+        "TCPForward": target
+      }}) %}
+    {% endfor %}
+    {% do serve_config.x.Services.update({service_name: {"TCP": tcp.x}}) %}
+  {% endfor %}
+
+  {% do c1.configs.add("serve-config", serve_config.x | tojson, values.consts.serve_config_path, "0444") %}
+  {% do c1.environment.add_env("TS_SERVE_CONFIG", values.consts.serve_config_path) %}
+{% endif %}
 {% if values.tailscale.tailscaled_args %}
   {% do c1.environment.add_env("TS_TAILSCALED_EXTRA_ARGS", values.tailscale.tailscaled_args|unique|list|join(" ")) %}
 {% endif %}

--- a/ix-dev/community/tailscale/templates/docker-compose.yaml
+++ b/ix-dev/community/tailscale/templates/docker-compose.yaml
@@ -32,29 +32,16 @@
 {% do c1.environment.add_env("TS_AUTHKEY", values.tailscale.auth_key) %}
 {% do c1.environment.add_env("TS_SOCKET", values.consts.socket_path) %}
 
-{% set run_config = {"type": "temporary", "volume_config": {"volume_name": "tailscale-run"}} %}
-{% set service_script = namespace(lines=[
-  "#!/bin/sh",
-  "set -eu",
-  "",
-  "attempt=0",
-  "until tailscale --socket=%s status --json 2>/dev/null | grep -q '\"BackendState\": \"Running\"'; do" | format(values.consts.socket_path),
-  "  attempt=$((attempt + 1))",
-  "  if [ \"$attempt\" -ge 120 ]; then",
-  "    echo 'Timed out waiting for Tailscale to reach the Running state' >&2",
-  "    exit 1",
-  "  fi",
-  "  sleep 1",
-  "done",
-  "",
-  "tailscale --socket=%s serve set-config --all %s" | format(
-    values.consts.socket_path, values.consts.empty_services_config_path
-  ),
-]) %}
-{% set configured_services = namespace(names=[]) %}
-{% if values.services %}
-  {% if not values.network.host_network %}
+{% if values.get("services_enabled", false) %}
+  {% set serve_config = namespace(x={"Services": {}}) %}
+  {% set configured_services = namespace(names=[]) %}
+  {% set tailnet_dns_suffix = values.get("tailnet_dns_suffix", "") %}
+
+  {% if values.services and not values.network.host_network %}
     {% do tpl.funcs.fail("Tailscale Services require Host Network to reach applications published on this NAS") %}
+  {% endif %}
+  {% if tailnet_dns_suffix and not tpl.funcs.match_regex(tailnet_dns_suffix, "^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$") %}
+    {% do tpl.funcs.fail("Invalid Tailnet DNS Suffix [%s]" | format(tailnet_dns_suffix)) %}
   {% endif %}
 
   {% for service in values.services %}
@@ -63,8 +50,9 @@
       {% do tpl.funcs.fail("Tailscale Service [%s] is configured more than once" | format(service_name)) %}
     {% endif %}
     {% do configured_services.names.append(service_name) %}
-
+    {% set service_config = namespace(x={"TCP": {}}) %}
     {% set configured_ports = namespace(x=[]) %}
+
     {% for endpoint in service.endpoints %}
       {% set service_port = endpoint.service_port | string %}
       {% if service_port in configured_ports.x %}
@@ -85,33 +73,36 @@
       {% set target = "[%s]:%d" | format(endpoint.target_host, endpoint.target_port)
         if ":" in endpoint.target_host else
         "%s:%d" | format(endpoint.target_host, endpoint.target_port) %}
-      {% set target_protocol = "tcp" if protocol == "tcp" else endpoint.get("target_protocol", "http") %}
-      {% set valid_target_protocols = ["tcp"] if protocol == "tcp" else ["http", "https", "https+insecure"] %}
-      {% if target_protocol not in valid_target_protocols %}
-        {% do tpl.funcs.fail(
-          "Invalid backend protocol [%s] for Tailscale Service [%s]" | format(target_protocol, service_name)
-        ) %}
-      {% endif %}
-      {% do service_script.lines.append(
-        "tailscale --socket=%s serve --service=%s --%s=%s %s://%s" | format(
-          values.consts.socket_path, service_name, protocol, service_port, target_protocol, target
-        )
-      ) %}
-    {% endfor %}
-  {% endfor %}
-{% endif %}
 
-{% set service_configurator = tpl.add_container(values.consts.service_configurator_container_name, "image") %}
-{% do service_configurator.setup_as_helper() %}
-{% do service_configurator.set_entrypoint([values.consts.service_config_script_path]) %}
-{% do service_configurator.configs.add(
-  "configure-services", service_script.lines | join("\n"), values.consts.service_config_script_path, "0555"
-) %}
-{% do service_configurator.configs.add(
-  "empty-services", '{"version":"0.0.1","services":{}}', values.consts.empty_services_config_path, "0444"
-) %}
-{% do service_configurator.add_storage("/var/run/tailscale", run_config) %}
-{% do service_configurator.depends.add_dependency(values.consts.tailscale_container_name, "service_healthy") %}
+      {% if protocol == "tcp" %}
+        {% do service_config.x.TCP.update({service_port: {"TCPForward": target}}) %}
+      {% else %}
+        {% if not tailnet_dns_suffix %}
+          {% do tpl.funcs.fail(
+            "Tailnet DNS Suffix is required for HTTP and HTTPS endpoints in Tailscale Service [%s]" | format(service_name)
+          ) %}
+        {% endif %}
+        {% set target_protocol = endpoint.get("target_protocol", "http") %}
+        {% if target_protocol not in ["http", "https", "https+insecure"] %}
+          {% do tpl.funcs.fail(
+            "Invalid backend protocol [%s] for Tailscale Service [%s]" | format(target_protocol, service_name)
+          ) %}
+        {% endif %}
+        {% do service_config.x.TCP.update({service_port: {"HTTPS": true} if protocol == "https" else {"HTTP": true}}) %}
+        {% if "Web" not in service_config.x %}
+          {% do service_config.x.update({"Web": {}}) %}
+        {% endif %}
+        {% set host_port = "%s.%s:%s" | format(service.name, tailnet_dns_suffix, service_port) %}
+        {% set proxy = "%s://%s" | format(target_protocol, target) %}
+        {% do service_config.x.Web.update({host_port: {"Handlers": {"/": {"Proxy": proxy}}}}) %}
+      {% endif %}
+    {% endfor %}
+    {% do serve_config.x.Services.update({service_name: service_config.x}) %}
+  {% endfor %}
+
+  {% do c1.configs.add("serve-config", serve_config.x | tojson, values.consts.serve_config_path, "0444") %}
+  {% do c1.environment.add_env("TS_SERVE_CONFIG", values.consts.serve_config_path) %}
+{% endif %}
 {% if values.tailscale.tailscaled_args %}
   {% do c1.environment.add_env("TS_TAILSCALED_EXTRA_ARGS", values.tailscale.tailscaled_args|unique|list|join(" ")) %}
 {% endif %}
@@ -129,7 +120,7 @@
   {% do c1.add_tun_device() %}
 {% endif %}
 
-{% do c1.add_storage("/var/run/tailscale", run_config) %}
+{% do c1.add_storage("/var/run/tailscale", {"type": "tmpfs", "tmpfs_config": {"mode": "0755"}}) %}
 
 {% do c1.add_storage(values.consts.state_path, values.storage.state) %}
 {% if values.tailscale.userspace %}

--- a/ix-dev/community/tailscale/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/tailscale/templates/test_values/basic-values.yaml
@@ -19,6 +19,8 @@ tailscale:
   advertise_routes: []
   additional_envs: []
 
+services_enabled: true
+tailnet_dns_suffix: example-tailnet.ts.net
 services:
   - name: linkding
     endpoints:

--- a/ix-dev/community/tailscale/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/tailscale/templates/test_values/basic-values.yaml
@@ -19,6 +19,13 @@ tailscale:
   advertise_routes: []
   additional_envs: []
 
+services:
+  - name: linkding
+    endpoints:
+      - service_port: 30000
+        target_host: 127.0.0.1
+        target_port: 30000
+
 network:
   host_network: true
 

--- a/ix-dev/community/tailscale/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/tailscale/templates/test_values/basic-values.yaml
@@ -22,7 +22,9 @@ tailscale:
 services:
   - name: linkding
     endpoints:
-      - service_port: 30000
+      - protocol: https
+        service_port: 443
+        target_protocol: http
         target_host: 127.0.0.1
         target_port: 30000
 


### PR DESCRIPTION
## Summary

- add optional Tailscale Services and backend endpoint settings to the existing Tailscale app
- generate a native `TS_SERVE_CONFIG` JSON file while keeping the stock image and a single Tailscale container
- default Services to Tailscale-managed HTTPS on port 443 while allowing HTTP, HTTPS, or raw TCP endpoints on custom ports
- add a Tailnet DNS Suffix setting for HTTP and HTTPS Service hostnames; raw TCP endpoints do not require it
- validate host networking, target hosts, backend protocols, and duplicate Service or port definitions

Related to #3937.

## AI

- [x] Part or all of this PR was generated with LLM assistance.

## Validation

- rendered HTTPS, HTTP, raw TCP, IPv6, empty-managed, disabled, and missing-DNS-suffix cases
- verified the generated HTTPS configuration maps a Service hostname on port 443 to a different local backend port
- confirmed the rendered Compose contains only the stock Tailscale container
- passed YAML parsing, `git diff --check`, and `docker compose config` for the installable test Compose
- inspected the Tailscale v1.98.9 Serve configuration and Service hostname lookup paths