### PR TITLE
renovate: stop fetching changelogs for minor/patch

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -388,6 +388,13 @@ module.exports = {
       "^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$",
       ["ghcr.io/zammad/zammad"],
     ),
+    customVersioning(
+      // 4.5.6 or 4.5.3.2, each with an optional "-full" variant.
+      // The variant is captured as "compatibility" so a plain pin never
+      // jumps to a -full tag. The ubuntu-* tags are intentionally skipped.
+      "^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<build>\\d+))?(-(?<compatibility>full))?$",
+      ["nicolargo/glances"],
+    ),
   ],
 };
 

--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -12,17 +12,15 @@ module.exports = {
   platform: "github",
   // https://docs.renovatebot.com/self-hosted-configuration/#repositories
   repositories: ["truenas/apps"],
-  // https://docs.renovatebot.com/self-hosted-configuration/#allowpostupgradecommandtemplating
-  allowPostUpgradeCommandTemplating: true,
-  // https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands
+  // https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands
   // TODO: Restrict this.
-  allowedPostUpgradeCommands: ["^.*"],
+  allowedCommands: ["^.*"],
   enabledManagers: ["custom.regex", "github-actions"],
   customManagers: [
     {
       customType: "regex",
       // Match only ix_values.yaml files in the ix-dev directory
-      fileMatch: ["^ix-dev/.*/ix_values\\.yaml$"],
+      managerFilePatterns: ["/^ix-dev/.*/ix_values\\.yaml$/"],
       // Matches the repository name and the tag of each image
       matchStrings: [
         "\\s{4}repository: (?<depName>[^\\s]+)\\n\\s{4}tag: [\"']?(?<currentValue>[^\\s\"']+)[\"']?",
@@ -65,12 +63,18 @@ module.exports = {
       matchUpdateTypes: ["minor"],
       groupName: "updates-patch-minor",
       labels: ["minor"],
+      // Assembling the changelogs for this group stalls renovate for ~60s,
+      // long enough for the pooled connection to api.github.com to go stale,
+      // which makes the POST /pulls that follows fail with EPIPE/ECONNRESET.
+      // https://docs.renovatebot.com/configuration-options/#fetchchangelogs
+      fetchChangeLogs: "off",
     },
     {
       matchDatasources: ["docker"],
       matchUpdateTypes: ["patch"],
       groupName: "updates-patch-minor",
       labels: ["patch"],
+      fetchChangeLogs: "off",
     },
     {
       matchDatasources: ["docker"],


### PR DESCRIPTION
1. Migrates configuration to fix some deprecations I found while I reviewing logs
2. Stops changelog fetching on minor/patch versions of non-enterprise apps, this was making Renovate stall for 1-5minutes pulling LARGE amounts of changelogs, which resulted in GH api connection to drop, so it failed to automatically create PRs afterwards.