### PR TITLE
fix(home-assistant): serve on fixed internal 8123 and map published port to it

### DIFF
--- a/ix-dev/stable/home-assistant/app.yaml
+++ b/ix-dev/stable/home-assistant/app.yaml
@@ -49,4 +49,4 @@ sources:
 - https://github.com/home-assistant/home-assistant
 title: Home Assistant
 train: stable
-version: 1.8.54
+version: 1.8.55

--- a/ix-dev/stable/home-assistant/ix_values.yaml
+++ b/ix-dev/stable/home-assistant/ix_values.yaml
@@ -26,3 +26,6 @@ consts:
   config_path: /config
   ssl_key_path: /ssl/key.pem
   ssl_cert_path: /ssl/cert.pem
+  # Home Assistant always listens on 8123 internally. The published host port is
+  # mapped to this, instead of reconfiguring HA's server_port (see config.sh.jinja).
+  web_port: 8123

--- a/ix-dev/stable/home-assistant/templates/docker-compose.yaml
+++ b/ix-dev/stable/home-assistant/templates/docker-compose.yaml
@@ -50,10 +50,10 @@
 {% endif %}
 
 {% set proto = "https" if values.network.certificate_id else "http" %}
-{% do c1.healthcheck.set_test("wget", {"port": values.network.web_port.port_number, "path": "/manifest.json", "scheme": proto, "spider": false}) %}
+{% do c1.healthcheck.set_test("wget", {"port": values.consts.web_port, "path": "/manifest.json", "scheme": proto, "spider": false}) %}
 {% do c1.environment.add_user_envs(values.home_assistant.additional_envs) %}
 
-{% do c1.add_port(values.network.web_port) %}
+{% do c1.add_port(values.network.web_port, {"container_port": values.consts.web_port}) %}
 {% for port in values.network.additional_ports %}
   {% do c1.add_port(port) %}
 {% endfor %}

--- a/ix-dev/stable/home-assistant/templates/macros/config.sh.jinja
+++ b/ix-dev/stable/home-assistant/templates/macros/config.sh.jinja
@@ -29,9 +29,6 @@ if ! yq --exit-status '.http' < "{{ config_file }}" &> /dev/null; then
   yq -i '.http = {}' "{{ config_file }}"
 fi
 
-echo "Matching server port to configured port [{{ values.network.web_port.port_number }}] in [{{ config_file }}]"
-yq -i '.http.server_port = {{ values.network.web_port.port_number }}' "{{ config_file }}"
-
 {%- if values.network.certificate_id %}
 echo "Setting up ssl paths [{{ values.consts.ssl_key_path }}] and [{{ values.consts.ssl_cert_path }}] in [{{ config_file }}]"
 yq -i '.http.ssl_key = "{{ values.consts.ssl_key_path }}"' "{{ config_file }}"


### PR DESCRIPTION
## Summary

Fixes #5645.

Home Assistant is unreachable and stays `unhealthy` when deployed on any WebUI port other than the container default `8123`.

The chart currently rewrites HA's `http.server_port` in `configuration.yaml` to the chosen host port, maps `host_port -> host_port`, and healthchecks `host_port`. But recent Home Assistant stages every `http` config change as **pending** and only promotes it once the new endpoint is confirmed reachable. On a headless TrueNAS deploy that confirmation never happens, so HA keeps listening on the **stable** default `8123` while nothing listens on the published port. Result: "Unable to connect" + failing healthcheck. (The same unpromoted-pending path is behind the "Pending HTTP config was not confirmed ... exit code 100" first-boot timeout.)

## Fix

Adopt the "fixed internal port" convention already used by ~118 apps in this catalog: keep HA on `8123` and map the published port to it.

- `ix_values.yaml`: add `consts.web_port: 8123`.
- `templates/docker-compose.yaml`: `add_port(values.network.web_port, {"container_port": values.consts.web_port})`; healthcheck `port: values.consts.web_port`.
- `templates/macros/config.sh.jinja`: remove the `http.server_port` rewrite (the pending-config trigger).
- `app.yaml`: version bump `1.8.54 -> 1.8.55`.

Portal and healthcheck scheme (proto based on `certificate_id`) are unchanged; the portal still advertises the published host port, which is correct.

## Evidence

Clean stock install, port `30103`, no cert:

```text
docker ps          -> 0.0.0.0:30103->30103/tcp  Up (unhealthy)
ss -tlnp           -> HA LISTENs on 8123, not 30103
configuration.yaml -> http.server_port: 30103   (written, but ignored)
.storage/http      -> stable=8123, pending=30103 "error": "not_promoted"
wget 127.0.0.1:8123/manifest.json -> 200 OK
```

## Testing

Relying on `app-test-suite` CI to render + boot the app.

## Note (out of scope)

The built-in certificate/TLS option drives HA TLS through the same `configuration.yaml` -> pending path, so it shares the deadlock. Recommend terminating TLS at a reverse proxy; can be handled in a follow-up.
