### PR TITLE
yuvomi: update to 1.71.0

### DIFF
--- a/ix-dev/community/yuvomi/app.yaml
+++ b/ix-dev/community/yuvomi/app.yaml
@@ -1,4 +1,4 @@
-app_version: 1.45.1
+app_version: 1.71.0
 capabilities: []
 categories:
 - productivity
@@ -38,4 +38,4 @@ sources:
 - https://github.com/ulsklyc/yuvomi
 title: Yuvomi
 train: community
-version: 1.0.42
+version: 1.0.43

--- a/ix-dev/community/yuvomi/ix_values.yaml
+++ b/ix-dev/community/yuvomi/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/ulsklyc/yuvomi
-    tag: 1.45.1
+    tag: 1.71.0
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
## Description

Updates Yuvomi from `1.45.1` to `1.71.0` and increments the TrueNAS catalog app version from `1.0.42` to `1.0.43`.

## Rationale

Renovate PR #5462 already proposed Yuvomi `1.69.1`, and Yuvomi's app test passed there. However, that grouped PR is blocked by an unrelated vLLM ROCm test failure.

This focused PR updates Yuvomi to `1.71.0`, the latest upstream release available when this change was prepared.

## Validation

- [x] Confirmed the `1.71.0` image exists on GHCR
- [x] Confirmed Linux `amd64` and `arm64` images are available
- [x] Reviewed deployment compatibility with the existing TrueNAS configuration
- [x] Confirmed the `/health` endpoint and configurable `PORT` remain supported
- [x] YAML parsing passed
- [x] Port validation passed
- [x] `git diff --check` passed

## Scope

Only the Yuvomi files under `ix-dev/community/yuvomi/` are modified. No generated catalog files are included.

## AI

- [x] Part or all of this PR was generated with assistance from an LLM.