### PR TITLE
home-assistant: fix port/ssl / deprecates HA app

### DIFF
--- a/ix-dev/stable/home-assistant/app.yaml
+++ b/ix-dev/stable/home-assistant/app.yaml
@@ -49,4 +49,4 @@ sources:
 - https://github.com/home-assistant/home-assistant
 title: Home Assistant
 train: stable
-version: 1.8.55
+version: 1.8.56

--- a/ix-dev/stable/home-assistant/app.yaml
+++ b/ix-dev/stable/home-assistant/app.yaml
@@ -47,6 +47,6 @@ screenshots:
 sources:
 - https://apps.truenas.com/catalog/home-assistant_stable/
 - https://github.com/home-assistant/home-assistant
-title: Home Assistant
+title: Home Assistant (Deprecated)
 train: stable
 version: 1.8.56

--- a/ix-dev/stable/home-assistant/deprecations.yaml
+++ b/ix-dev/stable/home-assistant/deprecations.yaml
@@ -1,0 +1,19 @@
+- scope: "full"
+
+  deprecated_date: "2026-08-26"
+  removal_date: "2026-11-26"
+  reason: >-
+    This app is deprecated and will be removed in a future release.
+    Run Home Assistant OS in a VM instead: it gets direct access to the host network,
+    so mDNS/zeroconf, DHCP, SSDP/UPnP, Bluetooth, HomeKit and Thread/Matter discovery all work,
+    and it can run the add-on ecosystem (ESPHome, Zigbee2MQTT, Mosquitto, Node-RED)
+    along with Supervisor-managed updates and backups.
+    USB radios such as Zigbee and Z-Wave sticks can be passed through to the VM.
+    Use the KVM (.qcow2) image from https://www.home-assistant.io/installation/linux
+    and move your existing setup across by creating a full backup here first, then restoring it
+    during onboarding: https://www.home-assistant.io/common-tasks/general/#restoring-a-backup.
+    Home Assistant's backup only covers its configuration directory. This app's PostgreSQL
+    database, where history and long-term statistics live, is not included in it and goes away
+    with the app. Home Assistant OS uses SQLite for the recorder (by default), so if you want to keep that
+    history, migrate the database before removing this app:
+    https://community.home-assistant.io/t/postgresql-to-sqlite-migration-moving-back-to-sqlite/764151

--- a/ix-dev/stable/home-assistant/templates/docker-compose.yaml
+++ b/ix-dev/stable/home-assistant/templates/docker-compose.yaml
@@ -51,6 +51,11 @@
 
 {% set proto = "https" if values.network.certificate_id else "http" %}
 {% do c1.healthcheck.set_test("wget", {"port": values.network.web_port.port_number, "path": "/manifest.json", "scheme": proto, "spider": false}) %}
