### PR TITLE
globalping: add extra caps

### DIFF
--- a/ix-dev/community/globalping-probe/app.yaml
+++ b/ix-dev/community/globalping-probe/app.yaml
@@ -1,5 +1,11 @@
 app_version: 0.50.1
 capabilities:
+- description: Globalping Probe is able to change file ownership arbitrarily
+  name: CHOWN
+- description: Globalping Probe is able to bypass file permission checks
+  name: DAC_OVERRIDE
+- description: Globalping Probe is able to bypass permission checks for file operations
+  name: FOWNER
 - description: Globalping Probe is able to use raw and packet sockets
   name: NET_RAW
 categories:
@@ -40,4 +46,4 @@ sources:
 - https://github.com/jsdelivr/globalping-probe
 title: Globalping Probe
 train: community
-version: 1.1.15
+version: 1.1.16

--- a/ix-dev/community/globalping-probe/templates/docker-compose.yaml
+++ b/ix-dev/community/globalping-probe/templates/docker-compose.yaml
@@ -3,7 +3,7 @@
 {% set c1 = tpl.add_container(values.consts.probe_container_name, "image") %}
 
 {# Add NET_RAW capability for ping/ICMP operations #}
-{% do c1.add_caps(["NET_RAW"]) %}
+{% do c1.add_caps(["NET_RAW", "CHOWN", "DAC_OVERRIDE", "FOWNER"]) %}
 
 {% if values.globalping.adoption_token %}
   {% do c1.environment.add_env("GP_ADOPTION_TOKEN", values.globalping.adoption_token) %}

--- a/ix-dev/community/globalping-probe/templates/test_values/bridge-values.yaml
+++ b/ix-dev/community/globalping-probe/templates/test_values/bridge-values.yaml
@@ -7,7 +7,6 @@ globalping:
   adoption_token: ""
   additional_envs: []
 
-
 network:
   host_network: false
 


### PR DESCRIPTION
Closes #5503 

entrypoint fetches a tar that needs to be able to extract as a specific user, which failed without these caps.