### PR TITLE
paperless-ngx update to 3.0.5

### DIFF
--- a/ix-dev/community/paperless-ngx/app.yaml
+++ b/ix-dev/community/paperless-ngx/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: 3.0.2
+app_version: 3.0.5
 capabilities:
 - description: Paperless is able to change file ownership arbitrarily
   name: CHOWN

--- a/ix-dev/community/paperless-ngx/ix_values.yaml
+++ b/ix-dev/community/paperless-ngx/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: paperlessngx/paperless-ngx
-    tag: "3.0.2"
+    tag: "3.0.5"
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
# App Update

Updating from paperless-ngx 3.0.2 to 3.0.5. There are no breaking changes between those two versions.