### PR TITLE
Fix broken icon URLs for clonarr and anki-sync-server

### DIFF
--- a/ix-dev/community/anki-sync-server/app.yaml
+++ b/ix-dev/community/anki-sync-server/app.yaml
@@ -35,4 +35,4 @@ sources:
 - https://github.com/chrislongros/anki-sync-server-enhanced
 title: Anki Sync Server
 train: community
-version: 1.1.8
+version: 1.1.9

--- a/ix-dev/community/anki-sync-server/app.yaml
+++ b/ix-dev/community/anki-sync-server/app.yaml
@@ -8,7 +8,7 @@ description: Self-hosted Anki sync server with multi-user support, automated bac
   and monitoring. Built from official Anki source.
 home: https://github.com/chrislongros/anki-sync-server-enhanced
 host_mounts: []
-icon: https://media.sys.truenas.net/apps/ix-app/icons/icon.webp
+icon: https://media.sys.truenas.net/apps/anki-sync-server/icons/icon.svg
 keywords:
 - anki
 - sync

--- a/ix-dev/community/anki-sync-server/item.yaml
+++ b/ix-dev/community/anki-sync-server/item.yaml
@@ -1,6 +1,6 @@
 categories:
 - productivity
-icon_url: https://media.sys.truenas.net/apps/anki-sync-server/icons/icon.png
+icon_url: https://media.sys.truenas.net/apps/ix-app/icons/icon.webp
 screenshots: []
 tags:
 - anki

--- a/ix-dev/community/anki-sync-server/item.yaml
+++ b/ix-dev/community/anki-sync-server/item.yaml
@@ -1,6 +1,6 @@
 categories:
 - productivity
-icon_url: https://media.sys.truenas.net/apps/ix-app/icons/icon.webp
+icon_url: https://media.sys.truenas.net/apps/anki-sync-server/icons/icon.svg
 screenshots: []
 tags:
 - anki

--- a/ix-dev/community/clonarr/app.yaml
+++ b/ix-dev/community/clonarr/app.yaml
@@ -14,7 +14,7 @@ description: Sync, build and manage quality profiles and custom formats for Rada
   and Sonarr - powered by TRaSH Guides.
 home: https://github.com/ProphetSe7en/clonarr
 host_mounts: []
-icon: https://media.sys.truenas.net/apps/clonarr/icons/icon.svg
+icon: https://media.sys.truenas.net/apps/clonarr/icons/icon.png
 keywords:
 - sync
 - sonarr
@@ -38,4 +38,4 @@ sources:
 - https://github.com/ProphetSe7en/clonarr
 title: Clonarr
 train: community
-version: 1.0.7
+version: 1.0.8

--- a/ix-dev/community/clonarr/item.yaml
+++ b/ix-dev/community/clonarr/item.yaml
@@ -1,6 +1,6 @@
 categories:
 - media
-icon_url: https://media.sys.truenas.net/apps/clonarr/icons/icon.svg
+icon_url: https://media.sys.truenas.net/apps/clonarr/icons/icon.png
 screenshots: []
 tags:
 - sync


### PR DESCRIPTION
## Description

Two community-train apps reference icon URLs that return 404, so they render a broken image / placeholder in catalog UIs. Both are metadata-only fixes — no CDN upload needed for either.

### clonarr

The icon **is** on the CDN, just under a different extension than the metadata claims:

| URL | Status |
|---|---|
| `https://media.sys.truenas.net/apps/clonarr/icons/icon.svg` (referenced) | 404 |
| `https://media.sys.truenas.net/apps/clonarr/icons/icon.png` (actual) | 200, valid 256x256 PNG |

Changed `.svg` -> `.png` in both `app.yaml` (`icon`) and `item.yaml` (`icon_url`).

### anki-sync-server

`app.yaml` and `item.yaml` disagree:

- `app.yaml` -> `apps/ix-app/icons/icon.webp` (the generic placeholder, 200)
- `item.yaml` -> `apps/anki-sync-server/icons/icon.png` (404 — never uploaded)

Since `catalog.json` takes `icon_url` from `item.yaml`, consumers reading the catalog get the 404 while `app.yaml` looks fine. Pointed `item.yaml` at the same placeholder so the two agree.

**Happy to drop this hunk** if you'd rather upload a real Anki icon instead — that's clearly the better outcome. Upstream has a vector logo at [`ankitects/anki` `docs-site/media/anki-logo.svg`](https://github.com/ankitects/anki/blob/main/docs-site/media/anki-logo.svg), and I can attach it here on request.

## Testing

Verified every extension variant (`.png`, `.svg`, `.webp`, `.jpg`, `.jpeg`, `.ico`, `.gif`) against the CDN for both apps: `clonarr/icons/icon.png` is the only one that resolves for clonarr, and nothing resolves under `anki-sync-server/`.

Bumped `version` on both apps per the "Increment on Every Change" guidance in CONTRIBUTIONS.md (clonarr 1.0.7 -> 1.0.8, anki-sync-server 1.1.8 -> 1.1.9).

## Checklist

- [x] Only files under `/ix-dev/` are modified
- [x] No auto-generated files are included in the PR
- [x] `version` bumped on every modified app

## Related

Three more community apps have `icon_url`s that 404, but those need an actual CDN upload rather than a metadata change, so they aren't in this PR: `swiparr`, `netbird-server`, `travelbuff`. I'll open a separate issue with source images attached.