### PR TITLE
arcane: update to v2.10.1

### DIFF
--- a/ix-dev/community/arcane/app.yaml
+++ b/ix-dev/community/arcane/app.yaml
@@ -1,4 +1,4 @@
-app_version: v2.10.0
+app_version: v2.10.1
 capabilities: []
 categories:
 - management
@@ -33,4 +33,4 @@ sources:
 - https://github.com/getarcaneapp/arcane
 title: Arcane
 train: community
-version: 1.0.86
+version: 1.0.87

--- a/ix-dev/community/arcane/ix_values.yaml
+++ b/ix-dev/community/arcane/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/getarcaneapp/manager
-    tag: v2.10.0
+    tag: v2.10.1
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Bumps arcane (community) v2.10.0 -> v2.10.1, catalog version 1.0.86 -> 1.0.87.

Patch release: compact browser session cookies (replaces the large ML-DSA access JWT that could exceed cookie size limits), sidebar display-name fix, dependency updates.

Release notes: https://github.com/getarcaneapp/arcane/releases/tag/v2.10.1