### PR TITLE
chore(cinefind-bridge): update to 1.0.2

### DIFF
--- a/ix-dev/community/cinefind-bridge/app.yaml
+++ b/ix-dev/community/cinefind-bridge/app.yaml
@@ -1,4 +1,4 @@
-app_version: v2.0.1
+app_version: v2.0.2
 capabilities: []
 categories:
 - media
@@ -35,4 +35,4 @@ sources:
 - https://github.com/sasray/cinefind-bridge
 title: CineFind Bridge
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/cinefind-bridge/ix_values.yaml
+++ b/ix-dev/community/cinefind-bridge/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/sasray/cinefind-bridge
-    tag: v2.0.1
+    tag: v2.0.2
   container_utils_image:
     repository: ixsystems/container-utils
     tag: 1.0.2


### PR DESCRIPTION
Updates CineFind Bridge to v2.0.2.\n\nThis release fixes re-pairing after a stored device token has been revoked: the bridge now removes the rejected local token so the configured one-time pairing code is used on the next cycle.\n\nUpstream release: https://github.com/sasray/cinefind-bridge/releases/tag/v2.0.2