### PR TITLE
fliks: drop the External URL question

### DIFF
--- a/ix-dev/community/fliks/app.yaml
+++ b/ix-dev/community/fliks/app.yaml
@@ -39,4 +39,4 @@ sources:
 - https://github.com/fliks-app/fliks
 title: Fliks
 train: community
-version: 1.0.1
+version: 1.0.2

--- a/ix-dev/community/fliks/app.yaml
+++ b/ix-dev/community/fliks/app.yaml
@@ -39,4 +39,4 @@ sources:
 - https://github.com/fliks-app/fliks
 title: Fliks
 train: community
-version: 1.0.2
+version: 1.1.0

--- a/ix-dev/community/fliks/app_migrations.yaml
+++ b/ix-dev/community/fliks/app_migrations.yaml
@@ -1,0 +1,6 @@
+migrations:
+- file: remove_external_url
+  from:
+    max_version: 1.0.1
+  target:
+    min_version: 1.1.0

--- a/ix-dev/community/fliks/migrations/remove_external_url
+++ b/ix-dev/community/fliks/migrations/remove_external_url
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import yaml
+
+
+def migrate(values):
+    values["fliks"].pop("external_url", None)
+    return values
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        exit(1)
+
+    if os.path.exists(sys.argv[1]):
+        with open(sys.argv[1], "r") as f:
+            print(yaml.dump(migrate(yaml.safe_load(f.read()))))

--- a/ix-dev/community/fliks/questions.yaml
+++ b/ix-dev/community/fliks/questions.yaml
@@ -52,14 +52,6 @@ questions:
             default: ""
             required: true
             private: true
-        - variable: external_url
-          label: External URL
-          description: |
-            Optional. The public URL Fliks is reachable at when it sits behind a reverse proxy.</br>
-            Example: https://fliks.example.com
-          schema:
-            type: uri
-            default: ""
         - variable: additional_envs
           label: Additional Environment Variables
           schema:

--- a/ix-dev/community/fliks/templates/docker-compose.yaml
+++ b/ix-dev/community/fliks/templates/docker-compose.yaml
@@ -27,7 +27,6 @@
 {% do c1.environment.add_env("DB_USERNAME", values.consts.db_user) %}
 {% do c1.environment.add_env("DB_PASSWORD", values.fliks.db_password) %}
 {% do c1.environment.add_env("DB_NAME", values.consts.db_name) %}
-{% do c1.environment.add_env("EXTERNAL_URL", values.fliks.external_url) %}
 {% do c1.environment.add_env("FLIKS_CONF_DIR", values.consts.config_dir) %}
 {% do c1.environment.add_env("FLIKS_DATA_DIR", values.consts.data_dir) %}
 {% do c1.environment.add_env("FLIKS_TRANSCODE_DIR", values.consts.transcode_dir) %}

--- a/ix-dev/community/fliks/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/fliks/templates/test_values/basic-values.yaml
@@ -6,7 +6,6 @@ resources:
 fliks:
   db_password: test_password
   postgres_image_selector: postgres_18_image
-  external_url: ""
   additional_envs: []
 
 run_as:


### PR DESCRIPTION
The app exposed an **External URL** question that set `EXTERNAL_URL` on the container. Fliks has its own **Settings > General > Public URL**, which already took precedence over that variable, so the question was a second place to set one value — and the losing one. An admin who filled it in and had also set the URL in the app saw their entry silently ignored.

Upstream has now removed the variable entirely, so the question would set nothing at all.

Changes, all in `ix-dev/community/fliks/`:

- `questions.yaml`: remove the `external_url` variable.
- `templates/docker-compose.yaml`: remove the `EXTERNAL_URL` env.
- `templates/test_values/basic-values.yaml`: remove the matching value.
- `app_migrations.yaml` + `migrations/remove_external_url`: pop `fliks.external_url` from the stored values of existing installs, following the same shape as the other `remove_*` migrations in the catalog.
- `app.yaml`: `version` 1.0.1 → 1.1.0.

Anyone who had filled the field in sets the URL in the app's own settings instead. It is only used to build the stream URL handed to a Chromecast, so nothing else changes; without it that falls back to the `Host` header, which is what an install with no reverse proxy already used.

### Testing

- `ci.py --app fliks --train community --test-file basic-values.yaml --render-only=true` renders clean, with no `EXTERNAL_URL` in the output.
- `generate_metadata.py` and `port_validation.py` pass.
- The migration script was run against a values file containing `fliks.external_url` and drops only that key.
- Only files under `/ix-dev/` are touched, and no auto-generated file is included.
