### PR TITLE
cantinarr: mention music in the description and keywords

### DIFF
--- a/ix-dev/community/cantinarr/app.yaml
+++ b/ix-dev/community/cantinarr/app.yaml
@@ -5,9 +5,9 @@ categories:
 changelog_url: https://github.com/windoze95/cantinarr/releases
 date_added: '2026-08-18'
 description: One app over your whole media stack. Household members browse and request
-  movies, TV, and books, and you keep Radarr, Sonarr, Chaptarr, download clients,
-  Tautulli, and Plex control to yourself, with plain-English fixes when a download
-  gets stuck.
+  movies, TV, books, and music, and you keep Radarr, Sonarr, Chaptarr, Lidarr, download
+  clients, Tautulli, and Plex control to yourself, with plain-English fixes when a
+  download gets stuck.
 home: https://cantinarr.com
 host_mounts: []
 icon: https://media.sys.truenas.net/apps/cantinarr/icons/icon.png
@@ -17,6 +17,8 @@ keywords:
 - radarr
 - sonarr
 - chaptarr
+- lidarr
+- music
 - plex
 - mcp
 lib_version: 2.3.11
@@ -40,4 +42,4 @@ sources:
 - https://github.com/windoze95/cantinarr
 title: Cantinarr
 train: community
-version: 1.0.6
+version: 1.0.7

--- a/ix-dev/community/cantinarr/questions.yaml
+++ b/ix-dev/community/cantinarr/questions.yaml
@@ -31,7 +31,7 @@ questions:
         - variable: public_url
           label: Arr Webhook Callback URL
           description: |
-            Origin your Radarr, Sonarr, and Chaptarr containers POST webhooks back to,
+            Origin your Radarr, Sonarr, Chaptarr, and Lidarr containers POST webhooks back to,
             so it has to be reachable from those containers.</br>
             For example http://192.168.1.10:30472. Leave blank to use whatever address you browse to.</br>
             This is not the address people reach Cantinarr at; set that in the app under


### PR DESCRIPTION
Cantinarr 0.8.0 added a Lidarr music module. This updates the listing copy to match: the `description` now says "movies, TV, books, and music" and names Lidarr beside the other arrs, `keywords` gain `lidarr` and `music`, and the `CANTINARR_ARR_CALLBACK_URL` question's hint names Lidarr among the containers that call back. `version` bumped 1.0.6 → 1.0.7. No values, ports, or storage changes.
Reviewed by human developers.