### PR TITLE
Bump seerr to v3.4.1

### DIFF
--- a/ix-dev/community/seerr/app.yaml
+++ b/ix-dev/community/seerr/app.yaml
@@ -1,4 +1,4 @@
-app_version: v3.3.0
+app_version: v3.4.1
 capabilities: []
 categories:
 - media
@@ -30,4 +30,4 @@ sources:
 - https://github.com/seerr-team/seerr
 title: Seerr
 train: community
-version: 1.0.10
+version: 1.0.11


### PR DESCRIPTION
## Description

Bumps the Seerr app definition to the latest upstream release, v3.4.1 (from v3.3.0).

This is a straight version bump only — no config/schema changes between these versions, so no migration script is needed.

## Motivation

v3.3.0 has a known bug where the "Sign in with Plex" popup closes immediately without completing authentication (see [seerr-team/seerr#2896](https://github.com/seerr-team/seerr/issues/2896), [#2897](https://github.com/seerr-team/seerr/issues/2897)). This has already been flagged in the batched Renovate PR #5462, but that PR is currently blocked on unrelated app failures (cloudbeaver, netbird-client, stdapi-ai, tailscale, vllm-rocm). Opening this standalone so the Seerr fix isn't held up by unrelated apps.

## Changes

- `app_version`: `v3.3.0` → `v3.4.1`
- `version`: `1.0.10` → `1.0.11`