### PR TITLE
cinedock: home page is now cinedock.tv; update to 4.3.2

### DIFF
--- a/ix-dev/community/cinedock/README.md
+++ b/ix-dev/community/cinedock/README.md
@@ -1,5 +1,5 @@
 # CineDock
 
-[CineDock](https://github.com/cinedock/unraid-templates) gives Plex, Emby or Jellyfin an enhanced
+[CineDock](https://cinedock.tv) gives Plex, Emby or Jellyfin an enhanced
 browsing experience on the NVIDIA Shield TV, on an Amazon Fire TV Stick, or in a browser on your
 computer or tablet. It does not scan, copy or change media files.

--- a/ix-dev/community/cinedock/app.yaml
+++ b/ix-dev/community/cinedock/app.yaml
@@ -31,10 +31,9 @@ run_as_context:
   user_name: Host user is [apps]
 screenshots: []
 sources:
-- https://cinedock.tv
 - https://apps.truenas.com/catalog/cinedock_community/
 - https://github.com/cinedock/unraid-templates
-- https://hub.docker.com/r/getcinedock/cinedock
+- https://cinedock.tv
 title: CineDock
 train: community
 version: 1.0.1

--- a/ix-dev/community/cinedock/app.yaml
+++ b/ix-dev/community/cinedock/app.yaml
@@ -1,4 +1,4 @@
-app_version: 4.3.0
+app_version: 4.3.2
 capabilities: []
 categories:
 - media
@@ -6,7 +6,7 @@ changelog_url: https://github.com/cinedock/unraid-templates/blob/main/CHANGELOG.
 date_added: '2026-08-17'
 description: An enhanced, television-first browsing experience for the Emby, Jellyfin
   or Plex server you already run.
-home: https://github.com/cinedock/unraid-templates
+home: https://cinedock.tv
 host_mounts: []
 icon: https://media.sys.truenas.net/apps/cinedock/icons/icon.png
 keywords:
@@ -31,9 +31,10 @@ run_as_context:
   user_name: Host user is [apps]
 screenshots: []
 sources:
+- https://cinedock.tv
 - https://apps.truenas.com/catalog/cinedock_community/
 - https://github.com/cinedock/unraid-templates
 - https://hub.docker.com/r/getcinedock/cinedock
 title: CineDock
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/cinedock/ix_values.yaml
+++ b/ix-dev/community/cinedock/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/cinedock/cinedock
-    tag: 4.3.0
+    tag: 4.3.2
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Follow-up to #5572 (CineDock, community train).

- `home:` now points at the project website, https://cinedock.tv, instead of the Unraid templates repository (the site went live after the original submission was opened; the templates repo stays in `sources`).
- `sources:` adds https://cinedock.tv.
- App/image updated 4.3.0 -> 4.3.2 (`ghcr.io/cinedock/cinedock:4.3.2`, published multi-arch amd64/arm64). Changelog for 4.3.1/4.3.2 is at the existing `changelog_url`.
- Chart `version` 1.0.0 -> 1.0.1.

No changes to questions, templates or the library version.