### PR TITLE
vllm: extend caps for cpu image

### DIFF
--- a/ix-dev/community/vllm/app.yaml
+++ b/ix-dev/community/vllm/app.yaml
@@ -1,5 +1,9 @@
 app_version: v0.25.1
-capabilities: []
+capabilities:
+- description: vLLM is able to modify process scheduling priority
+  name: SYS_NICE
+- description: vLLM is able to trace and control other processes
+  name: SYS_PTRACE
 categories:
 - ai
 changelog_url: https://github.com/vllm-project/vllm/releases
@@ -34,4 +38,4 @@ sources:
 - https://github.com/vllm-project/vllm
 title: vLLM
 train: community
-version: 1.0.10
+version: 1.0.11

--- a/ix-dev/community/vllm/templates/docker-compose.yaml
+++ b/ix-dev/community/vllm/templates/docker-compose.yaml
@@ -9,6 +9,14 @@
   {% do c1.set_ipc_mode("host") %}
 {% endif %}
 
+{% if values.vllm.image_selector == "rocm_image" %}
+  {% do c1.add_caps(["SYS_PTRACE"]) %}
+  {% do c1.add_security_opt("seccomp", "unconfined") %}
+{% elif values.vllm.image_selector == "cpu_image" %}
+  {% do c1.add_caps(["SYS_NICE"]) %}
+  {% do c1.add_security_opt("seccomp", "unconfined") %}
+{% endif %}
+
 {% do c1.healthcheck.set_test("http", {"port": values.network.web_port.port_number, "path": "/health"}) %}
 {% do c1.healthcheck.set_start_period(300) %}
 {% do c1.healthcheck.set_retries(10) %}
@@ -37,11 +45,6 @@
   {% do c1.add_storage(store.mount_path, store) %}
   {% do perm_container.add_or_skip_action(store.mount_path, store, perms_config) %}
 {% endfor %}
-
-{% if values.vllm.image_selector == "rocm_image" %}
-  {% do c1.add_caps(["SYS_PTRACE"]) %}
-  {% do c1.add_security_opt("seccomp", "unconfined") %}
-{% endif %}
 
 {% if perm_container.has_actions() %}
   {% do perm_container.activate() %}

--- a/ix-dev/community/vllm/templates/test_values/rocm-values.yaml
+++ b/ix-dev/community/vllm/templates/test_values/rocm-values.yaml
@@ -1,0 +1,34 @@
+resources:
+  limits:
+    cpus: 4.0
+    memory: 8192
+
+vllm:
+  image_selector: rocm_image
+  model_name: "Qwen/Qwen3-0.6B"
+  max_model_len: 4096
+  hf_token: ""
+  additional_envs:
+    - name: VLLM_CPU_KVCACHE_SPACE
+      value: "2"
+
+network:
+  host_network: false
+  web_port:
+    bind_mode: published
+    port_number: 30423
+
+run_as:
+  user: 568
+  group: 568
+
+ix_volumes:
+  data: /opt/tests/mnt/vllm/data
+
+storage:
+  data:
+    type: ix_volume
+    ix_volume_config:
+      dataset_name: data
+      create_host_path: true
+  additional_storage: []


### PR DESCRIPTION
Closes #5402 

ROCM values are expected to fail CI, but are added in order to keep in sync the metadata (capabilities).