### PR TITLE
Zammad: Use medium profile for the init container

### DIFF
--- a/ix-dev/community/zammad/app.yaml
+++ b/ix-dev/community/zammad/app.yaml
@@ -69,4 +69,4 @@ sources:
 - https://github.com/zammad/zammad-docker-compose/
 title: Zammad
 train: community
-version: 1.2.30
+version: 1.2.31

--- a/ix-dev/community/zammad/templates/docker-compose.yaml
+++ b/ix-dev/community/zammad/templates/docker-compose.yaml
@@ -100,7 +100,7 @@
 {% do websocket.healthcheck.set_test("tcp", {"port": values.consts.websocket_internal_port}) %}
 
 {% do init.set_command(["zammad-init"]) %}
-{% do init.setup_as_helper(disable_network=false) %}
+{% do init.setup_as_helper(profile="medium", disable_network=false) %}
 
 {% do nginx.set_command(["zammad-nginx"]) %}
 {% do nginx.healthcheck.set_test("curl", {"port": values.network.web_port.port_number}) %}


### PR DESCRIPTION
The Zammad init container currently uses `setup_as_helper()` with the default `low` profile, which limits the container to 1 CPU and 512 MiB RAM.

During the initial Zammad setup, the `Locale.sync` / `Translation.sync` operation runs a Ruby process which can exceed the 512 MiB limit, causing the init container to be killed by the memory cgroup with exit code 137.

Use the existing `medium` helper profile instead.

This changes the Zammad init container resources from:

- 1 CPU / 512 MiB

to:

- 2 CPU / 1 GiB

No other Zammad container resource limits are changed.