### PR TITLE
forgejo-runner: allow disabling the docker sock mount

### DIFF
--- a/ix-dev/community/forgejo-runner/app.yaml
+++ b/ix-dev/community/forgejo-runner/app.yaml
@@ -34,4 +34,4 @@ sources:
 - https://forgejo.org/docs/latest/admin/actions/runner-installation/
 title: Forgejo Runner
 train: community
-version: 2.0.18
+version: 2.0.19

--- a/ix-dev/community/forgejo-runner/questions.yaml
+++ b/ix-dev/community/forgejo-runner/questions.yaml
@@ -65,6 +65,12 @@ questions:
                 schema:
                   type: string
                   required: true
+        - variable: mount_docker_socket
+          label: Mount Docker Socket
+          description: Mount the Docker Socket into the container.
+          schema:
+            type: boolean
+            default: true
         - variable: additional_envs
           label: Additional Environment Variables
           schema:
@@ -198,7 +204,8 @@ questions:
                                           "null": true
                                       - variable: priority
                                         label: Priority (Optional)
-                                        description: Indicates in which order Compose connects the service's containers
+                                        description:
+                                          Indicates in which order Compose connects the service's containers
                                           to its networks.
                                         schema:
                                           type: int

--- a/ix-dev/community/forgejo-runner/templates/docker-compose.yaml
+++ b/ix-dev/community/forgejo-runner/templates/docker-compose.yaml
@@ -32,7 +32,9 @@
   {% do c1.add_port(port) %}
 {% endfor %}
 
-{% do c1.add_docker_socket(read_only=False) %}
+{% if values.forgejo_runner.mount_docker_socket %}
+  {% do c1.add_docker_socket(read_only=False) %}
+{% endif %}
 
 {% do c1.add_storage("/data", values.storage.data) %}
 {% do init.add_storage("/data", values.storage.data) %}

--- a/ix-dev/community/forgejo-runner/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/forgejo-runner/templates/test_values/basic-values.yaml
@@ -8,6 +8,7 @@ forgejo_runner:
   runner_uuid: c9e50be9-a7c3-4aee-ba35-624c4ff8c519
   runner_registration_token: 6634bb58be0db23cc013a2e72dd1828ae0257cf
   runner_labels: []
+  mount_docker_socket: true
   additional_envs: []
 
 run_as:


### PR DESCRIPTION
Closes #5683

Failure is expected, as it needs a real forgejo host to connect.