### PR TITLE
Zammad: Update to version 6.5.4

### DIFF
--- a/ix-dev/community/zammad/app.yaml
+++ b/ix-dev/community/zammad/app.yaml
@@ -1,4 +1,4 @@
-app_version: 6.5.2
+app_version: 6.5.4
 capabilities: []
 categories:
 - productivity
@@ -69,4 +69,4 @@ sources:
 - https://github.com/zammad/zammad-docker-compose/
 title: Zammad
 train: community
-version: 1.2.31
+version: 1.2.32

--- a/ix-dev/community/zammad/ix_values.yaml
+++ b/ix-dev/community/zammad/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/zammad/zammad
-    tag: 6.5.2-81
+    tag: 6.5.4
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2
@@ -17,7 +17,7 @@ images:
     tag: 1.6.45
   postgres_18_image:
     repository: postgres
-    tag: 18.4-trixie
+    tag: 18.6-trixie
   postgres_upgrade_image:
     repository: ixsystems/postgres-upgrade
     tag: 1.2.14


### PR DESCRIPTION
# Pull Request

Update Zammad from version 6.5.2 to 6.5.4 fixing some backwards implemented security issues.

Also update Postgres helper image from 18.4 to 18.6. which is available mainstream.