### PR TITLE
Update ActuallyFreeCD to 1.0.2

### DIFF
--- a/ix-dev/community/actuallyfreecd/app.yaml
+++ b/ix-dev/community/actuallyfreecd/app.yaml
@@ -1,7 +1,15 @@
-app_version: 0.9.0
+app_version: 1.0.2
 capabilities:
-- description: Actuallyfreecd is able to preserve set-user-ID and set-group-ID bits
-  name: FSETID
+- description: Actuallyfreecd is able to change file ownership arbitrarily
+  name: CHOWN
+- description: Actuallyfreecd is able to bypass file permission checks
+  name: DAC_OVERRIDE
+- description: Actuallyfreecd is able to bypass permission checks for file operations
+  name: FOWNER
+- description: Actuallyfreecd is able to change group ID of processes
+  name: SETGID
+- description: Actuallyfreecd is able to change user ID of processes
+  name: SETUID
 categories:
 - media
 changelog_url: https://github.com/D69wookie/ActuallyFreeCD-Server/releases
@@ -37,4 +45,4 @@ sources:
 - https://github.com/D69wookie/ActuallyFreeCD-Server
 title: ActuallyFreeCD Server
 train: community
-version: 1.0.1
+version: 1.0.3

--- a/ix-dev/community/actuallyfreecd/ix_values.yaml
+++ b/ix-dev/community/actuallyfreecd/ix_values.yaml
@@ -1,7 +1,7 @@
 images:
   image:
     repository: ghcr.io/d69wookie/actuallyfreecd-server
-    tag: 0.9.0
+    tag: 1.0.2
 
 consts:
   actuallyfreecd_container_name: actuallyfreecd

--- a/ix-dev/community/actuallyfreecd/questions.yaml
+++ b/ix-dev/community/actuallyfreecd/questions.yaml
@@ -1,6 +1,8 @@
 groups:
   - name: ActuallyFreeCD Server Configuration
     description: Configure ActuallyFreeCD Server
+  - name: User and Group Configuration
+    description: Configure User and Group for ActuallyFreeCD Server
   - name: Network Configuration
     description: Configure Network for ActuallyFreeCD Server
   - name: Storage Configuration
@@ -74,6 +76,29 @@ questions:
                       label: Value
                       schema:
                         type: string
+
+  - variable: run_as
+    label: ""
+    group: User and Group Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: user
+          label: User ID
+          description: The user id that ActuallyFreeCD files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
+        - variable: group
+          label: Group ID
+          description: The group id that ActuallyFreeCD files will be owned by.
+          schema:
+            type: int
+            min: 568
+            default: 568
+            required: true
 
   - variable: network
     label: ""

--- a/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
+++ b/ix-dev/community/actuallyfreecd/templates/docker-compose.yaml
@@ -2,8 +2,7 @@
 
 {% set c1 = tpl.add_container(values.consts.actuallyfreecd_container_name, "image") %}
 
-{% do c1.set_user(0, 0) %}
-{% do c1.add_caps(["FSETID"]) %}
+{% do c1.add_caps(["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"]) %}
 {% do c1.healthcheck.set_test("http", {"port": values.consts.internal_web_port, "path": "/api/status"}) %}
 
 {% for device in values.actuallyfreecd.devices %}

--- a/ix-dev/community/actuallyfreecd/templates/test_values/basic-values.yaml
+++ b/ix-dev/community/actuallyfreecd/templates/test_values/basic-values.yaml
@@ -8,6 +8,10 @@ TZ: Etc/UTC
 actuallyfreecd:
   devices: []
 
+run_as:
+  user: 568
+  group: 568
+
 network:
   web_port:
     bind_mode: published


### PR DESCRIPTION
## Description

Updates ActuallyFreeCD to application version 1.0.2 and catalogue version 1.0.3.

This update changes the container runtime model so the image starts as root for device/user setup, then drops to the configured application UID/GID before starting the server.

### Changes

- Update image to `ghcr.io/d69wookie/actuallyfreecd-server:1.0.2`
- Add standard User ID / Group ID configuration, defaulting to `568:568`
- Remove forced `set_user(0, 0)`
- Replace `FSETID` with the capabilities required by the container startup process:
  - `CHOWN`
  - `DAC_OVERRIDE`
  - `FOWNER`
  - `SETGID`
  - `SETUID`
- Add `run_as` values to the basic test configuration
- Update application metadata

### Testing

- TrueNAS render validation completed successfully
- Rendered compose correctly injects UID/GID 568 and UMASK 002
- Container capabilities and image version verified in rendered compose
- ActuallyFreeCD 1.0.2 was tested with `/dev/sr0` and `/dev/sg8`
- Application process runs as UID/GID 568 with supplementary optical device group access
- Ripped files are created as `apps:apps` with expected permissions
