### PR TITLE
cantinarr: point the push gateway default at push.cantinarr.com

### DIFF
--- a/ix-dev/community/cantinarr/app.yaml
+++ b/ix-dev/community/cantinarr/app.yaml
@@ -42,4 +42,4 @@ sources:
 - https://github.com/windoze95/cantinarr
 title: Cantinarr
 train: community
-version: 1.0.7
+version: 1.0.8

--- a/ix-dev/community/cantinarr/questions.yaml
+++ b/ix-dev/community/cantinarr/questions.yaml
@@ -27,7 +27,7 @@ questions:
             Clear the field to disable push entirely, or point it at your own gateway.
           schema:
             type: uri
-            default: https://push.julian.codes
+            default: https://push.cantinarr.com
         - variable: public_url
           label: Arr Webhook Callback URL
           description: |


### PR DESCRIPTION
Cantinarr's community push relay moved to `https://push.cantinarr.com`. This changes the default offered for the push gateway question and bumps the app version.

Existing installs are unaffected: their stored answer keeps pointing at `push.julian.codes`, which still answers from the same gateway, and current Cantinarr images rewrite that name to the new one at start. No variable keys change.