### PR TITLE
chore(cinefind-bridge): update to 1.0.1

### DIFF
--- a/ix-dev/community/cinefind-bridge/app.yaml
+++ b/ix-dev/community/cinefind-bridge/app.yaml
@@ -1,4 +1,4 @@
-app_version: v2.0.0
+app_version: v2.0.1
 capabilities: []
 categories:
 - media
@@ -35,4 +35,4 @@ sources:
 - https://github.com/sasray/cinefind-bridge
 title: CineFind Bridge
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/cinefind-bridge/ix_values.yaml
+++ b/ix-dev/community/cinefind-bridge/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/sasray/cinefind-bridge
-    tag: v2.0.0
+    tag: v2.0.1
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Updates CineFind Bridge to container v2.0.1.

This release prevents an optional cloud profile-catalog synchronization error from blocking the local bridge polling loop. Queued Seerr, Radarr, and Sonarr requests continue to be processed while profile synchronization is unavailable.

Release: https://github.com/sasray/cinefind-bridge/releases/tag/v2.0.1