### PR TITLE
Fix PlainNVR recording host path permissions

### DIFF
--- a/ix-dev/community/plainnvr/app.yaml
+++ b/ix-dev/community/plainnvr/app.yaml
@@ -1,4 +1,4 @@
-app_version: 0.1.0
+app_version: 0.1.1
 capabilities: []
 categories:
 - security
@@ -32,4 +32,4 @@ sources:
 - https://github.com/endless1233214/plainnvr
 title: PlainNVR
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/plainnvr/ix_values.yaml
+++ b/ix-dev/community/plainnvr/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/endless1233214/plainnvr
-    tag: 0.1.0
+    tag: 0.1.1
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2

--- a/ix-dev/community/plainnvr/questions.yaml
+++ b/ix-dev/community/plainnvr/questions.yaml
@@ -425,6 +425,17 @@ questions:
                         type: hostpath
                         show_if: [["acl_enable", "=", false]]
                         required: true
+                    - variable: auto_permissions
+                      label: Automatic Permissions
+                      description: |
+                        Automatically set permissions for the host path.
+                        PlainNVR runs as the configured User ID and Group ID, so
+                        enabling this lets TrueNAS correct ownership when the
+                        path is not writable by the app.
+                      schema:
+                        type: boolean
+                        default: true
+                        show_if: [["acl_enable", "=", false]]
         - variable: recordings
           label: Recordings Storage
           description: Stores camera recording segments.
@@ -501,6 +512,17 @@ questions:
                         type: hostpath
                         show_if: [["acl_enable", "=", false]]
                         required: true
+                    - variable: auto_permissions
+                      label: Automatic Permissions
+                      description: |
+                        Automatically set permissions for the host path.
+                        PlainNVR writes camera segment folders here, so enabling
+                        this lets TrueNAS correct ownership when the path is not
+                        writable by the app.
+                      schema:
+                        type: boolean
+                        default: true
+                        show_if: [["acl_enable", "=", false]]
         - variable: additional_storage
           label: Additional Storage
           schema:


### PR DESCRIPTION
## Summary
- bump PlainNVR to app image 0.1.1 / catalog version 1.0.1
- enable automatic permissions for PlainNVR data and recordings host paths
- keeps host-path installs writable by the configured non-root PlainNVR UID/GID

## Why
A real TrueNAS install using host-path recordings could start live view successfully while recording stayed in recovery because camera segment directories were not writable by UID/GID 568. The permission helper skipped host paths unless `auto_permissions` was set, so this exposes the checkbox and defaults it on for PlainNVR's writable storage mounts.

## Testing
- Ruby YAML parser loaded app.yaml, ix_values.yaml, and questions.yaml
- git diff --check
- Verified on a running TrueNAS install that fixing directory ownership restored segment writes
