### PR TITLE
Monero LWS app feature: Add auto-accept-import option

### DIFF
--- a/ix-dev/community/monero-lws/app.yaml
+++ b/ix-dev/community/monero-lws/app.yaml
@@ -35,4 +35,4 @@ sources:
 - https://github.com/vtnerd/monero-lws
 title: Monero LWS
 train: community
-version: 1.2.8
+version: 1.2.9

--- a/ix-dev/community/monero-lws/ix_values.yaml
+++ b/ix-dev/community/monero-lws/ix_values.yaml
@@ -22,3 +22,4 @@ consts:
     - --confirm-external-bind
     - --max-subaddresses
     - --auto-accept-creation
+    - --auto-accept-import

--- a/ix-dev/community/monero-lws/questions.yaml
+++ b/ix-dev/community/monero-lws/questions.yaml
@@ -86,7 +86,15 @@ questions:
         - variable: auto_accept_creation
           label: Auto Accept Creation
           description: |
-            Enable this option if you want new accounts to be automatically accepted for scanning.</br>
+            Enable this option if you want new accounts (which do not request historical scanning) to be automatically accepted.</br>
+            We recommend leaving this disabled. If you enable this setting, then anyone may be able to add their wallet to your server, which could expose your server to abuse.
+          schema:
+            type: boolean
+            default: false
+        - variable: auto_accept_import
+          label: Auto Accept Import
+          description: |
+            Enable this option if you want account import (rescan) requests to be automatically accepted.</br>
             We recommend leaving this disabled. If you enable this setting, then anyone may be able to add their wallet to your server, which could expose your server to abuse.
           schema:
             type: boolean

--- a/ix-dev/community/monero-lws/templates/docker-compose.yaml
+++ b/ix-dev/community/monero-lws/templates/docker-compose.yaml
@@ -42,6 +42,10 @@
   {% do commands.x.append("--auto-accept-creation") %}
 {% endif %}
 
+{% if values.lws.auto_accept_import %}
+  {% do commands.x.append("--auto-accept-import") %}
+{% endif %}
+
 {% for flag in values.lws.additional_flags %}
   {% do commands.x.append(flag) %}
 {% endfor %}

--- a/ix-dev/community/monero-lws/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/monero-lws/templates/test_values/basic-values.yaml
@@ -14,6 +14,7 @@ lws:
   monerod_zmq_pub_port: 18083
   max_subaddresses: 10000
   auto_accept_creation: false
+  auto_accept_import: false
   accounts: []
   additional_envs: []
 


### PR DESCRIPTION
This adds `--auto-accept-import` as a UI option, which is similar (but distinct) from the existing `--auto-accept-creation`.

https://github.com/vtnerd/monero-lws/blob/master/src/server_main.cpp#L148