### PR TITLE
fix(community): correct CineFind Bridge icon

### DIFF
--- a/ix-dev/community/cinefind-bridge/app.yaml
+++ b/ix-dev/community/cinefind-bridge/app.yaml
@@ -8,7 +8,7 @@ description: Securely sends CineFind movie and series discoveries to private See
   Radarr or Sonarr servers.
 home: https://cinefindpro.com
 host_mounts: []
-icon: https://media.sys.truenas.net/apps/cinefind-bridge/icons/icon.svg
+icon: https://raw.githubusercontent.com/sasray/cinefind-bridge/54a17abcb8b81e99d1845d54edcaa3294a1b7e50/assets/icon.svg
 keywords:
 - cinefind
 - seerr
@@ -35,4 +35,4 @@ sources:
 - https://github.com/sasray/cinefind-bridge
 title: CineFind Bridge
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/cinefind-bridge/item.yaml
+++ b/ix-dev/community/cinefind-bridge/item.yaml
@@ -1,6 +1,6 @@
 categories:
 - media
-icon_url: https://media.sys.truenas.net/apps/cinefind-bridge/icons/icon.svg
+icon_url: https://raw.githubusercontent.com/sasray/cinefind-bridge/54a17abcb8b81e99d1845d54edcaa3294a1b7e50/assets/icon.svg
 screenshots: []
 tags:
 - cinefind


### PR DESCRIPTION
## Description

The CineFind Bridge catalog entry currently serves an obsolete thick 3x3 grid icon from the TrueNAS CDN. It does not match the CineFindPro brand icon used by the website and browser extension.

This metadata-only fix:
- points `app.yaml` and `item.yaml` at the correct immutable CineFindPro SVG source
- bumps the catalog version from `1.0.0` to `1.0.1`

### Correct icon source

https://raw.githubusercontent.com/sasray/cinefind-bridge/54a17abcb8b81e99d1845d54edcaa3294a1b7e50/assets/icon.svg

![Correct CineFindPro icon](https://raw.githubusercontent.com/sasray/cinefind-bridge/54a17abcb8b81e99d1845d54edcaa3294a1b7e50/assets/icon.svg)

### Current incorrect CDN asset

https://media.sys.truenas.net/apps/cinefind-bridge/icons/icon.svg

The reviewer will need to upload/replace the correct SVG on the TrueNAS CDN and update the two metadata URLs to the resulting CDN URL before merge.

## Validation

- Correct immutable source returns HTTP 200
- Content type is `image/svg+xml`
- SVG geometry matches `extensions/cinefindpro/icons/icon-source.svg` in the CineFindPro website repository
- `git diff --check` passes

## Checklist

- [x] Only files under `/ix-dev/` are modified
- [x] Catalog version incremented
- [x] Correct icon source is publicly accessible and immutable
- [x] No application runtime or configuration changes
