### PR TITLE
nocodb: bump

### DIFF
--- a/ix-dev/community/nocodb/app.yaml
+++ b/ix-dev/community/nocodb/app.yaml
@@ -1,4 +1,4 @@
-app_version: 0.301.5
+app_version: 2026.08.0
 capabilities: []
 categories:
 - productivity
@@ -45,4 +45,4 @@ sources:
 - https://nocodb.com/
 title: NocoDB
 train: community
-version: 1.2.28
+version: 1.2.29

--- a/ix-dev/community/nocodb/ix_values.yaml
+++ b/ix-dev/community/nocodb/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: nocodb/nocodb
-    tag: 0.301.5
+    tag: 2026.08.0
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Upstream switched from semver to calver and renovate was skipping the upgrade due to having > 500 major versions diff.