### PR TITLE
Update ActuallyFreeCD to 1.0.1

### DIFF
--- a/ix-dev/community/actuallyfreecd/app.yaml
+++ b/ix-dev/community/actuallyfreecd/app.yaml
@@ -1,5 +1,7 @@
 app_version: 0.9.0
-capabilities: []
+capabilities:
+- description: Actuallyfreecd is able to preserve set-user-ID and set-group-ID bits
+  name: FSETID
 categories:
 - media
 changelog_url: https://github.com/D69wookie/ActuallyFreeCD-Server/releases
@@ -35,4 +37,4 @@ sources:
 - https://github.com/D69wookie/ActuallyFreeCD-Server
 title: ActuallyFreeCD Server
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/actuallyfreecd/app.yaml
+++ b/ix-dev/community/actuallyfreecd/app.yaml
@@ -35,4 +35,4 @@ sources:
 - https://github.com/D69wookie/ActuallyFreeCD-Server
 title: ActuallyFreeCD Server
 train: community
-version: 1.0.0
+version: 1.0.1

--- a/ix-dev/community/actuallyfreecd/questions.yaml
+++ b/ix-dev/community/actuallyfreecd/questions.yaml
@@ -1,6 +1,8 @@
 groups:
   - name: ActuallyFreeCD Server Configuration
     description: Configure ActuallyFreeCD Server
+  - name: Output Permissions Configuration
+    description: Configure ownership and permissions for ripped music files.
   - name: Network Configuration
     description: Configure Network for ActuallyFreeCD Server
   - name: Storage Configuration
@@ -74,6 +76,43 @@ questions:
                       label: Value
                       schema:
                         type: string
+
+  - variable: output_permissions
+    label: ""
+    group: Output Permissions Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: uid
+          label: Output User ID
+          description: User ID to assign to ripped files and directories.
+          schema:
+            type: int
+            min: 0
+            default: 0
+            required: true
+        - variable: gid
+          label: Output Group ID
+          description: Group ID to assign to ripped files and directories. Set this to the group that should have access to the music files.
+          schema:
+            type: int
+            min: 0
+            default: 568
+            required: true
+        - variable: directory_mode
+          label: Directory Mode
+          description: Permissions applied to newly created directories. Use an octal value such as 2775.
+          schema:
+            type: string
+            default: "2775"
+            required: true
+        - variable: file_mode
+          label: File Mode
+          description: Permissions applied to newly created music and metadata files. Use an octal value such as 0664.
+          schema:
+            type: string
+            default: "0664"
+            required: true
 
   - variable: network
     label: ""

--- a/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
+++ b/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
@@ -3,6 +3,7 @@
 {% set c1 = tpl.add_container(values.consts.actuallyfreecd_container_name, "image") %}
 
 {% do c1.set_user(0, 0) %}
+{% do c1.add_caps(["FSETID"]) %}
 {% do c1.healthcheck.set_test("http", {"port": values.consts.internal_web_port, "path": "/api/status"}) %}
 
 {% for device in values.actuallyfreecd.devices %}

--- a/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
+++ b/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
@@ -15,6 +15,11 @@
 
 {% do c1.environment.add_env("DEVICE_ROOT", "/hostdev") %}
 {% do c1.environment.add_env("MUSIC_ROOT", "/music") %}
+{% do c1.environment.add_env("AFCD_OUTPUT_UID", values.output_permissions.uid | string) %}
+{% do c1.environment.add_env("AFCD_OUTPUT_GID", values.output_permissions.gid | string) %}
+{% do c1.environment.add_env("AFCD_DIR_MODE", values.output_permissions.directory_mode) %}
+{% do c1.environment.add_env("AFCD_FILE_MODE", values.output_permissions.file_mode) %}
+
 {% do c1.environment.add_user_envs(values.actuallyfreecd.additional_envs) %}
 
 {% do c1.add_port(values.network.web_port, {"container_port": values.consts.internal_web_port}) %}

--- a/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
+++ b/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
@@ -14,6 +14,7 @@
 
 {% do c1.environment.add_env("DEVICE_ROOT", "/hostdev") %}
 {% do c1.environment.add_env("MUSIC_ROOT", "/music") %}
+{% do c1.environment.add_user_envs(values.actuallyfreecd.additional_envs) %}
 
 {% do c1.add_port(values.network.web_port, {"container_port": values.consts.internal_web_port}) %}
 

--- a/ix-dev/community/actuallyfreecd/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/actuallyfreecd/templates/test_values/basic-values.yaml
@@ -8,6 +8,12 @@ TZ: Etc/UTC
 actuallyfreecd:
   devices: []
 
+output_permissions:
+  uid: 0
+  gid: 3001
+  directory_mode: "2775"
+  file_mode: "0664"
+
 network:
   web_port:
     bind_mode: published


### PR DESCRIPTION
This updates ActuallyFreeCD to catalogue version 1.0.1.

Changes:
- Fixes Additional Environment Variables wiring.
- Adds configurable output UID, GID, directory mode and file mode settings.
- Adds only the FSETID capability so setgid directory permissions can persist while TrueNAS continues to drop all other container capabilities.
- Keeps the server image unchanged at ghcr.io/d69wookie/actuallyfreecd-server:0.9.0.

Hardware tested on TrueNAS with a physical optical drive using /dev/sr0 and /dev/sg8.

Verified output permissions:
- Directories: root:media 2775
- Files: root:media 0664

The app renders successfully and passes apps_dev_charts_validate.