### PR TITLE
fix(fliks): rename storage.conf to storage.config so the app renders

### DIFF
--- a/ix-dev/community/fliks/app.yaml
+++ b/ix-dev/community/fliks/app.yaml
@@ -39,4 +39,4 @@ sources:
 - https://github.com/fliks-app/fliks
 title: Fliks
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/fliks/questions.yaml
+++ b/ix-dev/community/fliks/questions.yaml
@@ -253,7 +253,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: conf
+        - variable: config
           label: Config Storage
           description: Holds the generated JWT signing key. Lose it and every user is logged out.
           schema:

--- a/ix-dev/community/fliks/templates/docker-compose.yaml
+++ b/ix-dev/community/fliks/templates/docker-compose.yaml
@@ -55,10 +55,6 @@
   {% do perm_container.add_or_skip_action(store.mount_path, store, perm_config) %}
 {% endfor %}
 
-{% for device in values.fliks.devices %}
-  {% do c1.devices.add_device(device.host_device, device.container_device) %}
-{% endfor %}
-
 {% if perm_container.has_actions() %}
   {% do perm_container.activate() %}
   {% do c1.depends.add_dependency(values.consts.perms_container_name, "service_completed_successfully") %}


### PR DESCRIPTION
## Problem

Installing Fliks fails immediately, before any container starts:

```
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'config'
  File ".../templates/docker-compose.yaml", line 39, in top-level template code
    {% do c1.add_storage(values.consts.config_dir, values.storage.config) %}
```

`questions.yaml` declares the storage variable as `conf`, while the compose template reads
`values.storage.config`. The two drifted apart in a1753022 ("sync port"), which renamed the key
in `templates/docker-compose.yaml` and in `test_values/basic-values.yaml` but not in
`questions.yaml`.

CI passes because the render is only ever exercised with `test_values/`, which was renamed in
the same commit. Nothing renders the app from the values the UI actually submits, so the drift
was invisible.

## Fix

- `questions.yaml`: `storage.conf` -> `storage.config`, matching the template, the test values,
  the `config` permissions action and the `config` ixVolume `dataset_name`.
- Drop the `values.fliks.devices` loop from the compose template. The `devices` question was
  removed in e718e58c ("this is not how apps pass gpus") in favour of `resources.gpus`, but the
  loop stayed behind and now references a variable that no longer exists. Jinja iterates
  Undefined as empty so it never raised, but it is dead code pointing at a removed question.
- Bump `version` to 1.0.1.

Happy to drop the second hunk if you would rather keep the template untouched.

## Verification

Rendered the app two ways with the vendored `base_v2_3_11` library:

1. **From `questions.yaml` defaults** (the real install path: walk the schema, take every
   `default`, fill in the required `db_password`). Fails on master with the exact traceback
   above; renders after the fix.
2. **From `test_values/basic-values.yaml`** (the CI path). Renders before and after, unchanged.

Resulting mounts from the defaults render:

```
fliks        bind  <ix>/config -> /app/conf
             bind  <ix>/data   -> /app/data
             volume fliks-transcode -> /app/transcode
permissions  bind  <ix>/config -> /mnt/permission/config
             bind  <ix>/data   -> /mnt/permission/data
             bind  <ix>/postgres_data -> /mnt/permission/postgres_postgres_data
             volume fliks-transcode -> /mnt/permission/transcode
postgres     bind  <ix>/postgres_data -> /var/lib/postgresql
```

No migration is needed: the render fails before an app is ever created, so there is no install
carrying values under the old `conf` key.

## Note on CI

A check that renders each changed app from its `questions.yaml` defaults, alongside the existing
`test_values` render, would catch this whole class of drift. I have not touched CI here since
that is a repo-wide call, but I am happy to open it separately if you want it.

Refs: #5749
