### PR TITLE
Update PlainNVR to 0.1.2

### DIFF
--- a/ix-dev/community/plainnvr/app.yaml
+++ b/ix-dev/community/plainnvr/app.yaml
@@ -1,4 +1,4 @@
-app_version: 0.1.1
+app_version: 0.1.2
 capabilities: []
 categories:
 - security
@@ -32,4 +32,4 @@ sources:
 - https://github.com/endless1233214/plainnvr
 title: PlainNVR
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/plainnvr/ix_values.yaml
+++ b/ix-dev/community/plainnvr/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/endless1233214/plainnvr
-    tag: 0.1.1
+    tag: 0.1.2
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
## What changed

Updates the PlainNVR community app to PlainNVR 0.1.2.

- Bumps `app_version` from `0.1.1` to `0.1.2`
- Bumps the TrueNAS catalog version from `1.0.1` to `1.0.2`
- Updates the PlainNVR image tag to `ghcr.io/endless1233214/plainnvr:0.1.2`

## Why

PlainNVR 0.1.2 includes a web UI clipboard fallback for Home Assistant copy fields when the browser is using plain HTTP and `navigator.clipboard` is unavailable.

## Validation

- PlainNVR tests passed: `PYTHONPATH=. python3 -m unittest tests.test_server_features tests.test_onvif_client`
- PlainNVR image build passed for `0.1.2`: https://github.com/endless1233214/plainnvr/actions/runs/30509502375