+{# Home Assistant stages an imported [http] YAML block as a *pending* config when it
+   differs from the built-in defaults, then auto-reverts it 5 minutes in if nobody
+   confirms. [SETUP_PORT] moves the port into those defaults, so a fresh install
+   imports straight to [stable] with no trial. #}
+{% do c1.environment.add_env("SETUP_PORT", values.network.web_port.port_number) %}
 {% do c1.environment.add_user_envs(values.home_assistant.additional_envs) %}
 
 {% do c1.add_port(values.network.web_port) %}

--- a/ix-dev/stable/home-assistant/templates/docker-compose.yaml
+++ b/ix-dev/stable/home-assistant/templates/docker-compose.yaml
@@ -2,6 +2,23 @@
 {% from "macros/config.sh.jinja" import config_script %}
 {% set tpl = ix_lib.base.render.Render(values) %}
 
+{% do tpl.notes.add_deprecation(
+  "This app is deprecated and will be removed in a future release. "
+  "Run Home Assistant OS in a VM instead: it gets direct access to the host network, "
+  "so mDNS/zeroconf, DHCP, SSDP/UPnP, Bluetooth, HomeKit and Thread/Matter discovery all work, "
+  "and it can run the add-on ecosystem (ESPHome, Zigbee2MQTT, Mosquitto, Node-RED) "
+  "along with Supervisor-managed updates and backups. "
+  "USB radios such as Zigbee and Z-Wave sticks can be passed through to the VM. "
+  "Use the KVM (.qcow2) image from https://www.home-assistant.io/installation/linux "
+  "and move your existing setup across by creating a full backup here first, then restoring it "
+  "during onboarding: https://www.home-assistant.io/common-tasks/general/#restoring-a-backup. "
+  "Home Assistant's backup only covers its configuration directory. This app's PostgreSQL database, "
+  "where history and long-term statistics live, is not included in it and goes away with the app. "
+  "Home Assistant OS uses SQLite for the recorder (by default), so if you want to keep that history, "
+  "migrate the database before removing this app: "
+  "https://community.home-assistant.io/t/postgresql-to-sqlite-migration-moving-back-to-sqlite/764151"
+) %}
+
 {# {% if values.home_assistant.postgres_image_selector == "postgres_17_image" %}
   {% do tpl.notes.add_deprecation("Postgres 17 is deprecated and will be removed in the near future. Please upgrade.") %}
 {% endif %} #}

--- a/ix-dev/stable/home-assistant/templates/macros/config.sh.jinja
+++ b/ix-dev/stable/home-assistant/templates/macros/config.sh.jinja
@@ -1,7 +1,9 @@
 {% macro config_script(values, db_url) -%}
 {%- set config_file = "%s/configuration.yaml"|format(values.consts.config_path) %}
+{%- set store_file = "%s/.storage/http"|format(values.consts.config_path) %}
 {%- set default_files_path = "/default/init" %}
 {%- set extra_files_to_create = ["automations.yaml", "scripts.yaml", "scenes.yaml"] %}
+{%- set web_port = values.network.web_port.port_number %}
 #!/bin/sh
 if [ ! -f "{{ config_file }}" ]; then
   echo "File [{{ config_file }}] does NOT exist. Creating..."
@@ -24,19 +26,66 @@ fi
 echo "Ensure DB URL is up to date [{{ db_url }}] in [{{ config_file }}]"
 yq -i '.recorder.db_url = "{{ db_url }}"' "{{ config_file }}"
 
-if ! yq --exit-status '.http' < "{{ config_file }}" &> /dev/null; then
-  echo "Section [http] does NOT exist in [{{ config_file }}]. Appending..."
-  yq -i '.http = {}' "{{ config_file }}"
+# Home Assistant 2026.8 moved the [http] config out of [{{ config_file }}] and into
+# [{{ store_file }}]. The YAML block is imported into that store exactly once, and is
+# ignored on every start after that, so which file we have to write depends on whether
+# that import has already happened. [yaml_migration_done] is the flag Home Assistant
+# sets once it has; it is absent on the pre-2026.8 store, which is a flat config dict.
+http_migrated="false"
+if [ -f "{{ store_file }}" ]; then
+  http_migrated="$(yq -p=json -o=json -I=0 '.data.yaml_migration_done // false' "{{ store_file }}" 2>/dev/null)"
 fi
 
-echo "Matching server port to configured port [{{ values.network.web_port.port_number }}] in [{{ config_file }}]"
-yq -i '.http.server_port = {{ values.network.web_port.port_number }}' "{{ config_file }}"
+if [ "$http_migrated" != "true" ]; then
+  echo "HTTP config not migrated yet. Writing [http] to [{{ config_file }}] for Home Assistant to import"
+  if ! yq --exit-status '.http' < "{{ config_file }}" &> /dev/null; then
+    echo "Section [http] does NOT exist in [{{ config_file }}]. Appending..."
+    yq -i '.http = {}' "{{ config_file }}"
+  fi
 
-{%- if values.network.certificate_id %}
-echo "Setting up ssl paths [{{ values.consts.ssl_key_path }}] and [{{ values.consts.ssl_cert_path }}] in [{{ config_file }}]"
-yq -i '.http.ssl_key = "{{ values.consts.ssl_key_path }}"' "{{ config_file }}"
-yq -i '.http.ssl_certificate = "{{ values.consts.ssl_cert_path }}"' "{{ config_file }}"
-{%- endif %}
+  echo "Matching server port to configured port [{{ web_port }}] in [{{ config_file }}]"
+  yq -i '.http.server_port = {{ web_port }}' "{{ config_file }}"
+
+  {%- if values.network.certificate_id %}
+  echo "Setting up ssl paths [{{ values.consts.ssl_key_path }}] and [{{ values.consts.ssl_cert_path }}] in [{{ config_file }}]"
+  yq -i '.http.ssl_key = "{{ values.consts.ssl_key_path }}"' "{{ config_file }}"
+  yq -i '.http.ssl_certificate = "{{ values.consts.ssl_cert_path }}"' "{{ config_file }}"
+  {%- else %}
+  echo "No certificate configured. Removing ssl paths from [{{ config_file }}]"
+  yq -i 'del(.http.ssl_key, .http.ssl_certificate)' "{{ config_file }}"
+  {%- endif %}
+else
+  echo "HTTP config lives in [{{ store_file }}]. Patching the fields this app owns"
+
+  # [stable] is the last config the user confirmed as working. [pending] is an
+  # unconfirmed one awaiting promotion; Home Assistant prefers it on the next start
+  # unless it already failed a trial, in which case [error] is set and it is never
+  # applied again. Patch both live slots so the app's settings win either way, and
+  # touch nothing else in them so anything the user staged in the UI survives.
+  # A [pending] left identical to [stable] is deliberately kept rather than cleared:
+  # Home Assistant loads it, starts its 5 minute trial, and restarts once to revert it
+  # when nobody confirms. That is preferred over this script deleting a slot the user owns.
+  echo "Matching server port to configured port [{{ web_port }}] in [{{ store_file }}]"
+  yq -p=json -o=json -i '.data.stable.server_port = {{ web_port }}' "{{ store_file }}"
+  yq -p=json -o=json -i '(.data.pending | select(. != null and .error == null)).server_port = {{ web_port }}' "{{ store_file }}"
+
+  {%- if values.network.certificate_id %}
+  echo "Setting up ssl paths [{{ values.consts.ssl_key_path }}] and [{{ values.consts.ssl_cert_path }}] in [{{ store_file }}]"
+  yq -p=json -o=json -i '.data.stable.ssl_certificate = "{{ values.consts.ssl_cert_path }}" | .data.stable.ssl_key = "{{ values.consts.ssl_key_path }}"' "{{ store_file }}"
+  yq -p=json -o=json -i '(.data.pending | select(. != null and .error == null)).ssl_certificate = "{{ values.consts.ssl_cert_path }}"' "{{ store_file }}"
+  yq -p=json -o=json -i '(.data.pending | select(. != null and .error == null)).ssl_key = "{{ values.consts.ssl_key_path }}"' "{{ store_file }}"
+  {%- else %}
+  echo "No certificate configured. Removing ssl paths from [{{ store_file }}]"
+  yq -p=json -o=json -i 'del(.data.stable.ssl_certificate, .data.stable.ssl_key)' "{{ store_file }}"
+  yq -p=json -o=json -i '(.data.pending | select(. != null and .error == null)) |= del(.ssl_certificate, .ssl_key)' "{{ store_file }}"
+  {%- endif %}
+
+  # The [http] block is ignored from here on and only raises a repair issue.
+  if yq --exit-status '.http' < "{{ config_file }}" &> /dev/null; then
+    echo "Section [http] in [{{ config_file }}] is ignored after migration. Removing..."
+    yq -i 'del(.http)' "{{ config_file }}"
+  fi
+fi
 
 echo "Done"
 {%- endmacro %}


### PR DESCRIPTION
Supersedes #5646
Closes #5645

Additionally deprecates HA app, as it is much more usable as a VM (HA OS).