### PR TITLE
backrest: expose mount propagation for host path storage

### DIFF
--- a/ix-dev/community/backrest/app.yaml
+++ b/ix-dev/community/backrest/app.yaml
@@ -30,4 +30,4 @@ sources:
 - https://github.com/garethgeorge/backrest
 title: Backrest
 train: community
-version: 1.1.11
+version: 1.1.12

--- a/ix-dev/community/backrest/questions.yaml
+++ b/ix-dev/community/backrest/questions.yaml
@@ -524,6 +524,29 @@ questions:
                               type: hostpath
                               show_if: [["acl_enable", "=", false]]
                               required: true
+                          - variable: propagation
+                            label: Mount Propagation
+                            description: |
+                              Controls whether mount changes made on the host after the app starts
+                              are visible inside the container.</br>
+                              Private: Changes on the host are not propagated. (Default)</br>
+                              Slave: Mounts and unmounts performed on the host are propagated into
+                              the container. Use this when the host path is a ZFS dataset tree whose
+                              children are remounted while the app runs, such as a replication
+                              target. Without it, those datasets appear empty inside the container
+                              until the app is restarted.
+                            schema:
+                              type: string
+                              default: "rprivate"
+                              enum:
+                                - value: "rprivate"
+                                  description: Private (Recursive)
+                                - value: "rslave"
+                                  description: Slave (Recursive)
+                                - value: "private"
+                                  description: Private
+                                - value: "slave"
+                                  description: Slave
                     - variable: ix_volume_config
                       label: ixVolume Configuration
                       description: The configuration for the ixVolume dataset.

--- a/ix-dev/community/backrest/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/backrest/templates/test_values/basic-values.yaml
@@ -44,4 +44,5 @@ storage:
       host_path_config:
         path: /opt/tests/mnt/backrest/backup-source
         acl_enable: false
+        create_host_path: true
         propagation: rprivate

--- a/ix-dev/community/backrest/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/backrest/templates/test_values/basic-values.yaml
@@ -37,4 +37,11 @@ storage:
     ix_volume_config:
       dataset_name: cache
       create_host_path: true
-  additional_storage: []
+  additional_storage:
+    - type: host_path
+      mount_path: /mnt/backup-source
+      read_only: false
+      host_path_config:
+        path: /opt/tests/mnt/backrest/backup-source
+        acl_enable: false
+        propagation: rprivate


### PR DESCRIPTION
Closes #5556

Exposes mount propagation on Backrest's additional_storage host path config, so a host path can be mounted rslave and follow host mount changes.