### PR TITLE
n8n: update to 2.33.7

### DIFF
--- a/ix-dev/community/n8n/app.yaml
+++ b/ix-dev/community/n8n/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: 2.32.5
+app_version: 2.33.7
 capabilities: []
 categories:
 - productivity
@@ -52,4 +52,4 @@ sources:
 - https://github.com/n8n-io/n8n
 title: n8n
 train: community
-version: 1.10.92
+version: 1.10.93

--- a/ix-dev/community/n8n/ix_values.yaml
+++ b/ix-dev/community/n8n/ix_values.yaml
@@ -1,10 +1,10 @@
 images:
   image:
     repository: ghcr.io/n8n-io/n8n
-    tag: "2.32.5"
+    tag: "2.33.7"
   task_runner_image:
     repository: ghcr.io/n8n-io/runners
-    tag: "2.32.5"
+    tag: "2.33.7"
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
# App Addition

- [ ] I have opened an [issue](https://github.com/truenas/apps/issues) to discuss this app addition before submitting this pull request.

# AI

This PR was created with guidance from an AI assistant (Hermes Agent). No code was generated by the AI for this PR.

## Description

Updates n8n from 2.32.5 to 2.33.7.

Release notes: [Release n8n@2.33.7 · n8n-io/n8n · GitHub](https://github.com/n8n-io/n8n/releases/tag/n8n%402.33.7)

## App Information

ix_values.yaml: image.tag 2.32.5 → 2.33.7
ix_values.yaml: task_runner_image.tag 2.32.5 → 2.33.7
app.yaml: app_version 2.32.5 → 2.33.7
app.yaml: version 1.10.92 → 1.10.93

## Testing

Tested locally with:

Local tests could not run due to Python version mismatch (3.10 vs required 3.11+). CI will validate. Changes are version number bumps only — no logic changes.


## Checklist

- [ ] App runs successfully locally
- [ X ] Only modified files under /ix-dev/ or /library/
- [ ] README.md included
- [ ] Multiple test scenarios tested
- [ ] questions.yaml has clear descriptions and follows structure of existing apps
- [ ] All automated CI checks pass
