### PR TITLE
Add Cuda 13 image option to localai

### DIFF
--- a/ix-dev/community/localai/app.yaml
+++ b/ix-dev/community/localai/app.yaml
@@ -31,4 +31,4 @@ sources:
 - https://github.com/ollama/ollama
 title: LocalAI
 train: community
-version: 1.1.30
+version: 1.1.31

--- a/ix-dev/community/localai/ix_values.yaml
+++ b/ix-dev/community/localai/ix_values.yaml
@@ -11,6 +11,9 @@ images:
   cuda12_image:
     repository: quay.io/go-skynet/local-ai
     tag: v4.7.1-gpu-nvidia-cuda-12
+  cuda13_image:
+    repository: quay.io/go-skynet/local-ai
+    tag: v4.7.1-gpu-nvidia-cuda-13
   rocm_image:
     repository: quay.io/go-skynet/local-ai
     tag: v4.7.1-gpu-hipblas

--- a/ix-dev/community/localai/questions.yaml
+++ b/ix-dev/community/localai/questions.yaml
@@ -33,6 +33,8 @@ questions:
                 description: NVIDIA CUDA 11 Image
               - value: cuda12_image
                 description: NVIDIA CUDA 12 Image
+              - value: cuda13_image
+                description: NVIDIA CUDA 13 Image
               - value: rocm_image
                 description: AMD ROCM Image
               - value: intel_image


### PR DESCRIPTION
Hi,

i have seen the Cuda 13 image is missing in the image selector, inspite there is one available.

Kind regards