### PR TITLE
fix(woodpecker-ci): publish gRPC port

### DIFF
--- a/ix-dev/community/woodpecker-ci/app.yaml
+++ b/ix-dev/community/woodpecker-ci/app.yaml
@@ -45,4 +45,4 @@ sources:
 - https://woodpecker-ci.org
 title: Woodpecker CI
 train: community
-version: 1.2.30
+version: 1.2.31

--- a/ix-dev/community/woodpecker-ci/templates/docker-compose.yaml
+++ b/ix-dev/community/woodpecker-ci/templates/docker-compose.yaml
@@ -107,6 +107,7 @@
 {% endif %}
 
 {% do server.add_port(values.network.http_port) %}
+{% do server.add_port(values.network.grpc_port) %}
 
 {% for store in values.storage.additional_storage %}
   {% do agent.add_storage(store.mount_path, store) %}


### PR DESCRIPTION
# AI

- [x] Part or All of this PR was generated by an LLM.

## Description

Fixes the Woodpecker CI gRPC port configuration so that selecting
"Publish port on the host for external access" actually publishes the
configured gRPC port.

The app already configures:

`WOODPECKER_GRPC_ADDR=:<grpc_port>`

but the gRPC port was not added to the server container's published ports.

This adds the missing:

```jinja
{% do server.add_port(values.network.grpc_port) %}
```

Without this, the Woodpecker server listens on the configured gRPC port
inside the container, but the port is not exposed on the TrueNAS host.

For example, with:

- HTTP port: `30166`
- gRPC port: `30167`
- gRPC bind mode: `published`

the server container currently publishes the HTTP port but not the gRPC
port.

## Testing

Tested locally with:

- [x] `basic-values.yaml`
- [x] `https-values.yaml`
- [x] Runtime deployment using the generated Compose configuration

Verified that:

- HTTP and gRPC ports are both published with `basic-values.yaml`
- HTTP, gRPC and HTTPS ports are all published with `https-values.yaml`
- The rendered gRPC port matches `WOODPECKER_GRPC_ADDR`
- The deployed server container exposes both HTTP and gRPC ports on the host

All local render and runtime tests passed successfully.

## Checklist

- [x] Only modified files under `/ix-dev/` or `/library/`
- [x] Multiple test scenarios tested
- [ ] All automated CI checks pass