### PR TITLE
Refresh MetaTana catalog presentation and install channel

### DIFF
--- a/ix-dev/community/metatana/README.md
+++ b/ix-dev/community/metatana/README.md
@@ -1,6 +1,9 @@
 # MetaTana
 
-[MetaTana](https://metatana.com) is an AI-powered media manager. It scans your
-media files, identifies content with AI and metadata providers, enriches
-artwork, subtitles, trailers, and people data, and organizes your library —
-drop a folder and let it work.
+[MetaTana](https://metatana.com) turns messy movie, TV, and anime folders into
+a clean, complete media library.
+
+Add the media you own and MetaTana identifies each title, fixes names and
+metadata, adds artwork and player-ready metadata files, and shows you what
+still needs attention. It runs locally and works with Plex, Jellyfin, Emby,
+and Kodi.

--- a/ix-dev/community/metatana/app.yaml
+++ b/ix-dev/community/metatana/app.yaml
@@ -1,4 +1,4 @@
-app_version: 1.1.5
+app_version: 1.1.6
 capabilities: []
 categories:
 - media

--- a/ix-dev/community/metatana/app.yaml
+++ b/ix-dev/community/metatana/app.yaml
@@ -1,4 +1,4 @@
-app_version: 1.1.9
+app_version: 1.1.4
 capabilities: []
 categories:
 - media
@@ -37,4 +37,4 @@ sources:
 - https://metatana.com
 title: MetaTana
 train: community
-version: 1.0.2
+version: 1.0.1

--- a/ix-dev/community/metatana/app.yaml
+++ b/ix-dev/community/metatana/app.yaml
@@ -38,4 +38,4 @@ sources:
 - https://metatana.com
 title: MetaTana
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/metatana/app.yaml
+++ b/ix-dev/community/metatana/app.yaml
@@ -4,8 +4,7 @@ categories:
 - media
 changelog_url: https://metatana.com/changelog
 date_added: '2026-07-24'
-description: AI-powered media manager that identifies, enriches, and organizes your
-  media library.
+description: Clean up and complete your movie, TV, and anime library.
 home: https://metatana.com
 host_mounts: []
 icon: https://media.sys.truenas.net/apps/metatana/icons/icon.svg
@@ -38,4 +37,4 @@ sources:
 - https://metatana.com
 title: MetaTana
 train: community
-version: 1.0.2
+version: 1.0.3

--- a/ix-dev/community/metatana/app.yaml
+++ b/ix-dev/community/metatana/app.yaml
@@ -1,4 +1,4 @@
-app_version: 1.1.4
+app_version: 1.1.5
 capabilities: []
 categories:
 - media

--- a/ix-dev/community/metatana/app.yaml
+++ b/ix-dev/community/metatana/app.yaml
@@ -1,4 +1,4 @@
-app_version: 1.1.8
+app_version: 1.1.9
 capabilities: []
 categories:
 - media

--- a/ix-dev/community/metatana/app.yaml
+++ b/ix-dev/community/metatana/app.yaml
@@ -1,4 +1,4 @@
-app_version: 1.1.6
+app_version: 1.1.8
 capabilities: []
 categories:
 - media
@@ -37,4 +37,4 @@ sources:
 - https://metatana.com
 title: MetaTana
 train: community
-version: 1.0.3
+version: 1.0.2

--- a/ix-dev/community/metatana/ix_values.yaml
+++ b/ix-dev/community/metatana/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/metatana/metatana-app
-    tag: 1.1.4
+    tag: 1.1.5
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2

--- a/ix-dev/community/metatana/ix_values.yaml
+++ b/ix-dev/community/metatana/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/metatana/metatana-app
-    tag: 1.1.5
+    tag: 1.1.6
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2

--- a/ix-dev/community/metatana/ix_values.yaml
+++ b/ix-dev/community/metatana/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/metatana/metatana-app
-    tag: 1.1.8
+    tag: 1.1.9
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2

--- a/ix-dev/community/metatana/ix_values.yaml
+++ b/ix-dev/community/metatana/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/metatana/metatana-app
-    tag: 1.1.6
+    tag: 1.1.8
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2

--- a/ix-dev/community/metatana/ix_values.yaml
+++ b/ix-dev/community/metatana/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/metatana/metatana-app
-    tag: 1.1.9
+    tag: 1.1.4
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2

--- a/ix-dev/community/metatana/templates/docker-compose.yaml
+++ b/ix-dev/community/metatana/templates/docker-compose.yaml
@@ -12,6 +12,10 @@
 {% do c1.environment.add_env("NODE_ENV", "production") %}
 {% do c1.environment.add_env("MEDIA_DIRS", values.consts.media_path) %}
 {% do c1.environment.add_env("METATANA_DATA_DIR", values.consts.data_path) %}
+{# Lets MetaTana report that this install came from the TrueNAS catalog.
+   All the NAS catalogs run the same image on Linux, so the platform alone
+   cannot distinguish them. Descriptive only; no behaviour depends on it. #}
+{% do c1.environment.add_env("METATANA_INSTALL_CHANNEL", "truenas") %}
 {% do c1.environment.add_user_envs(values.metatana.additional_envs) %}
 
 {% do c1.add_port(values.network.web_port) %}

--- a/ix-dev/community/metatana/templates/docker-compose.yaml
+++ b/ix-dev/community/metatana/templates/docker-compose.yaml
@@ -12,9 +12,6 @@
 {% do c1.environment.add_env("NODE_ENV", "production") %}
 {% do c1.environment.add_env("MEDIA_DIRS", values.consts.media_path) %}
 {% do c1.environment.add_env("METATANA_DATA_DIR", values.consts.data_path) %}
-{# Lets MetaTana report that this install came from the TrueNAS catalog.
-   All the NAS catalogs run the same image on Linux, so the platform alone
-   cannot distinguish them. Descriptive only; no behaviour depends on it. #}
 {% do c1.environment.add_env("METATANA_INSTALL_CHANNEL", "truenas") %}
 {% do c1.environment.add_user_envs(values.metatana.additional_envs) %}
 


### PR DESCRIPTION
## What

- sets `METATANA_INSTALL_CHANNEL=truenas` without changing auth or runtime behaviour
- updates the MetaTana app pin to `1.1.6`
- replaces the vague AI-first description with a clear library-cleanup outcome
- refreshes the README and bumps catalog metadata to `1.0.3`

## Why

MetaTana turns messy movie, TV, and anime folders into a clean, complete media library. The new copy says that plainly and describes the local-first, reviewable workflow.

The install-channel value is descriptive attribution only. It remains separate from every variable that affects runtime security or authentication.

## Catalog artwork refresh

Please replace the existing CDN assets with these sources after [metatana/website#11](https://github.com/metatana/website/pull/11) is deployed:

- Icon: https://metatana.com/catalog/icon.svg
- Screenshot 1: https://metatana.com/catalog/screenshot-1-library.png
- Screenshot 2: https://metatana.com/catalog/screenshot-2-first-run.png
- Screenshot 3: https://metatana.com/catalog/screenshot-3-home.png
- Screenshot 4: https://metatana.com/catalog/screenshot-4-detail.png

The four screenshots are purpose-built 1600×900 catalog frames around real production-style MetaTana UI. The fixture uses original generated artwork and open/public-domain titles.

## Validation

- local YAML parse and exact metadata assertions passed
- `git diff --check` passed
- TrueNAS `ix-dev-validate` passed
- TrueNAS Docker Compose render/install passed

Follow-up to #5443.