### PR TITLE
Update bentopdf image security - security update

### DIFF
--- a/ix-dev/community/bentopdf/app.yaml
+++ b/ix-dev/community/bentopdf/app.yaml
@@ -1,4 +1,4 @@
-app_version: 2.8.6
+app_version: 2.8.7
 capabilities: []
 categories:
 - productivity
@@ -29,4 +29,4 @@ sources:
 - https://github.com/alam00000/bentopdf
 title: BentoPDF
 train: community
-version: 1.1.19
+version: 1.1.20

--- a/ix-dev/community/bentopdf/ix_values.yaml
+++ b/ix-dev/community/bentopdf/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/alam00000/bentopdf-simple
-    tag: 2.8.6
+    tag: 2.8.7
 
 consts:
   bentopdf_container_name: bentopdf


### PR DESCRIPTION
Updates to the newest [release](https://github.com/alam00000/bentopdf/releases/tag/v2.8.7) which includes CVE fixes.