### PR TITLE
sabnzbd: update to 5.1.1 (fixes critical auth bypass GHSA-xrfq-jhgh-wqch)

### DIFF
--- a/ix-dev/community/sabnzbd/app.yaml
+++ b/ix-dev/community/sabnzbd/app.yaml
@@ -1,6 +1,6 @@
 annotations:
   min_scale_version: 24.10.2.2
-app_version: 5.1.0
+app_version: 5.1.1
 capabilities: []
 categories:
 - media
@@ -37,4 +37,4 @@ sources:
 - https://sabnzbd.org/
 title: SABnzbd
 train: community
-version: 1.3.11
+version: 1.3.12

--- a/ix-dev/community/sabnzbd/ix_values.yaml
+++ b/ix-dev/community/sabnzbd/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/home-operations/sabnzbd
-    tag: 5.1.0
+    tag: 5.1.1
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
## Description

Bumps SABnzbd from `5.1.0` to `5.1.1` and the chart version from `1.3.11` to `1.3.12`.

This is the same change that is already contained in the renovate batch PR #5621, split out into its own PR so it can be reviewed and merged on its own without waiting for the rest of the batch.

## Why this should be merged quickly

SABnzbd 5.1.1 fixes a critical authentication bypass ([GHSA-xrfq-jhgh-wqch](https://github.com/sabnzbd/sabnzbd/security/advisories/GHSA-xrfq-jhgh-wqch), see also https://sabnzbd.org/auth-bypass).

On 5.1.0 and earlier, anyone who can reach the SABnzbd login page can obtain a valid session **even when a username and password are configured**. Users who expose the app beyond their local device are fully exposed: usenet server credentials, indexer API keys, the SABnzbd API key and notification credentials are all readable through the UI/API once a session is obtained.

Upstream release notes: https://github.com/sabnzbd/sabnzbd/releases/tag/5.1.1

## Changes

- `ix-dev/community/sabnzbd/app.yaml`: `app_version` 5.1.0 → 5.1.1, `version` 1.3.11 → 1.3.12
- `ix-dev/community/sabnzbd/ix_values.yaml`: image tag 5.1.0 → 5.1.1

No other files touched; no auto-generated files included.
