### PR TITLE
fix(stdapi-ai): correct the listing description and README

### DIFF
--- a/ix-dev/community/stdapi-ai/README.md
+++ b/ix-dev/community/stdapi-ai/README.md
@@ -1,4 +1,4 @@
 # stdapi.ai
 
-[stdapi.ai](https://stdapi.ai) is an OpenAI and Anthropic compatible API gateway for AWS Bedrock.
-Access 80+ models including Claude, Nova, Deepseek, Mistral, and Minimax with enterprise compliance and pay-per-use pricing.
+[stdapi.ai](https://stdapi.ai) is an OpenAI and Anthropic compatible API gateway for Amazon Bedrock, running in your own AWS account.
+Not just chat: images, speech, embeddings, rerank and batch.

--- a/ix-dev/community/stdapi-ai/app.yaml
+++ b/ix-dev/community/stdapi-ai/app.yaml
@@ -4,9 +4,9 @@ categories:
 - ai
 changelog_url: https://stdapi.ai/roadmap/#release-history
 date_added: '2026-03-24'
-description: OpenAI and Anthropic compatible API gateway for AWS Bedrock. Access 80+
-  models including Claude, Nova, Deepseek, Mistral, and Minimax with enterprise compliance
-  and pay-per-use pricing.
+description: 'OpenAI and Anthropic compatible API gateway for Amazon Bedrock, in your
+  own AWS account. Not just chat: images, speech, embeddings, rerank and batch. Also
+  fronts Amazon Polly, Transcribe and Comprehend.'
 home: https://stdapi.ai
 host_mounts: []
 icon: https://media.sys.truenas.net/apps/stdapi-ai/icons/icon.svg
@@ -37,4 +37,4 @@ sources:
 - https://github.com/stdapi-ai/stdapi.ai
 title: stdapi.ai
 train: community
-version: 1.0.18
+version: 1.0.19


### PR DESCRIPTION
The catalogue text overstated and misdescribed the app:

- "80+ models" is stale. The gateway now fronts 100+ models from 20+ providers.
- "enterprise compliance" implies certifications the project does not hold.
- "pay-per-use pricing" is wrong for this listing. The image published here is the AGPL-3.0 community build, which costs nothing. AWS bills the user directly for model usage, with no markup.

Also name the other AWS services the gateway fronts (Polly, Transcribe, Comprehend) and the Cohere protocol, and mention the non-chat endpoints, so the card reflects what a reader actually gets.

Bump version 1.0.18 to 1.0.19 for the metadata change, and tag the two outbound stdapi.ai links so the maintainer can measure how much traffic this listing sends. changelog_url and sources are left untagged.