### PR TITLE
cinedock: update to 4.3.3

### DIFF
--- a/ix-dev/community/cinedock/app.yaml
+++ b/ix-dev/community/cinedock/app.yaml
@@ -1,4 +1,4 @@
-app_version: 4.3.2
+app_version: 4.3.3
 capabilities: []
 categories:
 - media
@@ -36,4 +36,4 @@ sources:
 - https://cinedock.tv
 title: CineDock
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/cinedock/ix_values.yaml
+++ b/ix-dev/community/cinedock/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/cinedock/cinedock
-    tag: 4.3.2
+    tag: 4.3.3
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Bumps CineDock to 4.3.3 (app_version, image tag) and the chart version to 1.0.2.

4.3.3 is an interface compatibility release for Zidoo television players (no changes for other devices). Changelog: https://github.com/cinedock/unraid-templates/blob/main/CHANGELOG.md