### PR TITLE
stdapi-ai: fix region test values

### DIFF
--- a/ix-dev/community/stdapi-ai/app.yaml
+++ b/ix-dev/community/stdapi-ai/app.yaml
@@ -37,4 +37,4 @@ sources:
 - https://github.com/stdapi-ai/stdapi.ai
 title: stdapi.ai
 train: community
-version: 1.0.15
+version: 1.0.16

--- a/ix-dev/community/stdapi-ai/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/stdapi-ai/templates/test_values/basic-values.yaml
@@ -8,7 +8,8 @@ TZ: Etc/UTC
 stdapi_ai:
   aws_access_key_id: test-access-key-id
   aws_secret_access_key: test-secret-access-key
-  aws_bedrock_regions: us-east-1
+  aws_bedrock_regions:
+    - us-east-1
   enable_docs: false
   additional_envs: []
 


### PR DESCRIPTION
# Pull Request

## Description

Fix the stdapi-ai test fixture to provide `aws_bedrock_regions` using the list shape declared by the app schema.

**Why:** The scalar value renders as invalid region entries and blocks catalog update checks containing stdapi-ai.

## Testing

- `uv run .github/scripts/ci.py --train community --app stdapi-ai --test-file basic-values.yaml --render-only true`
- `uv run .github/scripts/generate_metadata.py --train community --app stdapi-ai`
- `git diff --check`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*